### PR TITLE
correct EtherLike dot3Stats OIDs

### DIFF
--- a/objects/ietf/EtherLike-MIB.yml
+++ b/objects/ietf/EtherLike-MIB.yml
@@ -45,31 +45,31 @@ EtherLike-MIB::dot3StatsEntry:
       name: netif.ethernet.errors.carrier_sense
       syntax: Counter32
     dot3StatsFrameTooLongs:
-      oid: .1.3.6.1.2.1.10.7.2.1.12
+      oid: .1.3.6.1.2.1.10.7.2.1.13
       name: netif.ethernet.frames.too_long
       syntax: Counter32
     dot3StatsInternalMacReceiveErrors:
-      oid: .1.3.6.1.2.1.10.7.2.1.13
+      oid: .1.3.6.1.2.1.10.7.2.1.16
       name: netif.ethernet.errors.mac.rcv
       syntax: Counter32
     dot3StatsEtherChipSet:
-      oid: .1.3.6.1.2.1.10.7.2.1.14
+      oid: .1.3.6.1.2.1.10.7.2.1.17
       name: netif.ethernet.chipset
       syntax: EnumObjectIdentifier
     dot3StatsSymbolErrors:
-      oid: .1.3.6.1.2.1.10.7.2.1.15
+      oid: .1.3.6.1.2.1.10.7.2.1.18
       name: netif.ethernet.errors.symbol
       syntax: Counter32
     dot3StatsDuplexStatus:
-      oid: .1.3.6.1.2.1.10.7.2.1.16
+      oid: .1.3.6.1.2.1.10.7.2.1.19
       name: netif.ethernet.duplex
       syntax: EnumInteger
     dot3StatsRateControlAbility:
-      oid: .1.3.6.1.2.1.10.7.2.1.17
+      oid: .1.3.6.1.2.1.10.7.2.1.20
       name: netif.ethernet.rate_cntrl.capable
       syntax: TruthValue
     dot3StatsRateControlStatus:
-      oid: .1.3.6.1.2.1.10.7.2.1.18
+      oid: .1.3.6.1.2.1.10.7.2.1.21
       name: netif.ethernet.rate_cntrl
       syntax: EnumInteger
 


### PR DESCRIPTION
OIDs were incorrect. They are fixed and tested now.