### PR TITLE
Add traps credentials

### DIFF
--- a/traps/credentials/credentials.yml
+++ b/traps/credentials/credentials.yml
@@ -1,0 +1,8 @@
+credentials:
+  users:
+    # - username: myuser
+    #   authentication_protocol: md5
+    #   authentication_passphrase: mypassword
+    #   privacy_protocol: aes
+    #   privacy_passphrase: myprivacy
+    #   authoritative_engine_id: authoritative_engine_id


### PR DESCRIPTION
This will be the home for users to define the credentials for devices sending SNMP traps to their collector.