### PR TITLE
fix: fixed trap-collector DSL for a specific MIB

### DIFF
--- a/traps/rules/cisco/CISCO-CONFIG-MAN-MIB-ciscoConfigManMIBNotifications.yml
+++ b/traps/rules/cisco/CISCO-CONFIG-MAN-MIB-ciscoConfigManMIBNotifications.yml
@@ -13,7 +13,7 @@
             root.out.cisco.ccmHistoryEventCommandSource = this.trap.VarBinds.index(0).Value.enum_enrich(".1.3.6.1.4.1.9.9.43.1.1.6.1.3")
             root.out.cisco.ccmHistoryEventConfigSource = this.trap.VarBinds.index(1).Value.enum_enrich(".1.3.6.1.4.1.9.9.43.1.1.6.1.4")
             root.out.cisco.ccmHistoryEventConfigDestination = this.trap.VarBinds.index(2).Value.enum_enrich(".1.3.6.1.4.1.9.9.43.1.1.6.1.5")
-            root.out.cisco.ccmHistoryEventTerminalUser = this.trap.VarBinds.index(3).Value.snmp_display_string()
+            root.out.cisco.ccmHistoryEventTerminalUser = if this.trap.VarBinds.length() >= 4 { this.trap.VarBinds.index(3).Value.snmp_display_string() }
         - label: cisco_config_man_event_rules_1
           mapping: |-
             #!blobl


### PR DESCRIPTION
While our DSL follows the 'ciscoConfigManMIBNotifications' MIB, not all packets, in practice, have all the information in it. This PR allows us to support processing these production packets better.

# Testing

## Reproducing the error

- Created new Ubuntu VM
- installed Trap Collector
- ran a python script with test trap packet in it (snmptrapcolltest.py)
- observed an error message in trapcoll logs

## Testing the fix

- edited the yml file manually to match this PR
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/2484822b-483b-4e2a-a6d0-a5d377182ef1" />

- restarted trapcoll
- ran python script again
- observed there was no error message
- observed the output was present (with STDOUT enabled)
`{"cisco":{"ccmHistoryEventCommandSource":"commandLine","ccmHistoryEventConfigDestination":"running","ccmHistoryEventConfigSource":"commandSource"},"event":{"category":{"name":"Configuration Change"},"class":{"name":"SNMPTRAP-cisco-CISCO-CONFIG-MAN-MIB-ciscoConfigManEvent"},"id":"SNMPTRAP-cisco-CISCO-CONFIG-MAN-MIB-ciscoConfigManEvent","message":"Configuration Changed via commandLine  ( Source: commandSource, Destination: running )","severity":{"code":4,"level":"Warning"}},"object":{"name":"ccmHistoryEventEntry.2"},"origin":{"agent":{"name":"CISCO-CONFIG-MAN-MIB"},"manager":{"name":"NetObserv SNMP Trap"}},"record":{"collect":{"timestamp":1741794838797}},"system":{"ip":{"addr":"127.0.0.1"}}}`
