### PR TITLE
ENG-9015 - Add Cisco Call Manager and SIP support

### DIFF
--- a/autodiscover/oid_device_group.yml
+++ b/autodiscover/oid_device_group.yml
@@ -776,8 +776,8 @@
 .1.3.6.1.4.1.9.1.797: 'cisco_cat_3560' # Cisco Catalyst 3560 WS-C3560-8PC-S
 .1.3.6.1.4.1.9.1.798: 'cisco_cat_2960' # Cisco Catalyst 2960 WS-C2960-8TC-L
 .1.3.6.1.4.1.9.1.799: 'cisco_cat_2960' # Cisco Catalyst 2960 WS-C2960G-8TC-L
-.1.3.6.1.4.1.9.1.800: 'cisco_telepresence_codec' # Cisco TelePresence CTS-CODEC-PRIM
-.1.3.6.1.4.1.9.1.801: 'cisco_telepresence_codec' # Cisco TelePresence CTS-CODEC-SEC
+.1.3.6.1.4.1.9.1.800: 'cisco_telepresence' # Cisco TelePresence CTS-CODEC-PRIM
+.1.3.6.1.4.1.9.1.801: 'cisco_telepresence' # Cisco TelePresence CTS-CODEC-SEC
 .1.3.6.1.4.1.9.1.802: 'cisco_uip_7900' # Cisco Unified IP Phone 7900 CP-7921G
 .1.3.6.1.4.1.9.1.803: 'cisco_uip_7900' # Cisco Unified IP Phone 7900 CP-7920
 .1.3.6.1.4.1.9.1.804: 'cisco_wmic' # Cisco WMIC C3200WMIC-K9
@@ -979,7 +979,7 @@
 .1.3.6.1.4.1.9.1.1000: 'cisco_cat_cbs3000' # Cisco Catalyst Blade Switch 3000 WS-CBS3012-IBM-I
 .1.3.6.1.4.1.9.1.1001: 'cisco_cat_cbs3000' # Cisco Catalyst Blade Switch 3000 WS-CBS3125G-S
 .1.3.6.1.4.1.9.1.1002: 'cisco_cat_cbs3000' # Cisco Catalyst Blade Switch 3000 WS-CBS3125X-S
-.1.3.6.1.4.1.9.1.1003: 'cisco_telepresence_codec' # Cisco TelePresence CTS-CODEC-PRI-G2
+.1.3.6.1.4.1.9.1.1003: 'cisco_telepresence' # Cisco TelePresence CTS-CODEC-PRI-G2
 .1.3.6.1.4.1.9.1.1004: 'cisco_cat_4900' # Cisco Catalyst 4900 WS-C4928-10GE
 .1.3.6.1.4.1.9.1.1005: 'cisco_cat_2960' # Cisco Catalyst 2960 WS-C2960-48TT-S
 .1.3.6.1.4.1.9.1.1006: 'cisco_cat_2960' # Cisco Catalyst 2960 WS-C2960-8TC-S
@@ -1400,10 +1400,10 @@
 .1.3.6.1.4.1.9.1.1428: 'cisco_ips_4300' # Cisco IPS 4300  IPS-4345-K9
 .1.3.6.1.4.1.9.1.1429: 'cisco_ips_4300' # Cisco IPS 4300  IPS-4360-K9
 .1.3.6.1.4.1.9.1.1432: 'cisco_ecds_mde' # Cisco ECDS MDE-VB
-.1.3.6.1.4.1.9.1.1433: 'cisco_telepresence_codec' # Cisco TelePresence CTS-CODEC-PRI-G2
-.1.3.6.1.4.1.9.1.1434: 'cisco_telepresence_codec' # Cisco TelePresence CTS-CODEC-PRI-G2C
-.1.3.6.1.4.1.9.1.1435: 'cisco_telepresence_codec' # Cisco TelePresence CTS-CODEC-PRI-G2RC
-.1.3.6.1.4.1.9.1.1436: 'cisco_telepresence_codec' # Cisco TelePresence CTS-CODEC-PRI-G2R
+.1.3.6.1.4.1.9.1.1433: 'cisco_telepresence' # Cisco TelePresence CTS-CODEC-PRI-G2
+.1.3.6.1.4.1.9.1.1434: 'cisco_telepresence' # Cisco TelePresence CTS-CODEC-PRI-G2C
+.1.3.6.1.4.1.9.1.1435: 'cisco_telepresence' # Cisco TelePresence CTS-CODEC-PRI-G2RC
+.1.3.6.1.4.1.9.1.1436: 'cisco_telepresence' # Cisco TelePresence CTS-CODEC-PRI-G2R
 .1.3.6.1.4.1.9.1.1437: 'cisco_asa' # Cisco ASA 5500 ASA5585-IPS-SSP-10 Virtual
 .1.3.6.1.4.1.9.1.1438: 'cisco_asa' # Cisco ASA 5500 ASA5585-IPS-SSP-20 Virtual
 .1.3.6.1.4.1.9.1.1439: 'cisco_asa' # Cisco ASA 5500 ASA5585-IPS-SSP-40 Virtual
@@ -1481,8 +1481,8 @@
 .1.3.6.1.4.1.9.1.1537: 'cisco_csr_1k' # Cisco CSR 1000V CSR1000V
 .1.3.6.1.4.1.9.1.1538: 'cisco_asr_5000' # Cisco ASR 5000 ASR-5000
 .1.3.6.1.4.1.9.1.1539: 'cisco_nga_3000' # Cisco NGA 3000 NGA-3140
-.1.3.6.1.4.1.9.1.1540: 'cisco_telepresence_mcu' # Cisco TelePresence MCU 5300 CTI-5310-MCU-K9
-.1.3.6.1.4.1.9.1.1541: 'cisco_telepresence_mcu' # Cisco TelePresence MCU 5300 CTI-5320-MCU-K9
+.1.3.6.1.4.1.9.1.1540: 'cisco_telepresence' # Cisco TelePresence MCU 5300 CTI-5310-MCU-K9
+.1.3.6.1.4.1.9.1.1541: 'cisco_telepresence' # Cisco TelePresence MCU 5300 CTI-5320-MCU-K9
 .1.3.6.1.4.1.9.1.1542: 'cisco_isr_880' # Cisco ISR 880 C888EA
 .1.3.6.1.4.1.9.1.1557: 'cisco_vg_300' # Cisco VG 300 VG350
 .1.3.6.1.4.1.9.1.1558: 'cisco_cgr_1000' # Cisco CGR 1000 CGR1120/K9
@@ -1936,7 +1936,7 @@
 .1.3.6.1.4.1.9.1.2158: 'cisco_asr_920' # Cisco ASR 920 ASR-920-12CZ-D
 .1.3.6.1.4.1.9.1.2159: 'cisco_asr_920' # Cisco ASR 920 ASR-920-4SZ-A
 .1.3.6.1.4.1.9.1.2160: 'cisco_asr_920' # Cisco ASR 920 ASR-920-10SZ-PD
-.1.3.6.1.4.1.9.1.2161: 'cisco_telepresence_codec' # Cisco TelePresence CTS-CODEC-PRI-G3
+.1.3.6.1.4.1.9.1.2161: 'cisco_telepresence' # Cisco TelePresence CTS-CODEC-PRI-G3
 .1.3.6.1.4.1.9.1.2162: 'cisco_cat_3850' # Cisco Catalyst 3850 WS-C3850-12XS-E
 .1.3.6.1.4.1.9.1.2163: 'cisco_cat_3850' # Cisco Catalyst 3850 WS-C3850-24XS-E
 .1.3.6.1.4.1.9.1.2164: 'cisco_cat_3850' # Cisco Catalyst 3850 WS-C3850-48XS-E

--- a/device_groups/cisco.yml
+++ b/device_groups/cisco.yml
@@ -15,6 +15,7 @@ cisco_3800:
     - cisco_system
     - cisco_cdp
     - cisco_config
+    - cisco_sip
 
 cisco_4000:
   object_groups:
@@ -38,6 +39,7 @@ cisco_4000:
     - cisco_config
     - cisco_ntp
     - cisco_process
+    - cisco_syslog
 
 cisco_aironet_ap:
   object_groups:
@@ -58,6 +60,7 @@ cisco_aironet_ap:
     - cisco_cdp
     - cisco_config
     - cisco_process
+    - cisco_syslog
     - cisco_temperature
 
 cisco_aironet_br:
@@ -79,6 +82,7 @@ cisco_aironet_br:
     - cisco_cdp
     - cisco_config
     - cisco_process
+    - cisco_syslog
     - cisco_temperature
 
 cisco_aironet_wlc:
@@ -111,6 +115,7 @@ cisco_asa:
     - cisco_system
     - cisco_entity
     - cisco_process
+    - cisco_syslog
 
 cisco_asr_1000:
   object_groups:
@@ -148,6 +153,9 @@ cisco_asr_1000:
     - cisco_ospf
     - cisco_process
     - cisco_ptp
+    - cisco_sess_border_ctrlr
+    - cisco_sip
+    - cisco_syslog
 
 cisco_asr1000: # DEPRECATED: this device group will be removed in a future release. Use cisco_asr_1000.
   object_groups:
@@ -221,6 +229,7 @@ cisco_cat_1000:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_syslog
 
 cisco_cat1000: # DEPRECATED: this device group will be removed in a future release. Use cisco_cat_1000.
   object_groups:
@@ -372,6 +381,7 @@ cisco_cat_2950:
     - cisco_envmon
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_2955:
   object_groups:
@@ -394,6 +404,7 @@ cisco_cat_2955:
     - cisco_envmon
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_2960:
   object_groups:
@@ -424,6 +435,7 @@ cisco_cat_2960:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_syslog
 
 cisco_cat_2970:
   object_groups:
@@ -444,6 +456,7 @@ cisco_cat_2970:
     - cisco_envmon
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_2975:
   object_groups:
@@ -465,6 +478,7 @@ cisco_cat_2975:
     - cisco_envmon
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_3550:
   object_groups:
@@ -487,6 +501,7 @@ cisco_cat_3550:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_syslog
 
 cisco_cat_3560:
   object_groups:
@@ -518,6 +533,7 @@ cisco_cat_3560:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_syslog
 
 cisco_cat_3650:
   object_groups:
@@ -555,6 +571,7 @@ cisco_cat_3650:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_3750:
   object_groups:
@@ -586,6 +603,7 @@ cisco_cat_3750:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_syslog
 
 cisco_cat_3850:
   object_groups:
@@ -623,6 +641,7 @@ cisco_cat_3850:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_4500:
   object_groups:
@@ -649,6 +668,7 @@ cisco_cat_4500:
     - cisco_ntp
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_4900:
   object_groups:
@@ -675,6 +695,7 @@ cisco_cat_4900:
     - cisco_netif
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_6500:
   object_groups:
@@ -709,6 +730,7 @@ cisco_cat_6500:
     - cisco_process
     - cisco_stack
     - cisco_switch
+    - cisco_syslog
 
 cisco_cat_6800:
   object_groups:
@@ -747,6 +769,7 @@ cisco_cat_6800:
     - cisco_process
     - cisco_stack
     - cisco_switch
+    - cisco_syslog
 
 cisco_cat_8000:
   object_groups:
@@ -784,6 +807,9 @@ cisco_cat_8000:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_sess_border_ctrlr
+    - cisco_sip
+    - cisco_syslog
 
 cisco_cat_8200:
   object_groups:
@@ -822,6 +848,8 @@ cisco_cat_8200:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_sip
+    - cisco_syslog
 
 cisco_cat_8300:
   object_groups:
@@ -860,6 +888,8 @@ cisco_cat_8300:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_sip
+    - cisco_syslog
 
 cisco_cat_8500:
   object_groups:
@@ -898,6 +928,8 @@ cisco_cat_8500:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_sip
+    - cisco_syslog
 
 cisco_cat_9200:
   object_groups:
@@ -935,6 +967,7 @@ cisco_cat_9200:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_9300:
   object_groups:
@@ -972,6 +1005,7 @@ cisco_cat_9300:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_9400:
   object_groups:
@@ -1009,6 +1043,7 @@ cisco_cat_9400:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_9500:
   object_groups:
@@ -1046,6 +1081,7 @@ cisco_cat_9500:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_9600:
   object_groups:
@@ -1083,6 +1119,7 @@ cisco_cat_9600:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_cat_9800:
   object_groups:
@@ -1121,6 +1158,9 @@ cisco_cat_9800:
     - cisco_ospf
     - cisco_process
     - cisco_ptp
+    - cisco_sess_border_ctrlr
+    - cisco_sip
+    - cisco_syslog
 
 cisco_cat_cbs3000:
   object_groups:
@@ -1152,6 +1192,7 @@ cisco_cat_cbs3000:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_syslog
 
 cisco_cat_ce500:
   object_groups:
@@ -1169,6 +1210,7 @@ cisco_cat_ce500:
     - cisco_cdp
     - cisco_envmon
     - cisco_ntp
+    - cisco_syslog
 
 cisco_cat_ir1800:
   object_groups:
@@ -1208,6 +1250,8 @@ cisco_cat_ir1800:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_sip
+    - cisco_syslog
 
 cisco_cat_micro:
   object_groups:
@@ -1231,6 +1275,7 @@ cisco_cat_micro:
     - cisco_netif
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_ess_3300:
   object_groups:
@@ -1254,6 +1299,7 @@ cisco_ess_3300:
     - cisco_netif
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_firepower:
   object_groups:
@@ -1307,6 +1353,7 @@ cisco_ie2000:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_syslog
 
 cisco_ie3x00:
   object_groups:
@@ -1343,6 +1390,7 @@ cisco_ie3x00:
     - cisco_process
     - cisco_ptp
     - cisco_stack
+    - cisco_syslog
 
 cisco_isr_1800:
   object_groups:
@@ -1375,6 +1423,7 @@ cisco_isr_1800:
     - cisco_ntp
     - cisco_ospf
     - cisco_process
+    - cisco_syslog
 
 cisco_isr_1900:
   object_groups:
@@ -1409,6 +1458,7 @@ cisco_isr_1900:
     - cisco_ntp
     - cisco_ospf
     - cisco_process
+    - cisco_syslog
 
 cisco_isr_2900:
   object_groups:
@@ -1443,6 +1493,7 @@ cisco_isr_2900:
     - cisco_ntp
     - cisco_ospf
     - cisco_process
+    - cisco_syslog
 
 cisco_isr_3800:
   object_groups:
@@ -1475,6 +1526,7 @@ cisco_isr_3800:
     - cisco_ntp
     - cisco_ospf
     - cisco_process
+    - cisco_syslog
 
 cisco_isr_3900:
   object_groups:
@@ -1509,6 +1561,7 @@ cisco_isr_3900:
     - cisco_ntp
     - cisco_ospf
     - cisco_process
+    - cisco_syslog
 
 cisco_isr_4000:
   object_groups:
@@ -1547,6 +1600,8 @@ cisco_isr_4000:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_sip
+    - cisco_syslog
 
 cisco_isr_v:
   object_groups:
@@ -1584,6 +1639,9 @@ cisco_isr_v:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_sess_border_ctrlr
+    - cisco_sip
+    - cisco_syslog
 
 cisco_mds_9000:
   object_groups:
@@ -1614,6 +1672,7 @@ cisco_mds_9000:
     - cisco_ntp
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_nexus_1k:
   object_groups:
@@ -1689,6 +1748,7 @@ cisco_nexus_3k:
     - cisco_ntp
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_nexus_4k:
   object_groups:
@@ -1822,6 +1882,7 @@ cisco_nexus_9k:
     - cisco_ntp
     - cisco_port
     - cisco_process
+    - cisco_syslog
 
 cisco_nexus9000: # DEPRECATED: this device group will be removed in a future release. Use cisco_nexus_9k.
   object_groups:
@@ -1847,6 +1908,43 @@ cisco_nexus9000: # DEPRECATED: this device group will be removed in a future rel
     - cisco_ntp
     - cisco_router
     - cisco_switch
+
+# https://www.cisco.com/c/en/us/td/docs/telepresence/system_messages/ct_sys_message2/ct_syslog_snmp.html
+cisco_telepresence:
+  object_groups:
+    # standards-based
+    - ietf_system
+    - ietf_netif
+    - ietf_ip
+    - ietf_icmp
+    - ietf_tcp
+    - ietf_udp
+    - ietf_snmp
+    - ietf_host
+    # vendor-specific
+    - cisco_envmon
+    - cisco_telepresence
+    - cisco_syslog
+    - cisco_voice
+
+# https://www.cisco.com/c/en/us/td/docs/voice_ip_comm/cucm/admin/14SU2/adminGd/cucm_b_administration-guide-14su2/cucm_b_test-adminguide_chapter_010110.html
+cisco_uc_cucm:
+  object_groups:
+    # standards-based
+    - ietf_system
+    - ietf_netif
+    - ietf_ip
+    - ietf_icmp
+    - ietf_tcp
+    - ietf_udp
+    - ietf_snmp
+    - ietf_host
+    # vendor-specific
+    - cisco_ccm
+    - cisco_cdp
+    - cisco_syslog
+    - cisco_unity
+    - cisco_voice
 
 cisco_ucs:
   object_groups:
@@ -1894,6 +1992,7 @@ cisco_vg_200:
     - cisco_ntp
     - cisco_ospf
     - cisco_process
+    - cisco_syslog
 
 cisco_vg_300:
   object_groups:
@@ -1924,6 +2023,7 @@ cisco_vg_300:
     - cisco_ntp
     - cisco_ospf
     - cisco_process
+    - cisco_syslog
 
 cisco_vg_400:
   object_groups:
@@ -1962,6 +2062,8 @@ cisco_vg_400:
     - cisco_ospf
     - cisco_port
     - cisco_process
+    - cisco_sip
+    - cisco_syslog
 
 cisco_wlc: # DEPRECATED: this device group will be removed in a future release. Use cisco_aironet_wlc.
   object_groups:
@@ -2044,6 +2146,7 @@ rockwell_stratix_5100:
     - cisco_entity
     - cisco_netif
     - cisco_process
+    - cisco_syslog
 
 rockwell_stratix_5400:
   object_groups:
@@ -2076,6 +2179,7 @@ rockwell_stratix_5400:
     - cisco_process
     - cisco_ptp
     - cisco_stack
+    - cisco_syslog
 
 rockwell_stratix_5700:
   object_groups:
@@ -2106,6 +2210,7 @@ rockwell_stratix_5700:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_syslog
 
 rockwell_stratix_5900:
   object_groups:
@@ -2138,6 +2243,7 @@ rockwell_stratix_5900:
     - cisco_ntp
     - cisco_ospf
     - cisco_process
+    - cisco_syslog
 
 rockwell_stratix_6000:
   object_groups:
@@ -2174,3 +2280,4 @@ rockwell_stratix_8000:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_syslog

--- a/device_groups/cisco_wip.yml
+++ b/device_groups/cisco_wip.yml
@@ -4030,20 +4030,6 @@ cisco_uc_500: # WIP: Currently the same as cisco_generic
     - cisco_system
     - cisco_cdp
 
-cisco_uc_cucm: # WIP: Currently the same as cisco_generic
-  object_groups:
-    # standards-based
-    - ietf_system
-    - ietf_netif
-    - ietf_ip
-    - ietf_icmp
-    - ietf_tcp
-    - ietf_udp
-    - ietf_snmp
-    # vendor-specific
-    - cisco_system
-    - cisco_cdp
-
 cisco_uip_7900: # WIP: Currently the same as cisco_generic
   object_groups:
     # standards-based

--- a/device_groups/truenas.yml
+++ b/device_groups/truenas.yml
@@ -1,0 +1,13 @@
+truenas:
+  object_groups:
+    # standards-based
+    - ietf_system
+    - ietf_host
+    - ietf_netif_ethernet
+    - ietf_ip
+    - ietf_icmp
+    - ietf_tcp
+    - ietf_udp
+    - ietf_snmp
+    # vendor-specific
+    - ucdavis_system

--- a/device_groups/ubiquiti.yml
+++ b/device_groups/ubiquiti.yml
@@ -29,3 +29,33 @@ ubiquiti_unifi:
     # vendor-specific
     - ubiquiti_unifi
     - ucdavis_system
+
+ubiquiti_unifi_ap:
+  object_groups:
+    # standards-based
+    - ietf_system
+    - ietf_host
+    - ietf_netif
+    - ietf_ip
+    - ietf_icmp
+    - ietf_tcp
+    - ietf_udp
+    - ietf_snmp
+    # vendor-specific
+    - ubiquiti_unifi
+    - ucdavis_system
+
+ubiquiti_unifi_os:
+  object_groups:
+    # standards-based
+    - ietf_system
+    - ietf_host
+    - ietf_netif
+    - ietf_ip
+    - ietf_icmp
+    - ietf_tcp
+    - ietf_udp
+    - ietf_snmp
+    # vendor-specific
+    - ubiquiti_unifi
+    - ucdavis_system

--- a/enums/integer/cisco/CISCO-CCM-MIB.yml
+++ b/enums/integer/cisco/CISCO-CCM-MIB.yml
@@ -1,11 +1,767 @@
-.1.3.6.1.4.1.9.9.156.1.3.1.1.7:
-  0: 'unknown' # unknown
-  1: 'IPv4' # ipv4
-  2: 'IPv6' # ipv6
-  3: 'IPv4 zone' # ipv4z
-  4: 'IPv6 zone' # ipv6z
-  16: 'DNS' # dns
+# ccmStatus
+.1.3.6.1.4.1.9.9.156.1.1.2.1.5:
+  1: unknown
+  2: up
+  3: down
 
+# ccmRegionAvailableBandWidth
+.1.3.6.1.4.1.9.9.156.1.1.5.1.3:
+  1: unknown
+  2: other
+  3: bwG723
+  4: bwG729
+  5: bwG711
+  6: bwGSM
+  7: bwWideband
+
+# ccmProductCategory
+.1.3.6.1.4.1.9.9.156.1.1.8.1.4:
+  -1: unknown
+  0: notApplicable
+  1: phone
+  2: gateway
+  3: h323Device
+  4: ctiDevice
+  5: voiceMailDevice
+  6: mediaResourceDevice
+  7: huntListDevice
+  8: sipDevice
+
+# ccmPhoneType
+.1.3.6.1.4.1.9.9.156.1.2.1.1.3:
+  1: unknown
+  2: other
+  3: cisco30SPplus
+  4: cisco12SPplus
+  5: cisco12SP
+  6: cisco12S
+  7: cisco30VIP
+  8: ciscoTeleCasterBid
+  9: ciscoTeleCasterMgr
+  10: ciscoTeleCasterBusiness
+  11: ciscoSoftPhone
+  12: ciscoConferencePhone
+  13: cisco7902
+  14: cisco7905
+  15: cisco7912
+  16: cisco7970
+
+# ccmPhoneStatus
+.1.3.6.1.4.1.9.9.156.1.2.1.1.7:
+  1: unknown
+  2: registered
+  3: unregistered
+  4: rejected
+  5: partiallyregistered
+
+# ccmPhoneStatusReason
+.1.3.6.1.4.1.9.9.156.1.2.1.1.16:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegReached
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+
+# ccmPhoneProtocol
+.1.3.6.1.4.1.9.9.156.1.2.1.1.19:
+  1: unknown
+  2: sccp
+  3: sip
+
+# ccmPhoneIPv4Attribute
+.1.3.6.1.4.1.9.9.156.1.2.1.1.23:
+  0: unknown
+  1: adminOnly
+  2: controlOnly
+  3: adminAndControl
+
+# ccmPhoneIPv6Attribute
+.1.3.6.1.4.1.9.9.156.1.2.1.1.24:
+  0: unknown
+  1: adminOnly
+  2: controlOnly
+  3: adminAndControl
+
+# ccmPhoneUnregReason
+.1.3.6.1.4.1.9.9.156.1.2.1.1.26:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: deviceUnregistered
+  11: malformedRegisterMsg
+  12: sccpDeviceThrottling
+  13: keepAliveTimeout
+  14: configurationMismatch
+  15: callManagerRestart
+  16: duplicateRegistration
+  17: callManagerApplyConfig
+  18: deviceNoResponse
+  19: emLoginLogout
+  20: emccLoginLogout
+  21: energywisePowerSavePlus
+  22: callManagerForcedRestart
+  23: sourceIPAddrChanged
+  24: sourcePortChanged
+  25: registrationSequenceError
+  26: invalidCapabilities
+  28: fallbackInitiated
+  29: deviceSwitch
+
+# ccmPhoneRegFailReason
+.1.3.6.1.4.1.9.9.156.1.2.1.1.27:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+  15: protocolMismatch
+  16: deviceNotActive
+  17: authenticatedDeviceAlreadyExists
+  18: obsoleteProtocolVersion
+  23: databaseTimeout
+  25: registrationSequenceError
+  26: invalidCapabilities
+  27: capabilityResponseTimeout
+  28: securityMismatch
+  29: autoRegisterDBError
+  30: dbAccessError
+  31: autoRegisterDBConfigTimeout
+  32: deviceTypeMismatch
+  33: addressingModeMismatch
+
+# ccmPhoneFailCauseCode
+.1.3.6.1.4.1.9.9.156.1.2.3.1.6:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegReached
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+
+# ccmPhoneFailedIPv4Attribute
+.1.3.6.1.4.1.9.9.156.1.2.3.1.10:
+  0: unknown
+  1: adminOnly
+  2: controlOnly
+  3: adminAndControl
+
+# ccmPhoneFailedIPv6Attribute
+.1.3.6.1.4.1.9.9.156.1.2.3.1.11:
+  0: unknown
+  1: adminOnly
+  2: controlOnly
+  3: adminAndControl
+
+# ccmPhoneFailedRegFailReason
+.1.3.6.1.4.1.9.9.156.1.2.3.1.12:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+  15: protocolMismatch
+  16: deviceNotActive
+  17: authenticatedDeviceAlreadyExists
+  18: obsoleteProtocolVersion
+  23: databaseTimeout
+  25: registrationSequenceError
+  26: invalidCapabilities
+  27: capabilityResponseTimeout
+  28: securityMismatch
+  29: autoRegisterDBError
+  30: dbAccessError
+  31: autoRegisterDBConfigTimeout
+  32: deviceTypeMismatch
+  33: addressingModeMismatch
+
+# ccmPhoneStatusUpdateType
+.1.3.6.1.4.1.9.9.156.1.2.4.1.4:
+  1: unknown
+  2: phoneRegistered
+  3: phoneUnregistered
+  4: phonePartiallyregistered
+
+# ccmPhoneStatusUpdateReason
+.1.3.6.1.4.1.9.9.156.1.2.4.1.5:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegReached
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+
+# ccmPhoneStatusUnregReason
+.1.3.6.1.4.1.9.9.156.1.2.4.1.6:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: deviceUnregistered
+  11: malformedRegisterMsg
+  12: sccpDeviceThrottling
+  13: keepAliveTimeout
+  14: configurationMismatch
+  15: callManagerRestart
+  16: duplicateRegistration
+  17: callManagerApplyConfig
+  18: deviceNoResponse
+  19: emLoginLogout
+  20: emccLoginLogout
+  21: energywisePowerSavePlus
+  22: callManagerForcedRestart
+  23: sourceIPAddrChanged
+  24: sourcePortChanged
+  25: registrationSequenceError
+  26: invalidCapabilities
+  28: fallbackInitiated
+  29: deviceSwitch
+
+# ccmPhoneStatusRegFailReason
+.1.3.6.1.4.1.9.9.156.1.2.4.1.7:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+  15: protocolMismatch
+  16: deviceNotActive
+  17: authenticatedDeviceAlreadyExists
+  18: obsoleteProtocolVersion
+  23: databaseTimeout
+  25: registrationSequenceError
+  26: invalidCapabilities
+  27: capabilityResponseTimeout
+  28: securityMismatch
+  29: autoRegisterDBError
+  30: dbAccessError
+  31: autoRegisterDBConfigTimeout
+  32: deviceTypeMismatch
+  33: addressingModeMismatch
+
+# ccmPhoneExtnStatus
+.1.3.6.1.4.1.9.9.156.1.2.5.1.6:
+  1: unknown
+  2: registered
+  3: unregistered
+  4: rejected
+
+# ccmGatewayType
+.1.3.6.1.4.1.9.9.156.1.3.1.1.3:
+  1: unknown
+  2: other
+  3: ciscoAnalogAccess
+  4: ciscoDigitalAccessPRI
+  5: ciscoDigitalAccessT1
+  6: ciscoDigitalAccessPRIPlus
+  7: ciscoDigitalAccessWSX6608E1
+  8: ciscoDigitalAccessWSX6608T1
+  9: ciscoAnalogAccessWSX6624
+  10: ciscoMGCPStation
+  11: ciscoDigitalAccessE1Plus
+  12: ciscoDigitalAccessT1Plus
+  13: ciscoDigitalAccessWSX6608PRI
+  14: ciscoAnalogAccessWSX6612
+  15: ciscoMGCPTrunk
+  16: ciscoVG200
+  17: cisco26XX
+  18: cisco362X
+  19: cisco364X
+  20: cisco366X
+  21: ciscoCat4224VoiceGatewaySwitch
+  22: ciscoCat4000AccessGatewayModule
+  23: ciscoIAD2400
+  24: ciscoVGCEndPoint
+  25: ciscoVG224VG248Gateway
+  26: ciscoVGCBox
+  27: ciscoATA186
+  28: ciscoICS77XXMRP2XX
+  29: ciscoICS77XXASI81
+  30: ciscoICS77XXASI160
+  31: ciscoSlotVGCPort
+  32: ciscoCat6000AVVIDServModule
+  33: ciscoWSX6600
+  34: ciscoWSSVCCMMMS
+  35: cisco3745
+  36: cisco3725
+  37: ciscoICS77XXMRP3XX
+  38: ciscoICS77XXMRP38FXS
+  39: ciscoICS77XXMRP316FXS
+  40: ciscoICS77XXMRP38FXOM1
+  41: cisco269X
+  42: cisco1760
+  43: cisco1751
+  44: ciscoMGCPBRIPort
+
+# ccmGatewayStatus
+.1.3.6.1.4.1.9.9.156.1.3.1.1.5:
+  1: unknown
+  2: registered
+  3: unregistered
+  4: rejected
+  5: partiallyregistered
+
+# ccmGatewayProductId
+.1.3.6.1.4.1.9.9.156.1.3.1.1.9:
+  -2: other
+  -1: unknown
+  1: gwyCiscoCat6KT1
+  2: gwyCiscoCat6KE1
+  3: gwyCiscoCat6KFXS
+  4: gwyCiscoCat6KFXO
+  7: gwyCiscoDT24Plus
+  8: gwyCiscoDT30Plus
+  9: gwyCiscoDT24
+  10: gwyCiscoAT2
+  11: gwyCiscoAT4
+  12: gwyCiscoAT8
+  13: gwyCiscoAS2
+  14: gwyCiscoAS4
+  15: gwyCiscoAS8
+  16: h323Phone
+  17: h323Trunk
+  18: gwyCiscoMGCPFXOPort
+  19: gwyCiscoMGCPFXSPort
+  27: voiceMailUOnePort
+  43: gwyCiscoVG200
+  44: gwyCisco26XX
+  45: gwyCisco362X
+  46: gwyCisco364X
+  47: gwyCisco366X
+  49: h323AnonymousGatewy
+  52: gwyCiscoMGCPT1Port
+  55: gwyCiscoMGCPE1Port
+  58: gwyCiscoCat4224VoiceGwySwitch
+  59: gwyCiscoCat4000AccessGwyModule
+  62: gwyCiscoIAD2400
+  65: gwyCiscoVGCEndPoint
+  66: gwyCiscoVG224AndV248
+  67: gwyCiscoSlotVGCPort
+  68: gwyCiscoVGCBox
+  69: gwyCiscoATA186
+  70: gwyCiscoICS77XXMRP2XX
+  71: gwyCiscoICS77XXASI81
+  72: gwyCiscoICS77XXASI160
+  75: h323H225GKControlledTrunk
+  76: h323ICTGKControlled
+  77: h323ICTNonGKControlled
+  80: gwyCiscoCat6000AVVIDServModule
+  81: gwyCiscoWSX6600
+  90: gwyCiscoMGCPBRIPort
+  95: sipTrunk
+  10001: gwyCiscoWSSVCCMMMS
+  20000: gwyCisco3745
+  20002: gwyCisco3725
+  30004: gwyCiscoICS77XXMRP3XX
+  30005: gwyCiscoICS77XXMRP38FXS
+  30006: gwyCiscoICS77XXMRP316FXS
+  30007: gwyCiscoICS77XXMRP38FXOM1
+  30011: gwyCisco269X
+  30019: gwyCisco1760
+  30020: gwyCisco1751
+
+# ccmGatewayStatusReason
+.1.3.6.1.4.1.9.9.156.1.3.1.1.10:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegReached
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+
+# ccmGatewayDChannelStatus
+.1.3.6.1.4.1.9.9.156.1.3.1.1.13:
+  1: active
+  2: inActive
+  3: unknown
+  4: notApplicable
+
+# ccmGatewayUnregReason
+.1.3.6.1.4.1.9.9.156.1.3.1.1.16:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: deviceUnregistered
+  11: malformedRegisterMsg
+  12: sccpDeviceThrottling
+  13: keepAliveTimeout
+  14: configurationMismatch
+  15: callManagerRestart
+  16: duplicateRegistration
+  17: callManagerApplyConfig
+  18: deviceNoResponse
+  19: emLoginLogout
+  20: emccLoginLogout
+  21: energywisePowerSavePlus
+  22: callManagerForcedRestart
+  23: sourceIPAddrChanged
+  24: sourcePortChanged
+  25: registrationSequenceError
+  26: invalidCapabilities
+  28: fallbackInitiated
+  29: deviceSwitch
+
+# ccmGatewayRegFailReason
+.1.3.6.1.4.1.9.9.156.1.3.1.1.17:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+  15: protocolMismatch
+  16: deviceNotActive
+  17: authenticatedDeviceAlreadyExists
+  18: obsoleteProtocolVersion
+  23: databaseTimeout
+  25: registrationSequenceError
+  26: invalidCapabilities
+  27: capabilityResponseTimeout
+  28: securityMismatch
+  29: autoRegisterDBError
+  30: dbAccessError
+  31: autoRegisterDBConfigTimeout
+  32: deviceTypeMismatch
+  33: addressingModeMismatch
+
+# ccmGatewayTrunkType
+.1.3.6.1.4.1.9.9.156.1.4.1.1.2:
+  1: unknown
+  2: other
+  3: trunkGroundStart
+  4: trunkLoopStart
+  5: trunkDID
+  6: trunkPOTS
+  7: trunkEM1
+  8: trunkEM2
+  9: trunkEM3
+  10: trunkEM4
+  11: trunkEM5
+  12: analog
+  13: pri
+  14: bri
+
+# ccmGatewayTrunkStatus
+.1.3.6.1.4.1.9.9.156.1.4.1.1.5:
+  1: unknown
+  2: up
+  3: busy
+  4: down
+
+# ccmMediaDeviceType
+.1.3.6.1.4.1.9.9.156.1.6.1.1.3:
+  1: unknown
+  2: ciscoMediaTerminPointWSX6608
+  3: ciscoConfBridgeWSX6608
+  4: ciscoSwMediaTerminationPoint
+  5: ciscoSwConfBridge
+  6: ciscoMusicOnHold
+  7: ciscoToneAnnouncementPlayer
+  8: ciscoConfBridgeWSSVCCMM
+  9: ciscoMediaServerWSSVCCMMMS
+  10: ciscoMTPWSSVCCMM
+  11: ciscoIOSSWMTPHDV2
+  12: ciscoIOSConfBridgeHDV2
+  13: ciscoIOSMTPHDV2
+  14: ciscoVCBIPVC35XX
+
+# ccmMediaDeviceStatus
+.1.3.6.1.4.1.9.9.156.1.6.1.1.5:
+  1: unknown
+  2: registered
+  3: unregistered
+  4: rejected
+  5: partiallyregistered
+
+# ccmMediaDeviceStatusReason
+.1.3.6.1.4.1.9.9.156.1.6.1.1.9:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegReached
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+
+# ccmMediaDeviceUnregReason
+.1.3.6.1.4.1.9.9.156.1.6.1.1.15:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: deviceUnregistered
+  11: malformedRegisterMsg
+  12: sccpDeviceThrottling
+  13: keepAliveTimeout
+  14: configurationMismatch
+  15: callManagerRestart
+  16: duplicateRegistration
+  17: callManagerApplyConfig
+  18: deviceNoResponse
+  19: emLoginLogout
+  20: emccLoginLogout
+  21: energywisePowerSavePlus
+  22: callManagerForcedRestart
+  23: sourceIPAddrChanged
+  24: sourcePortChanged
+  25: registrationSequenceError
+  26: invalidCapabilities
+  28: fallbackInitiated
+  29: deviceSwitch
+
+# ccmMediaDeviceRegFailReason
+.1.3.6.1.4.1.9.9.156.1.6.1.1.16:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+  15: protocolMismatch
+  16: deviceNotActive
+  17: authenticatedDeviceAlreadyExists
+  18: obsoleteProtocolVersion
+  23: databaseTimeout
+  25: registrationSequenceError
+  26: invalidCapabilities
+  27: capabilityResponseTimeout
+  28: securityMismatch
+  29: autoRegisterDBError
+  30: dbAccessError
+  31: autoRegisterDBConfigTimeout
+  32: deviceTypeMismatch
+  33: addressingModeMismatch
+
+# ccmGatekeeperType
+.1.3.6.1.4.1.9.9.156.1.7.1.1.3:
+  1: unknown
+  2: other
+  3: terminal
+  4: gateway
+
+# ccmGatekeeperStatus
+.1.3.6.1.4.1.9.9.156.1.7.1.1.5:
+  1: unknown
+  2: registered
+  3: unregistered
+  4: rejected
+
+# ccmCTIDeviceType
+.1.3.6.1.4.1.9.9.156.1.8.1.1.3:
+  1: unknown
+  2: other
+  3: ctiRoutePoint
+  4: ctiPort
+
+# ccmCTIDeviceStatus
+.1.3.6.1.4.1.9.9.156.1.8.1.1.5:
+  1: unknown
+  2: registered
+  3: unregistered
+  4: rejected
+  5: partiallyregistered
+
+# ccmCTIDeviceStatusReason
+.1.3.6.1.4.1.9.9.156.1.8.1.1.10:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegReached
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+
+# ccmCTIDeviceUnregReason
+.1.3.6.1.4.1.9.9.156.1.8.1.1.16:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: deviceUnregistered
+  11: malformedRegisterMsg
+  12: sccpDeviceThrottling
+  13: keepAliveTimeout
+  14: configurationMismatch
+  15: callManagerRestart
+  16: duplicateRegistration
+  17: callManagerApplyConfig
+  18: deviceNoResponse
+  19: emLoginLogout
+  20: emccLoginLogout
+  21: energywisePowerSavePlus
+  22: callManagerForcedRestart
+  23: sourceIPAddrChanged
+  24: sourcePortChanged
+  25: registrationSequenceError
+  26: invalidCapabilities
+  28: fallbackInitiated
+  29: deviceSwitch
+
+# ccmCTIDeviceRegFailReason
+.1.3.6.1.4.1.9.9.156.1.8.1.1.17:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+  15: protocolMismatch
+  16: deviceNotActive
+  17: authenticatedDeviceAlreadyExists
+  18: obsoleteProtocolVersion
+  23: databaseTimeout
+  25: registrationSequenceError
+  26: invalidCapabilities
+  27: capabilityResponseTimeout
+  28: securityMismatch
+  29: autoRegisterDBError
+  30: dbAccessError
+  31: autoRegisterDBConfigTimeout
+  32: deviceTypeMismatch
+  33: addressingModeMismatch
+
+# ccmAlarmSeverity
 .1.3.6.1.4.1.9.9.156.1.10.1:
   1: emergency
   2: alert
@@ -15,6 +771,7 @@
   6: notice
   7: informational
 
+# ccmFailCauseCode
 .1.3.6.1.4.1.9.9.156.1.10.2:
   1: unknown
   2: heartBeatStopped
@@ -29,6 +786,7 @@
   11: msgTranslatorInitFailed
   12: suppServicesInitFailed
 
+# ccmGatewayFailCauseCode
 .1.3.6.1.4.1.9.9.156.1.10.5:
   0: noError
   1: unknown
@@ -46,6 +804,7 @@
   13: directoryNumberMismatch
   14: malformedRegisterMsg
 
+# ccmMediaResourceType
 .1.3.6.1.4.1.9.9.156.1.10.6:
   1: unknown
   2: mediaTerminationPoint
@@ -53,25 +812,20 @@
   4: conferenceBridge
   5: musicOnHold
 
+# ccmGatewayPhysIfL2Status
 .1.3.6.1.4.1.9.9.156.1.10.10:
   1: unknown
   2: up
   3: down
 
-.1.3.6.1.4.1.9.9.156.1.10.24:
-  0: 'unknown' # unknown
-  1: 'IPv4' # ipv4
-  2: 'IPv6' # ipv6
-  3: 'IPv4 zone' # ipv4z
-  4: 'IPv6 zone' # ipv6z
-  16: 'DNS' # dns
-
+# ccmTLSConnectionFailReasonCode
 .1.3.6.1.4.1.9.9.156.1.10.27:
   1: unknown
   2: authenticationerror
   3: invalidx509nameincertificate
   4: invalidtlscipher
 
+# ccmGatewayRegFailCauseCode
 .1.3.6.1.4.1.9.9.156.1.10.28:
   0: noError
   1: unknown
@@ -102,3 +856,317 @@
   31: autoRegisterDBConfigTimeout
   32: deviceTypeMismatch
   33: addressingModeMismatch
+
+# ccmH323DevProductId
+.1.3.6.1.4.1.9.9.156.1.11.1.1.3:
+  -2: other
+  -1: unknown
+  1: gwyCiscoCat6KT1
+  2: gwyCiscoCat6KE1
+  3: gwyCiscoCat6KFXS
+  4: gwyCiscoCat6KFXO
+  7: gwyCiscoDT24Plus
+  8: gwyCiscoDT30Plus
+  9: gwyCiscoDT24
+  10: gwyCiscoAT2
+  11: gwyCiscoAT4
+  12: gwyCiscoAT8
+  13: gwyCiscoAS2
+  14: gwyCiscoAS4
+  15: gwyCiscoAS8
+  16: h323Phone
+  17: h323Trunk
+  18: gwyCiscoMGCPFXOPort
+  19: gwyCiscoMGCPFXSPort
+  27: voiceMailUOnePort
+  43: gwyCiscoVG200
+  44: gwyCisco26XX
+  45: gwyCisco362X
+  46: gwyCisco364X
+  47: gwyCisco366X
+  49: h323AnonymousGatewy
+  52: gwyCiscoMGCPT1Port
+  55: gwyCiscoMGCPE1Port
+  58: gwyCiscoCat4224VoiceGwySwitch
+  59: gwyCiscoCat4000AccessGwyModule
+  62: gwyCiscoIAD2400
+  65: gwyCiscoVGCEndPoint
+  66: gwyCiscoVG224AndV248
+  67: gwyCiscoSlotVGCPort
+  68: gwyCiscoVGCBox
+  69: gwyCiscoATA186
+  70: gwyCiscoICS77XXMRP2XX
+  71: gwyCiscoICS77XXASI81
+  72: gwyCiscoICS77XXASI160
+  75: h323H225GKControlledTrunk
+  76: h323ICTGKControlled
+  77: h323ICTNonGKControlled
+  80: gwyCiscoCat6000AVVIDServModule
+  81: gwyCiscoWSX6600
+  90: gwyCiscoMGCPBRIPort
+  95: sipTrunk
+  10001: gwyCiscoWSSVCCMMMS
+  20000: gwyCisco3745
+  20002: gwyCisco3725
+  30004: gwyCiscoICS77XXMRP3XX
+  30005: gwyCiscoICS77XXMRP38FXS
+  30006: gwyCiscoICS77XXMRP316FXS
+  30007: gwyCiscoICS77XXMRP38FXOM1
+  30011: gwyCisco269X
+  30019: gwyCisco1760
+  30020: gwyCisco1751
+
+# ccmH323DevStatus
+.1.3.6.1.4.1.9.9.156.1.11.1.1.21:
+  0: notApplicable
+  1: unknown
+  2: registered
+  3: unregistered
+  4: rejected
+
+# ccmH323DevStatusReason
+.1.3.6.1.4.1.9.9.156.1.11.1.1.22:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegReached
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+
+# ccmH323DevUnregReason
+.1.3.6.1.4.1.9.9.156.1.11.1.1.32:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: deviceUnregistered
+  11: malformedRegisterMsg
+  12: sccpDeviceThrottling
+  13: keepAliveTimeout
+  14: configurationMismatch
+  15: callManagerRestart
+  16: duplicateRegistration
+  17: callManagerApplyConfig
+  18: deviceNoResponse
+  19: emLoginLogout
+  20: emccLoginLogout
+  21: energywisePowerSavePlus
+  22: callManagerForcedRestart
+  23: sourceIPAddrChanged
+  24: sourcePortChanged
+  25: registrationSequenceError
+  26: invalidCapabilities
+  28: fallbackInitiated
+  29: deviceSwitch
+
+# ccmH323DevRegFailReason
+.1.3.6.1.4.1.9.9.156.1.11.1.1.33:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+  15: protocolMismatch
+  16: deviceNotActive
+  17: authenticatedDeviceAlreadyExists
+  18: obsoleteProtocolVersion
+  23: databaseTimeout
+  25: registrationSequenceError
+  26: invalidCapabilities
+  27: capabilityResponseTimeout
+  28: securityMismatch
+  29: autoRegisterDBError
+  30: dbAccessError
+  31: autoRegisterDBConfigTimeout
+  32: deviceTypeMismatch
+  33: addressingModeMismatch
+
+# ccmVMailDevProductId
+.1.3.6.1.4.1.9.9.156.1.12.1.1.3:
+  -2: other
+  -1: unknown
+  1: gwyCiscoCat6KT1
+  2: gwyCiscoCat6KE1
+  3: gwyCiscoCat6KFXS
+  4: gwyCiscoCat6KFXO
+  7: gwyCiscoDT24Plus
+  8: gwyCiscoDT30Plus
+  9: gwyCiscoDT24
+  10: gwyCiscoAT2
+  11: gwyCiscoAT4
+  12: gwyCiscoAT8
+  13: gwyCiscoAS2
+  14: gwyCiscoAS4
+  15: gwyCiscoAS8
+  16: h323Phone
+  17: h323Trunk
+  18: gwyCiscoMGCPFXOPort
+  19: gwyCiscoMGCPFXSPort
+  27: voiceMailUOnePort
+  43: gwyCiscoVG200
+  44: gwyCisco26XX
+  45: gwyCisco362X
+  46: gwyCisco364X
+  47: gwyCisco366X
+  49: h323AnonymousGatewy
+  52: gwyCiscoMGCPT1Port
+  55: gwyCiscoMGCPE1Port
+  58: gwyCiscoCat4224VoiceGwySwitch
+  59: gwyCiscoCat4000AccessGwyModule
+  62: gwyCiscoIAD2400
+  65: gwyCiscoVGCEndPoint
+  66: gwyCiscoVG224AndV248
+  67: gwyCiscoSlotVGCPort
+  68: gwyCiscoVGCBox
+  69: gwyCiscoATA186
+  70: gwyCiscoICS77XXMRP2XX
+  71: gwyCiscoICS77XXASI81
+  72: gwyCiscoICS77XXASI160
+  75: h323H225GKControlledTrunk
+  76: h323ICTGKControlled
+  77: h323ICTNonGKControlled
+  80: gwyCiscoCat6000AVVIDServModule
+  81: gwyCiscoWSX6600
+  90: gwyCiscoMGCPBRIPort
+  95: sipTrunk
+  10001: gwyCiscoWSSVCCMMMS
+  20000: gwyCisco3745
+  20002: gwyCisco3725
+  30004: gwyCiscoICS77XXMRP3XX
+  30005: gwyCiscoICS77XXMRP38FXS
+  30006: gwyCiscoICS77XXMRP316FXS
+  30007: gwyCiscoICS77XXMRP38FXOM1
+  30011: gwyCisco269X
+  30019: gwyCisco1760
+  30020: gwyCisco1751
+
+# ccmVMailDevStatus
+.1.3.6.1.4.1.9.9.156.1.12.1.1.5:
+  1: unknown
+  2: registered
+  3: unregistered
+  4: rejected
+  5: partiallyregistered
+
+# ccmVMailDevStatusReason
+.1.3.6.1.4.1.9.9.156.1.12.1.1.8:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegReached
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+
+# ccmVMailDevUnregReason
+.1.3.6.1.4.1.9.9.156.1.12.1.1.12:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: deviceUnregistered
+  11: malformedRegisterMsg
+  12: sccpDeviceThrottling
+  13: keepAliveTimeout
+  14: configurationMismatch
+  15: callManagerRestart
+  16: duplicateRegistration
+  17: callManagerApplyConfig
+  18: deviceNoResponse
+  19: emLoginLogout
+  20: emccLoginLogout
+  21: energywisePowerSavePlus
+  22: callManagerForcedRestart
+  23: sourceIPAddrChanged
+  24: sourcePortChanged
+  25: registrationSequenceError
+  26: invalidCapabilities
+  28: fallbackInitiated
+  29: deviceSwitch
+
+# ccmVMailDevRegFailReason
+.1.3.6.1.4.1.9.9.156.1.12.1.1.13:
+  0: noError
+  1: unknown
+  2: noEntryInDatabase
+  3: databaseConfigurationError
+  4: deviceNameUnresolveable
+  5: maxDevRegExceeded
+  6: connectivityError
+  7: initializationError
+  8: deviceInitiatedReset
+  9: callManagerReset
+  10: authenticationError
+  11: invalidX509NameInCertificate
+  12: invalidTLSCipher
+  13: directoryNumberMismatch
+  14: malformedRegisterMsg
+  15: protocolMismatch
+  16: deviceNotActive
+  17: authenticatedDeviceAlreadyExists
+  18: obsoleteProtocolVersion
+  23: databaseTimeout
+  25: registrationSequenceError
+  26: invalidCapabilities
+  27: capabilityResponseTimeout
+  28: securityMismatch
+  29: autoRegisterDBError
+  30: dbAccessError
+  31: autoRegisterDBConfigTimeout
+  32: deviceTypeMismatch
+  33: addressingModeMismatch
+
+# ccmSIPInTransportProtocolType
+.1.3.6.1.4.1.9.9.156.1.14.1.1.7:
+  1: unknown
+  2: tcp
+  3: udp
+  4: tcpAndUdp
+  5: tls
+
+# ccmSIPOutTransportProtocolType
+.1.3.6.1.4.1.9.9.156.1.14.1.1.9:
+  1: unknown
+  2: tcp
+  3: udp
+  4: tcpAndUdp
+  5: tls

--- a/enums/integer/cisco/CISCO-CDP-MIB.yml
+++ b/enums/integer/cisco/CISCO-CDP-MIB.yml
@@ -32,6 +32,12 @@
   25: 'HTTP' # http
   65535: 'unknown' # unknown
 
+# cdpCacheDuplex
+.1.3.6.1.4.1.9.9.23.1.2.1.1.12:
+  1: 'unknown' # unknown
+  2: 'half-duplex' # halfduplex
+  3: 'full-duplex' # fullduplex
+
 # cdpCachePrimaryMgmtAddrType:
 .1.3.6.1.4.1.9.9.23.1.2.1.1.19:
   1: 'IPv4' # ip
@@ -90,11 +96,34 @@
   25: 'HTTP' # http
   65535: 'unknown' # unknown
 
-# cdpCacheDuplex
-.1.3.6.1.4.1.9.9.23.1.2.1.1.12:
-  1: 'unknown' # unknown
-  2: 'half-duplex' # halfduplex
-  3: 'full-duplex' # fullduplex
+# cdpCtAddressType
+.1.3.6.1.4.1.9.9.23.1.2.2.1.4:
+  1: 'IPv4' # ip
+  2: 'DECnet' # decnet
+  3: 'PUP' # pup
+  4: 'CHAOS' # chaos
+  5: 'XNS' # xns
+  6: 'X.121' # x121
+  7: 'AppleTalk' # appletalk
+  8: 'CLNS' # clns
+  9: 'LAT' # lat
+  10: 'Banyan Vines' # vines
+  11: 'CONS' # cons
+  12: 'Apollo' # apollo
+  13: 'STUN' # stun
+  14: 'Novell' # novell
+  15: 'QLLC' # qllc
+  16: 'snapshot' # snapshot
+  17: 'ATM ILMI' # atmIlmi
+  18: 'BSTUN' # bstun
+  19: 'X.25 PVC' # x25pvc
+  20: 'IPv6' # ipv6
+  21: 'CDM' # cdm
+  22: 'NBF' # nbf
+  23: 'BPX IGX' # bpxIgx
+  24: 'CLNS PFX' # clnsPfx
+  25: 'HTTP' # http
+  65535: 'unknown' # unknown
 
 # cdpGlobalDeviceIdFormat
 .1.3.6.1.4.1.9.9.23.1.3.7:

--- a/enums/integer/cisco/CISCO-SESS-BORDER-CTRLR-EVENT-MIB.yml
+++ b/enums/integer/cisco/CISCO-SESS-BORDER-CTRLR-EVENT-MIB.yml
@@ -1,0 +1,111 @@
+# csbAlarmSubsystem
+.1.3.6.1.4.1.9.9.658.1.1:
+  1: signaling
+  2: media
+  3: cac
+
+# csbAlarmSeverity
+.1.3.6.1.4.1.9.9.658.1.2:
+  1: cleared
+  2: indeterminate
+  3: critical
+  4: major
+  5: minor
+  6: warning
+  7: info
+
+# csbDynamicBlackListSubFamily
+.1.3.6.1.4.1.9.9.658.1.17:
+  1: blackVPN
+  2: blackAddress
+  3: blackPort
+
+# csbDynamicBlackListTransportType
+.1.3.6.1.4.1.9.9.658.1.21:
+  1: none
+  2: udp
+  3: tcp
+
+# csbAdjacencyType
+.1.3.6.1.4.1.9.9.658.1.24:
+  1: sip
+  2: h323
+
+# csbAdjacencyState
+.1.3.6.1.4.1.9.9.658.1.25:
+  1: attached
+  2: detached
+
+# csbSBCServiceState
+.1.3.6.1.4.1.9.9.658.1.28:
+  1: active
+  2: standby
+  3: offline
+
+# csbCongestionAlarmType
+.1.3.6.1.4.1.9.9.658.1.30:
+  1: unknown
+  2: cpu
+  3: memory
+
+# csbCongestionAlarmState
+.1.3.6.1.4.1.9.9.658.1.31:
+  1: raised
+  2: cleared
+
+# csbRadiusConnectionState
+.1.3.6.1.4.1.9.9.658.1.38:
+  1: up
+  2: down
+
+# csbRadiusType
+.1.3.6.1.4.1.9.9.658.1.39:
+  1: accounting
+  2: authentication
+
+# csbDiameterConnectionState
+.1.3.6.1.4.1.9.9.658.1.44:
+  1: up
+  2: down
+
+# csbDiameterType
+.1.3.6.1.4.1.9.9.658.1.45:
+  1: accounting
+  2: authentication
+
+# csbH248ControllerState
+.1.3.6.1.4.1.9.9.658.1.48:
+  1: attached
+  2: detached
+
+# csbQOSAlertCurrentLevel
+.1.3.6.1.4.1.9.9.658.1.65:
+  1: cleared
+  2: indeterminate
+  3: critical
+  4: major
+  5: minor
+  6: warning
+  7: info
+
+# csbQOSAlertPreviousLevel
+.1.3.6.1.4.1.9.9.658.1.66:
+  1: cleared
+  2: indeterminate
+  3: critical
+  4: major
+  5: minor
+  6: warning
+  7: info
+
+# csbQOSAlertType
+.1.3.6.1.4.1.9.9.658.1.71:
+  1: global
+  2: adjacency
+
+# csbQOSAlertSummaryPeriod
+.1.3.6.1.4.1.9.9.658.1.72:
+  1: fiveMinute
+  2: fifteenMinute
+  3: oneHour
+  4: oneDay

--- a/enums/integer/cisco/CISCO-SESS-BORDER-CTRLR-STATS-MIB.yml
+++ b/enums/integer/cisco/CISCO-SESS-BORDER-CTRLR-STATS-MIB.yml
@@ -1,0 +1,100 @@
+# csbRadiusStatsClientType
+.1.3.6.1.4.1.9.9.757.1.1.1.3:
+  1: authentication
+  2: accounting
+
+# csbSIPMthdCurrentStatsMethod
+.1.3.6.1.4.1.9.9.757.1.3.1.2:
+  1: unknown
+  2: ack
+  3: bye
+  4: cancel
+  5: info
+  6: invite
+  7: message
+  8: notify
+  9: options
+  10: prack
+  11: refer
+  12: register
+  13: subscribe
+  14: update
+
+# csbSIPMthdCurrentStatsInterval
+.1.3.6.1.4.1.9.9.757.1.3.1.3:
+  1: fiveMinute
+  2: fifteenMinute
+  3: oneHour
+  4: oneDay
+
+# csbSIPMthdHistoryStatsMethod
+.1.3.6.1.4.1.9.9.757.1.4.1.2:
+  1: unknown
+  2: ack
+  3: bye
+  4: cancel
+  5: info
+  6: invite
+  7: message
+  8: notify
+  9: options
+  10: prack
+  11: refer
+  12: register
+  13: subscribe
+  14: update
+
+# csbSIPMthdHistoryStatsInterval
+.1.3.6.1.4.1.9.9.757.1.4.1.3:
+  1: fiveMinute
+  2: fifteenMinute
+  3: oneHour
+  4: oneDay
+
+# csbSIPMthdRCCurrentStatsMethod
+.1.3.6.1.4.1.9.9.757.1.5.1.2:
+  1: unknown
+  2: ack
+  3: bye
+  4: cancel
+  5: info
+  6: invite
+  7: message
+  8: notify
+  9: options
+  10: prack
+  11: refer
+  12: register
+  13: subscribe
+  14: update
+
+# csbSIPMthdRCCurrentStatsInterval
+.1.3.6.1.4.1.9.9.757.1.5.1.4:
+  1: fiveMinute
+  2: fifteenMinute
+  3: oneHour
+  4: oneDay
+
+# csbSIPMthdRCHistoryStatsMethod
+.1.3.6.1.4.1.9.9.757.1.6.1.2:
+  1: unknown
+  2: ack
+  3: bye
+  4: cancel
+  5: info
+  6: invite
+  7: message
+  8: notify
+  9: options
+  10: prack
+  11: refer
+  12: register
+  13: subscribe
+  14: update
+
+# csbSIPMthdRCHistoryStatsInterval
+.1.3.6.1.4.1.9.9.757.1.6.1.5:
+  1: fiveMinute
+  2: fifteenMinute
+  3: oneHour
+  4: oneDay

--- a/enums/integer/cisco/CISCO-SIP-UA-MIB.yml
+++ b/enums/integer/cisco/CISCO-SIP-UA-MIB.yml
@@ -1,0 +1,88 @@
+# cSipCfgTransport
+.1.3.6.1.4.1.9.9.152.1.1.1.2:
+  1: udp
+  2: tcp
+  3: udpAndTcp
+  4: disabled
+
+# cSipCfgBindSrcAddrScope
+.1.3.6.1.4.1.9.9.152.1.1.1.6:
+  1: all
+  2: control
+
+# cSipCfgDnsSrvQueryStringFormat
+.1.3.6.1.4.1.9.9.152.1.1.1.7:
+  1: v1
+  2: v2
+
+# cSipCfgSymNatDirectionRole
+.1.3.6.1.4.1.9.9.152.1.1.1.11:
+  1: none
+  2: passive
+  3: active
+
+# cSipCfgBindSourceAddrScope
+.1.3.6.1.4.1.9.9.152.1.1.1.12.1.1:
+  1: media
+  2: control
+
+# cSipCfgOfferCallHold
+.1.3.6.1.4.1.9.9.152.1.1.1.14:
+  1: directionAttr
+  2: connAddr
+
+# cSipCfgPeerOutSessionTransport
+.1.3.6.1.4.1.9.9.152.1.1.4.1.1.2:
+  1: system
+  2: udp
+  3: tcp
+
+# cSipCfgPeerReliable1xxRspHdr
+.1.3.6.1.4.1.9.9.152.1.1.4.1.1.4:
+  1: system
+  2: supported
+  3: require
+  4: disabled
+
+# cSipCfgPeerUrlType
+.1.3.6.1.4.1.9.9.152.1.1.4.1.1.5:
+  1: system
+  2: sip
+  3: tel
+
+# cSipCfgOutSessionTransport
+.1.3.6.1.4.1.9.9.152.1.1.4.2:
+  1: udp
+  2: tcp
+
+# cSipCfgReliable1xxRspHdr
+.1.3.6.1.4.1.9.9.152.1.1.4.4:
+  1: supported
+  2: require
+  3: disabled
+
+# cSipCfgUrlType
+.1.3.6.1.4.1.9.9.152.1.1.4.5:
+  1: sip
+  2: tel
+
+# cSipCfgStatusCauseStoreStatus
+.1.3.6.1.4.1.9.9.152.1.1.5.1.1.3:
+  1: 'other' # other
+  2: 'volatile' # volatile
+  3: 'non-volatile' # nonVolatile
+  4: 'permanent' # permanent
+  5: 'read-only' # readOnly
+
+# cSipCfgCauseStatusStoreStatus
+.1.3.6.1.4.1.9.9.152.1.1.5.2.1.3:
+  1: 'other' # other
+  2: 'volatile' # volatile
+  3: 'non-volatile' # nonVolatile
+  4: 'permanent' # permanent
+  5: 'read-only' # readOnly
+
+# cSipCfgAaaUsername
+.1.3.6.1.4.1.9.9.152.1.1.6.1:
+  1: callingNumber
+  2: proxyAuth

--- a/enums/integer/cisco/CISCO-SYSLOG-MIB.yml
+++ b/enums/integer/cisco/CISCO-SYSLOG-MIB.yml
@@ -1,3 +1,24 @@
+# clogMaxSeverity
+.1.3.6.1.4.1.9.9.41.1.1.3:
+  1: emergency
+  2: alert
+  3: critical
+  4: error
+  5: warning
+  6: notice
+  7: info
+  8: debug
+
+# clogOriginIDType
+.1.3.6.1.4.1.9.9.41.1.1.6:
+  1: none
+  2: other
+  3: hostName
+  4: ipv4Address
+  5: contextName
+  6: userDefined
+
+# clogHistSeverity
 .1.3.6.1.4.1.9.9.41.1.2.3.1.3:
   1: emergency
   2: alert

--- a/enums/integer/cisco/CISCO-TELEPRESENCE-CALL-MIB.yml
+++ b/enums/integer/cisco/CISCO-TELEPRESENCE-CALL-MIB.yml
@@ -1,0 +1,192 @@
+# ctpcMode
+.1.3.6.1.4.1.9.9.644.1.2.4:
+  1: noMgmtSys
+  2: mgmtSys
+
+# ctpcMgmtSysConnStatus
+.1.3.6.1.4.1.9.9.644.1.2.6.1.4:
+  1: unknown
+  2: other
+  3: internalError
+  4: notRegister
+  5: registered
+  6: registraionFailure
+
+# ctpcStatMonitoredType
+.1.3.6.1.4.1.9.9.644.1.3.1.1.1:
+  1: latency
+  2: jitter
+  3: packetLoss
+  4: authFailurePacket
+
+# ctpcStatMonitoredStreamType
+.1.3.6.1.4.1.9.9.644.1.3.1.1.2:
+  0: all
+  1: video
+  2: audio
+
+# ctpcStatMonitoredUnit
+.1.3.6.1.4.1.9.9.644.1.3.1.1.3:
+  1: milliseconds
+  2: micropercent
+  3: packets
+
+# ctpcStatStartupAlarm
+.1.3.6.1.4.1.9.9.644.1.3.1.1.6:
+  1: risingAlarm
+  2: fallingAlarm
+  3: risingOrFallingAlarm
+
+# ctpcType
+.1.3.6.1.4.1.9.9.644.1.4.8.1.8:
+  1: audioVideo
+  2: audioOnly
+  3: unknown
+
+# ctpcSecurity
+.1.3.6.1.4.1.9.9.644.1.4.8.1.9:
+  1: nonSecured
+  2: authenticated
+  3: secured
+  4: unknown
+
+# ctpcDirection
+.1.3.6.1.4.1.9.9.644.1.4.8.1.10:
+  1: incoming
+  2: outgoing
+  3: unknown
+
+# ctpcState
+.1.3.6.1.4.1.9.9.644.1.4.8.1.11:
+  1: unknown
+  2: other
+  3: noMgmtSysConn
+  4: noDialTone
+  5: invalidNumber
+  6: ringing
+  7: noAnswer
+  8: inProgress
+  9: remoteHold
+  10: shareLineActive
+  11: inLocalConference
+  12: terminatedbyError
+  13: localHold
+  14: terminatedNormally
+  15: answer
+  16: resume
+  17: busy
+  18: pause
+  19: playback
+  20: recording
+
+# ctpcAttributes
+.1.3.6.1.4.1.9.9.644.1.4.8.1.15:
+  0: interop
+  1: highDefinitionInterop
+  2: webEx
+  3: schedule
+  4: satellite
+  5: t1
+  6: liveDesk
+
+# ctpcRemoteDevice
+.1.3.6.1.4.1.9.9.644.1.4.8.1.16:
+  1: unknown
+  2: other
+  3: audioDevice
+  4: videoLegacyDevice
+  5: highDefinitionLegacyDevice
+  6: singleTelepresence
+  7: tripleTelepresence
+  8: telepresenceMultipointSwitch
+  9: telepresenceRecordingServer
+  10: telepresenceTranscodingDevice
+
+# ctpcCallTermReason
+.1.3.6.1.4.1.9.9.644.1.4.8.1.17:
+  1: unknown
+  2: other
+  3: internalError
+  4: localDisconnected
+  5: remoteDisconnected
+  6: networkCongestion
+  7: mediaNegotiationFailure
+  8: securityConfigMismatched
+  9: incompatibleRemoteEndPt
+  10: serviceUnavailable
+  11: remoteTerminatedWithError
+  12: incall
+
+# ctpcStreamType
+.1.3.6.1.4.1.9.9.644.1.4.9.1.1:
+  1: video
+  2: audio
+  3: content
+
+# ctpcStreamSource
+.1.3.6.1.4.1.9.9.644.1.4.10.1.1:
+  1: secCodec1
+  2: priCodec
+  3: secCodec2
+  4: auxiliary1
+  5: secLegacy1
+  6: priLegacy
+  7: secLegacy2
+  8: auxiliary2
+  9: center
+  10: left
+  11: right
+  12: legacyCtr
+  13: legacyLeft
+  14: legacyRight
+  15: auxiliary3
+  16: auxiliary4
+  17: other
+
+# ctpcTxCodec
+.1.3.6.1.4.1.9.9.644.1.4.10.1.27:
+  1: unknown
+  2: other
+  3: aaclc
+  4: aacld
+  5: g711A
+  6: g711U
+  7: g722
+  8: g7221
+  9: g728
+  10: g729
+  11: h263
+  12: h264
+  13: aacldLatm
+  14: h265
+
+# ctpcRxCodec
+.1.3.6.1.4.1.9.9.644.1.4.10.1.29:
+  1: unknown
+  2: other
+  3: aaclc
+  4: aacld
+  5: g711A
+  6: g711U
+  7: g722
+  8: g7221
+  9: g728
+  10: g729
+  11: h263
+  12: h264
+  13: aacldLatm
+  14: h265
+
+# ctpcStatEventCrossedType
+.1.3.6.1.4.1.9.9.644.1.5.3.1.4:
+  1: risingThreshold
+  2: fallingThreshold
+
+# ctpcMgmtSysConnEventStatus
+.1.3.6.1.4.1.9.9.644.1.6.3.1.2:
+  1: unknown
+  2: other
+  3: internalError
+  4: notRegister
+  5: registered
+  6: registraionFailure

--- a/enums/integer/cisco/CISCO-TELEPRESENCE-MIB.yml
+++ b/enums/integer/cisco/CISCO-TELEPRESENCE-MIB.yml
@@ -1,0 +1,185 @@
+# ctpSystemReset
+.1.3.6.1.4.1.9.9.643.1.1.3:
+  1: noRestart
+  2: restartPending
+  3: resetPending
+  4: forceReset
+
+# ctpPeripheralStatus
+.1.3.6.1.4.1.9.9.643.1.2.1.1.3:
+  0: noError
+  1: other
+  2: cableError
+  3: powerError
+  4: mgmtSysConfigError
+  5: systemError
+  6: deviceError
+  7: linkError
+  8: commError
+  9: detectionDisabled
+
+# ctpPeripheralDeviceCategory
+.1.3.6.1.4.1.9.9.643.1.2.1.1.4:
+  0: unknown
+  1: other
+  2: uplinkDevice
+  3: ipPhone
+  4: camera
+  5: display
+  6: secCodec
+  7: docCamera
+  8: projector
+  9: dviDevice
+  10: presentationCodec
+  11: auxiliaryControlUnit
+  12: audioExpansionUnit
+  13: microphone
+  14: headset
+  15: positionMic
+  16: digitialMediaSystem
+  17: auxHDMIOutputDevice
+  18: uiDevice
+  19: auxHDMIInputDevice
+  20: bringYourOwnDevice
+
+# ctpEtherPeripheralStatus
+.1.3.6.1.4.1.9.9.643.1.2.2.1.5:
+  0: noError
+  1: other
+  2: cableError
+  3: powerError
+  4: mgmtSysConfigError
+  5: systemError
+  6: deviceError
+  7: linkError
+  8: commError
+  9: detectionDisabled
+
+# ctpHDMIPeripheralCableStatus
+.1.3.6.1.4.1.9.9.643.1.2.3.1.2:
+  1: plugged
+  2: loose
+  3: unplugged
+  4: unknown
+  5: internalError
+
+# ctpHDMIPeripheralPowerStatus
+.1.3.6.1.4.1.9.9.643.1.2.3.1.3:
+  1: 'on'
+  2: standby
+  3: 'off'
+  4: unknown
+  5: internalError
+
+# ctpDVIPeripheralCableStatus
+.1.3.6.1.4.1.9.9.643.1.2.4.1.2:
+  1: plugged
+  2: loose
+  3: unplugged
+  4: unknown
+  5: internalError
+
+# ctpRS232PeripheralConnStatus
+.1.3.6.1.4.1.9.9.643.1.2.5.1.3:
+  1: connected
+  2: unknown
+
+# ctpPeripheralAttributeDescr
+.1.3.6.1.4.1.9.9.643.1.2.6.1.2:
+  1: lampOperTime
+  2: lampState
+  3: powerSwitchState
+
+# ctpUSBPeripheralCableStatus
+.1.3.6.1.4.1.9.9.643.1.2.7.1.2:
+  1: plugged
+  2: loose
+  3: unplugged
+  4: unknown
+  5: internalError
+
+# ctpUSBPeripheralPowerStatus
+.1.3.6.1.4.1.9.9.643.1.2.7.1.3:
+  1: unknown
+  2: self
+  3: bus
+  4: both
+
+# ctpUSBPeripheralPortType
+.1.3.6.1.4.1.9.9.643.1.2.7.1.4:
+  1: host
+  2: device
+  3: hub
+
+# ctpUSBPeripheralPortRate
+.1.3.6.1.4.1.9.9.643.1.2.7.1.5:
+  1: low
+  2: full
+  3: high
+
+# ctp802dot11PeripheralLinkStatus
+.1.3.6.1.4.1.9.9.643.1.2.8.1.6:
+  1: plugged
+  2: loose
+  3: unplugged
+  4: unknown
+  5: internalError
+
+# ctpDPPeripheralCableStatus
+.1.3.6.1.4.1.9.9.643.1.2.9.1.2:
+  1: plugged
+  2: loose
+  3: unplugged
+  4: unknown
+  5: internalError
+
+# ctpDPPeripheralPowerStatus
+.1.3.6.1.4.1.9.9.643.1.2.9.1.3:
+  1: 'on'
+  2: standby
+  3: 'off'
+  4: unknown
+  5: internalError
+
+# ctpPeripheralErrorStatus
+.1.3.6.1.4.1.9.9.643.1.3.3.1.3:
+  0: noError
+  1: other
+  2: cableError
+  3: powerError
+  4: mgmtSysConfigError
+  5: systemError
+  6: deviceError
+  7: linkError
+  8: commError
+  9: detectionDisabled
+
+# ctpPeripheralErrorDeviceCategory
+.1.3.6.1.4.1.9.9.643.1.3.3.1.5:
+  0: unknown
+  1: other
+  2: uplinkDevice
+  3: ipPhone
+  4: camera
+  5: display
+  6: secCodec
+  7: docCamera
+  8: projector
+  9: dviDevice
+  10: presentationCodec
+  11: auxiliaryControlUnit
+  12: audioExpansionUnit
+  13: microphone
+  14: headset
+  15: positionMic
+  16: digitialMediaSystem
+  17: auxHDMIOutputDevice
+  18: uiDevice
+  19: auxHDMIInputDevice
+  20: bringYourOwnDevice
+
+# ctpSysUserAuthFailAccessProtocol
+.1.3.6.1.4.1.9.9.643.1.3.6.1.6:
+  1: http
+  2: snmp
+  3: ssh

--- a/enums/integer/cisco/CISCO-UNITY-MIB.yml
+++ b/enums/integer/cisco/CISCO-UNITY-MIB.yml
@@ -1,0 +1,12 @@
+# ciscoUnityServerState
+.1.3.6.1.4.1.9.9.385.1.2.1:
+  1: stopped
+  2: starting
+  3: running
+  4: stopping
+
+# ciscoUnityEventType
+.1.3.6.1.4.1.9.9.385.1.3.1:
+  1: error
+  2: warning
+  3: informational

--- a/enums/integer/cisco/CISCO-VOICE-APPS-MIB.yml
+++ b/enums/integer/cisco/CISCO-VOICE-APPS-MIB.yml
@@ -1,3 +1,4 @@
+# cvaAlarmSeverity
 .1.3.6.1.4.1.9.9.190.1.2.1:
   1: emergency
   2: alert
@@ -7,6 +8,7 @@
   6: notice
   7: informational
 
+# cvaModuleFailureCause
 .1.3.6.1.4.1.9.9.190.1.2.5:
   1: other
   2: gracefulShutDown
@@ -15,6 +17,7 @@
   5: outOfResource
   6: partialFailure
 
+# cvaModuleRunTimeFailureCause
 .1.3.6.1.4.1.9.9.190.1.2.7:
   1: other
   2: readAccessFailure

--- a/object_groups/cisco.yml
+++ b/object_groups/cisco.yml
@@ -27,6 +27,21 @@ cisco_bridge:
     - CISCO-BRIDGE-EXT-MIB::cbeDot1dStaticEntry
     - CISCO-BRIDGE-EXT-MIB::cbeDot1dVlanEntry
 
+cisco_ccm:
+  objects:
+    - CISCO-CCM-MIB::ccmPhoneEntry
+    - CISCO-CCM-MIB::ccmPhoneFailedEntry
+    - CISCO-CCM-MIB::ccmPhoneStatusUpdateEntry
+    - CISCO-CCM-MIB::ccmPhoneExtnEntry
+    - CISCO-CCM-MIB::ccmGatewayEntry
+    - CISCO-CCM-MIB::ccmGatewayTrunkEntry
+    - CISCO-CCM-MIB::ccmGlobalInfo
+    - CISCO-CCM-MIB::ccmMediaDeviceEntry
+    - CISCO-CCM-MIB::ccmGatekeeperEntry
+    - CISCO-CCM-MIB::ccmCTIDeviceEntry
+    - CISCO-CCM-MIB::ccmH323DeviceEntry
+    - CISCO-CCM-MIB::ccmVoiceMailDeviceEntry
+
 cisco_cdp:
   objects:
     - CISCO-CDP-MIB::cdpInterfaceEntry
@@ -251,6 +266,30 @@ cisco_ptp:
     - CISCO-PTP-MIB::cPtpClockPortAssociateEntry
     - CISCO-PTP-MIB::cPtpClockSystemTimePropertiesEntry
 
+cisco_sess_border_ctrlr:
+  objects:
+    - CISCO-SESS-BORDER-CTRLR-EVENT-MIB::ciscoSessBorderCtrlrMIBObjects
+    - CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbRadiusStatsEntry
+    - CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbRfBillRealmStatsEntry
+    - CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbSIPMthdCurrentStatsEntry
+    - CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbSIPMthdHistoryStatsEntry
+    - CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbSIPMthdRCCurrentStatsEntry
+    - CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbSIPMthdRCHistoryStatsEntry
+
+cisco_sip:
+  objects:
+    - CISCO-SIP-UA-MIB::cSipStatsInfo
+    - CISCO-SIP-UA-MIB::cSipStatsSuccess
+    - CISCO-SIP-UA-MIB::cSipStatsSuccessOkEntry
+    - CISCO-SIP-UA-MIB::cSipStatsRedirect
+    - CISCO-SIP-UA-MIB::cSipStatsErrClient
+    - CISCO-SIP-UA-MIB::cSipStatsErrServer
+    - CISCO-SIP-UA-MIB::cSipStatsGlobalFail
+    - CISCO-SIP-UA-MIB::cSipStatsTraffic
+    - CISCO-SIP-UA-MIB::cSipStatsRetry
+    - CISCO-SIP-UA-MIB::cSipStatsMisc
+    - CISCO-SIP-UA-MIB::cSipStatsConnection
+
 cisco_stack:
   objects:
     - CISCO-STACK-MIB::systemGrp
@@ -275,6 +314,36 @@ cisco_switch:
     - CISCO-SWITCH-MULTICAST-MIB::cswmFlowQueryEntry
     - CISCO-SWITCH-MULTICAST-MIB::cswmFlowResultEntry
 
+cisco_syslog:
+  objects:
+    - CISCO-SYSLOG-MIB::clogBasic
+    - CISCO-SYSLOG-MIB::clogHistory
+
+cisco_telepresence:
+  objects:
+    - CISCO-TELEPRESENCE-MIB::ctpObjects
+    - CISCO-TELEPRESENCE-MIB::ctpPeripheralStatusEntry
+    - CISCO-TELEPRESENCE-MIB::ctpEtherPeripheralStatusEntry
+    - CISCO-TELEPRESENCE-MIB::ctpHDMIPeripheralStatusEntry
+    - CISCO-TELEPRESENCE-MIB::ctpDVIPeripheralStatusEntry
+    - CISCO-TELEPRESENCE-MIB::ctpRS232PeripheralStatusEntry
+    - CISCO-TELEPRESENCE-MIB::ctpPeripheralAttributeEntry
+    - CISCO-TELEPRESENCE-MIB::ctpUSBPeripheralStatusEntry
+    - CISCO-TELEPRESENCE-MIB::ctp802dot11PeripheralStatusEntry
+    - CISCO-TELEPRESENCE-MIB::ctpDPPeripheralStatusEntry
+    - CISCO-TELEPRESENCE-CALL-MIB::ctpcMgmtSysEntry
+    - CISCO-TELEPRESENCE-CALL-MIB::ctpcStatObjects
+    - CISCO-TELEPRESENCE-CALL-MIB::ctpcStatStreamSourceEntry
+
 cisco_temperature:
   objects:
     - CISCO-TEMPERATURE-MIB::ciscoTempEntry
+
+cisco_unity:
+  objects:
+    - CISCO-UNITY-MIB::ciscoUnityPortEntry
+    - CISCO-UNITY-MIB::ciscoUnityGlobalInfo
+
+cisco_voice:
+  objects:
+    - CISCO-VOICE-APPS-MIB::cvaWorkflowInstallEntry

--- a/object_groups/ietf/router.yml
+++ b/object_groups/ietf/router.yml
@@ -1,3 +1,4 @@
+# DEPRECATED: this object group will be removed in a future release. Use ietf_bgp, ietf_isis, ietf_ospf, ietf_rip and ietf_vrrp.
 ietf_router:
   objects:
     # BGP

--- a/object_groups/ietf/switch.yml
+++ b/object_groups/ietf/switch.yml
@@ -1,3 +1,4 @@
+# DEPRECATED: this object group will be removed in a future release. Use ietf_bridge, ietf_p_bridge, ietf_q_bridge, and ietf_rstp.
 ietf_switch:
   objects:
     - BRIDGE-MIB::dot1dBase

--- a/objects/cisco/CISCO-CCM-MIB.yml
+++ b/objects/cisco/CISCO-CCM-MIB.yml
@@ -1,0 +1,1140 @@
+# CISCO-CCM-MIB::ccmGroupEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmGroupEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.1.1.1
+#       name: cisco.ccmGroupIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmGroupName
+#   attributes:
+#     ccmGroupName:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.1.1.2
+#       name: cisco.ccmGroupName
+#       syntax: DisplayString # SnmpAdminString
+#     ccmGroupTftpDefault:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.1.1.3
+#       name: cisco.ccmGroupTftpDefault
+#       syntax: TruthValue
+
+# CISCO-CCM-MIB::ccmEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.2.1.1
+#       name: cisco.ccmIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmName
+#   attributes:
+#     ccmName:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.2.1.2
+#       name: cisco.ccmName
+#       syntax: DisplayString # SnmpAdminString
+#     ccmDescription:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.2.1.3
+#       name: cisco.ccmDescription
+#       syntax: DisplayString # SnmpAdminString
+#     ccmVersion:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.2.1.4
+#       name: cisco.ccmVersion
+#       syntax: DisplayString # SnmpAdminString
+#     ccmStatus:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.2.1.5
+#       name: cisco.ccmStatus
+#       syntax: EnumInteger
+#     ccmInetAddress:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.2.1.7
+#       name: cisco.ccmInetAddress
+#       syntax: IpAddressNoSuffix # InetAddress
+#     ccmClusterId:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.2.1.8
+#       name: cisco.ccmClusterId
+#       syntax: DisplayString # SnmpAdminString
+#     ccmInetAddress2:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.2.1.10
+#       name: cisco.ccmInetAddress2
+#       syntax: IpAddressNoSuffix # InetAddress
+
+# CISCO-CCM-MIB::ccmGroupMappingEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmGroupMappingEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.1.1.1
+#       name: cisco.ccmGroupIndex
+#       syntax: UnsignedAsID # CcmIndex
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.2.1.1
+#       name: cisco.ccmIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmCMGroupMappingCMPriority
+#   attributes:
+#     ccmCMGroupMappingCMPriority:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.3.1.1
+#       name: cisco.ccmCMGroupMappingCMPriority
+#       syntax: Unsigned32
+
+# CISCO-CCM-MIB::ccmRegionEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmRegionEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.4.1.1
+#       name: cisco.ccmRegionIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmRegionName
+#   attributes:
+#     ccmRegionName:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.4.1.2
+#       name: cisco.ccmRegionName
+#       syntax: DisplayString # SnmpAdminString
+
+# CISCO-CCM-MIB::ccmRegionPairEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmRegionPairEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.5.1.1
+#       name: cisco.ccmRegionSrcIndex
+#       syntax: UnsignedAsID # CcmIndex
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.5.1.2
+#       name: cisco.ccmRegionDestIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmRegionAvailableBandWidth
+#   attributes:
+#     ccmRegionAvailableBandWidth:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.5.1.3
+#       name: cisco.ccmRegionAvailableBandWidth
+#       syntax: EnumInteger
+
+# CISCO-CCM-MIB::ccmTimeZoneEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmTimeZoneEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.6.1.1
+#       name: cisco.ccmTimeZoneIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmTimeZoneName
+#   attributes:
+#     ccmTimeZoneName:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.6.1.2
+#       name: cisco.ccmTimeZoneName
+#       syntax: DisplayString # SnmpAdminString
+#     ccmTimeZoneOffset:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.6.1.3
+#       name: cisco.ccmTimeZoneOffset
+#       syntax: Integer32
+#     ccmTimeZoneOffsetHours:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.6.1.4
+#       name: cisco.ccmTimeZoneOffsetHours
+#       syntax: Integer32
+#     ccmTimeZoneOffsetMinutes:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.6.1.5
+#       name: cisco.ccmTimeZoneOffsetMinutes
+#       syntax: Integer32
+
+# CISCO-CCM-MIB::ccmDevicePoolEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmDevicePoolEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.7.1.1
+#       name: cisco.ccmDevicePoolIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmDevicePoolName
+#   attributes:
+#     ccmDevicePoolName:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.7.1.2
+#       name: cisco.ccmDevicePoolName
+#       syntax: DisplayString # SnmpAdminString
+#     ccmDevicePoolRegionIndex:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.7.1.3
+#       name: cisco.ccmDevicePoolRegionIndex
+#       syntax: UnsignedAsID # CcmIndexOrZero
+#     ccmDevicePoolTimeZoneIndex:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.7.1.4
+#       name: cisco.ccmDevicePoolTimeZoneIndex
+#       syntax: UnsignedAsID # CcmIndexOrZero
+#     ccmDevicePoolGroupIndex:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.7.1.5
+#       name: cisco.ccmDevicePoolGroupIndex
+#       syntax: UnsignedAsID # CcmIndexOrZero
+
+# CISCO-CCM-MIB::ccmProductTypeEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmProductTypeEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.8.1.1
+#       name: cisco.ccmProductTypeIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmProductType
+#   attributes:
+#     ccmProductType:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.8.1.2
+#       name: cisco.ccmProductType
+#       syntax: Unsigned32
+#     ccmProductName:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.8.1.3
+#       name: cisco.ccmProductName
+#       syntax: DisplayString # SnmpAdminString
+#     ccmProductCategory:
+#       oid: .1.3.6.1.4.1.9.9.156.1.1.8.1.4
+#       name: cisco.ccmProductCategory
+#       syntax: EnumInteger
+
+CISCO-CCM-MIB::ccmPhoneEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmPhoneEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.1
+      name: cisco.ccmPhoneIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmPhonePhysicalAddress
+  attributes:
+    ccmPhonePhysicalAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.2
+      name: cisco.ccmPhonePhysicalAddress
+      syntax: MacAddressNoSuffix # MacAddress
+    ccmPhoneType:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.3
+      name: cisco.ccmPhoneType
+      syntax: EnumInteger
+    ccmPhoneDescription:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.4
+      name: cisco.ccmPhoneDescription
+      syntax: DisplayString # SnmpAdminString
+    ccmPhoneUserName:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.5
+      name: cisco.ccmPhoneUserName
+      syntax: DisplayString # SnmpAdminString
+    ccmPhoneIpAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.6
+      name: cisco.ccmPhoneIpAddress
+      syntax: IpAddressNoSuffix # IpAddress
+    ccmPhoneStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.7
+      name: cisco.ccmPhoneStatus
+      syntax: EnumInteger
+    ccmPhoneTimeLastRegistered:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.8
+      name: cisco.ccmPhoneTimeLastRegistered
+      syntax: DateAndTime
+    ccmPhoneE911Location:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.9
+      name: cisco.ccmPhoneE911Location
+      syntax: DisplayString # SnmpAdminString
+    ccmPhoneLoadID:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.10
+      name: cisco.ccmPhoneLoadID
+      syntax: DisplayString # SnmpAdminString
+    ccmPhoneLastError:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.11
+      name: cisco.ccmPhoneLastError
+      syntax: Integer32
+    ccmPhoneTimeLastError:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.12
+      name: cisco.ccmPhoneTimeLastError
+      syntax: DateAndTime
+    ccmPhoneDevicePoolIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.13
+      name: cisco.ccmPhoneDevicePoolIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmPhoneInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.15
+      name: cisco.ccmPhoneIpAddress
+      syntax: IpAddressNoSuffix # InetAddress
+      overrides:
+        object: CISCO-CCM-MIB::ccmPhoneEntry
+        attribute: ccmPhoneIpAddress
+    ccmPhoneStatusReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.16
+      name: cisco.ccmPhoneStatusReason
+      syntax: EnumInteger
+    ccmPhoneTimeLastStatusUpdt:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.17
+      name: cisco.ccmPhoneTimeLastStatusUpdt
+      syntax: DateAndTime
+    ccmPhoneProductTypeIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.18
+      name: cisco.ccmPhoneProductTypeIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmPhoneProtocol:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.19
+      name: cisco.ccmPhoneProtocol
+      syntax: EnumInteger
+    ccmPhoneName:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.20
+      name: cisco.ccmPhoneName
+      syntax: DisplayString # SnmpAdminString
+    ccmPhoneInetAddressIPv4:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.21
+      name: cisco.ccmPhoneInetAddressIPv4
+      syntax: IpAddressNoSuffix # InetAddressIPv4
+    ccmPhoneInetAddressIPv6:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.22
+      name: cisco.ccmPhoneInetAddressIPv6
+      syntax: IpAddressNoSuffix # InetAddressIPv6
+    ccmPhoneIPv4Attribute:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.23
+      name: cisco.ccmPhoneIPv4Attribute
+      syntax: EnumInteger
+    ccmPhoneIPv6Attribute:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.24
+      name: cisco.ccmPhoneIPv6Attribute
+      syntax: EnumInteger
+    ccmPhoneActiveLoadID:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.25
+      name: cisco.ccmPhoneActiveLoadID
+      syntax: DisplayString # SnmpAdminString
+    ccmPhoneUnregReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.26
+      name: cisco.ccmPhoneUnregReason
+      syntax: EnumInteger
+    ccmPhoneRegFailReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.27
+      name: cisco.ccmPhoneRegFailReason
+      syntax: EnumInteger
+
+# CISCO-CCM-MIB::ccmPhoneExtensionEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmPhoneExtensionEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.2.2.1.1
+#       name: cisco.ccmPhoneExtensionIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmPhoneExtension
+#   attributes:
+#     ccmPhoneExtension:
+#       oid: .1.3.6.1.4.1.9.9.156.1.2.2.1.2
+#       name: cisco.ccmPhoneExtension
+#       syntax: DisplayString # SnmpAdminString
+#     ccmPhoneExtensionIpAddress:
+#       oid: .1.3.6.1.4.1.9.9.156.1.2.2.1.3
+#       name: cisco.ccmPhoneExtensionIpAddress
+#       syntax: IpAddressNoSuffix # IpAddress
+#     ccmPhoneExtensionMultiLines:
+#       oid: .1.3.6.1.4.1.9.9.156.1.2.2.1.4
+#       name: cisco.ccmPhoneExtensionMultiLines
+#       syntax: Unsigned32
+#     ccmPhoneExtensionInetAddress:
+#       oid: .1.3.6.1.4.1.9.9.156.1.2.2.1.6
+#       name: cisco.ccmPhoneExtensionIpAddress
+#       syntax: IpAddressNoSuffix # InetAddress
+#       overrides:
+#         object: CISCO-CCM-MIB::ccmPhoneExtensionIpAddress
+#         attribute: ccmPhoneIpAddress
+
+CISCO-CCM-MIB::ccmPhoneFailedEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmPhoneFailedEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.1
+      name: cisco.ccmPhoneFailedIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmPhoneFailedTime
+  attributes:
+    ccmPhoneFailedTime:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.2
+      name: cisco.ccmPhoneFailedTime
+      syntax: DateAndTime
+    ccmPhoneFailedName:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.3
+      name: cisco.ccmPhoneFailedName
+      syntax: DisplayString # SnmpAdminString
+    ccmPhoneFailedInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.5
+      name: cisco.ccmPhoneFailedInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmPhoneFailCauseCode:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.6
+      name: cisco.ccmPhoneFailCauseCode
+      syntax: EnumInteger
+    ccmPhoneFailedMacAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.7
+      name: cisco.ccmPhoneFailedMacAddress
+      syntax: MacAddressNoSuffix # MacAddress
+    ccmPhoneFailedInetAddressIPv4:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.8
+      name: cisco.ccmPhoneFailedInetAddressIPv4
+      syntax: IpAddressNoSuffix # InetAddressIPv4
+    ccmPhoneFailedInetAddressIPv6:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.9
+      name: cisco.ccmPhoneFailedInetAddressIPv6
+      syntax: IpAddressNoSuffix # InetAddressIPv6
+    ccmPhoneFailedIPv4Attribute:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.10
+      name: cisco.ccmPhoneFailedIPv4Attribute
+      syntax: EnumInteger
+    ccmPhoneFailedIPv6Attribute:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.11
+      name: cisco.ccmPhoneFailedIPv6Attribute
+      syntax: EnumInteger
+    ccmPhoneFailedRegFailReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.3.1.12
+      name: cisco.ccmPhoneFailedRegFailReason
+      syntax: EnumInteger
+
+CISCO-CCM-MIB::ccmPhoneStatusUpdateEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmPhoneStatusUpdateEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.2.4.1.1
+      name: cisco.ccmPhoneStatusUpdateIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmPhoneStatusPhoneIndex
+  attributes:
+    ccmPhoneStatusPhoneIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.4.1.2
+      name: cisco.ccmPhoneStatusPhoneIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmPhoneStatusUpdateTime:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.4.1.3
+      name: cisco.ccmPhoneStatusUpdateTime
+      syntax: DateAndTime
+    ccmPhoneStatusUpdateType:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.4.1.4
+      name: cisco.ccmPhoneStatusUpdateType
+      syntax: EnumInteger
+    ccmPhoneStatusUpdateReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.4.1.5
+      name: cisco.ccmPhoneStatusUpdateReason
+      syntax: EnumInteger
+    ccmPhoneStatusUnregReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.4.1.6
+      name: cisco.ccmPhoneStatusUnregReason
+      syntax: EnumInteger
+    ccmPhoneStatusRegFailReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.4.1.7
+      name: cisco.ccmPhoneStatusRegFailReason
+      syntax: EnumInteger
+
+CISCO-CCM-MIB::ccmPhoneExtnEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmPhoneExtnEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.2.1.1.1
+      name: cisco.ccmPhoneIndex
+      syntax: UnsignedAsID # CcmIndex
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.2.5.1.1
+      name: cisco.ccmPhoneExtnIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmPhoneExtn
+  attributes:
+    ccmPhoneExtn:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.5.1.2
+      name: cisco.ccmPhoneExtn
+      syntax: DisplayString # SnmpAdminString
+    ccmPhoneExtnMultiLines:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.5.1.3
+      name: cisco.ccmPhoneExtnMultiLines
+      syntax: Unsigned32
+    ccmPhoneExtnInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.5.1.5
+      name: cisco.ccmPhoneExtnInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmPhoneExtnStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.2.5.1.6
+      name: cisco.ccmPhoneExtnStatus
+      syntax: EnumInteger
+
+CISCO-CCM-MIB::ccmGatewayEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmGatewayEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.1
+      name: cisco.ccmGatewayIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmGatewayName
+  attributes:
+    ccmGatewayName:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.2
+      name: cisco.ccmGatewayName
+      syntax: DisplayString # SnmpAdminString
+    ccmGatewayType:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.3
+      name: cisco.ccmGatewayType
+      syntax: EnumInteger
+    ccmGatewayDescription:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.4
+      name: cisco.ccmGatewayDescription
+      syntax: DisplayString # SnmpAdminString
+    ccmGatewayStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.5
+      name: cisco.ccmGatewayStatus
+      syntax: EnumInteger
+    ccmGatewayDevicePoolIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.6
+      name: cisco.ccmGatewayDevicePoolIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmGatewayInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.8
+      name: cisco.ccmGatewayInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmGatewayProductId:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.9
+      name: cisco.ccmGatewayProductId
+      syntax: EnumInteger
+    ccmGatewayStatusReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.10
+      name: cisco.ccmGatewayStatusReason
+      syntax: EnumInteger
+    ccmGatewayTimeLastStatusUpdt:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.11
+      name: cisco.ccmGatewayTimeLastStatusUpdt
+      syntax: DateAndTime
+    ccmGatewayTimeLastRegistered:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.12
+      name: cisco.ccmGatewayTimeLastRegistered
+      syntax: DateAndTime
+    ccmGatewayDChannelStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.13
+      name: cisco.ccmGatewayDChannelStatus
+      syntax: EnumInteger
+    ccmGatewayDChannelNumber:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.14
+      name: cisco.ccmGatewayDChannelNumber
+      syntax: Integer32
+    ccmGatewayProductTypeIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.15
+      name: cisco.ccmGatewayProductTypeIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmGatewayUnregReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.16
+      name: cisco.ccmGatewayUnregReason
+      syntax: EnumInteger
+    ccmGatewayRegFailReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.3.1.1.17
+      name: cisco.ccmGatewayRegFailReason
+      syntax: EnumInteger
+
+CISCO-CCM-MIB::ccmGatewayTrunkEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmGatewayTrunkEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.4.1.1.1
+      name: cisco.ccmGatewayTrunkIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmGatewayTrunkType
+  attributes:
+    ccmGatewayTrunkType:
+      oid: .1.3.6.1.4.1.9.9.156.1.4.1.1.2
+      name: cisco.ccmGatewayTrunkType
+      syntax: EnumInteger
+    ccmGatewayTrunkName:
+      oid: .1.3.6.1.4.1.9.9.156.1.4.1.1.3
+      name: cisco.ccmGatewayTrunkName
+      syntax: DisplayString # SnmpAdminString
+    ccmTrunkGatewayIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.4.1.1.4
+      name: cisco.ccmTrunkGatewayIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmGatewayTrunkStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.4.1.1.5
+      name: cisco.ccmGatewayTrunkStatus
+      syntax: EnumInteger
+
+CISCO-CCM-MIB::ccmGlobalInfo:
+  mib: CISCO-CCM-MIB
+  object: ccmGlobalInfo
+  discovery_attribute: ccmActivePhones
+  attributes:
+    ccmActivePhones:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.1
+      name: cisco.ccmActivePhones
+      syntax: Counter32
+    ccmInActivePhones:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.2
+      name: cisco.ccmInActivePhones
+      syntax: Counter32
+    ccmActiveGateways:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.3
+      name: cisco.ccmActiveGateways
+      syntax: Counter32
+    ccmInActiveGateways:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.4
+      name: cisco.ccmInActiveGateways
+      syntax: Counter32
+    ccmRegisteredPhones:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.5
+      name: cisco.ccmRegisteredPhones
+      syntax: Counter32
+    ccmUnregisteredPhones:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.6
+      name: cisco.ccmUnregisteredPhones
+      syntax: Counter32
+    ccmRejectedPhones:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.7
+      name: cisco.ccmRejectedPhones
+      syntax: Counter32
+    ccmRegisteredGateways:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.8
+      name: cisco.ccmRegisteredGateways
+      syntax: Counter32
+    ccmUnregisteredGateways:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.9
+      name: cisco.ccmUnregisteredGateways
+      syntax: Counter32
+    ccmRejectedGateways:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.10
+      name: cisco.ccmRejectedGateways
+      syntax: Counter32
+    ccmRegisteredMediaDevices:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.11
+      name: cisco.ccmRegisteredMediaDevices
+      syntax: Counter32
+    ccmUnregisteredMediaDevices:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.12
+      name: cisco.ccmUnregisteredMediaDevices
+      syntax: Counter32
+    ccmRejectedMediaDevices:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.13
+      name: cisco.ccmRejectedMediaDevices
+      syntax: Counter32
+    ccmRegisteredCTIDevices:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.14
+      name: cisco.ccmRegisteredCTIDevices
+      syntax: Counter32
+    ccmUnregisteredCTIDevices:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.15
+      name: cisco.ccmUnregisteredCTIDevices
+      syntax: Counter32
+    ccmRejectedCTIDevices:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.16
+      name: cisco.ccmRejectedCTIDevices
+      syntax: Counter32
+    ccmRegisteredVoiceMailDevices:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.17
+      name: cisco.ccmRegisteredVoiceMailDevices
+      syntax: Counter32
+    ccmUnregisteredVoiceMailDevices:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.18
+      name: cisco.ccmUnregisteredVoiceMailDevices
+      syntax: Counter32
+    ccmRejectedVoiceMailDevices:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.19
+      name: cisco.ccmRejectedVoiceMailDevices
+      syntax: Counter32
+    ccmCallManagerStartTime:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.20
+      name: cisco.ccmCallManagerStartTime
+      syntax: DateAndTime
+    ccmPhoneTableStateId:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.21
+      name: cisco.ccmPhoneTableStateId
+      syntax: Integer32
+    ccmPhoneExtensionTableStateId:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.22
+      name: cisco.ccmPhoneExtensionTableStateId
+      syntax: Integer32
+    ccmPhoneStatusUpdateTableStateId:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.23
+      name: cisco.ccmPhoneStatusUpdateTableStateId
+      syntax: Integer32
+    ccmGatewayTableStateId:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.24
+      name: cisco.ccmGatewayTableStateId
+      syntax: Integer32
+    ccmCTIDeviceTableStateId:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.25
+      name: cisco.ccmCTIDeviceTableStateId
+      syntax: Integer32
+    ccmCTIDeviceDirNumTableStateId:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.26
+      name: cisco.ccmCTIDeviceDirNumTableStateId
+      syntax: Integer32
+    ccmPhStatUpdtTblLastAddedIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.27
+      name: cisco.ccmPhStatUpdtTblLastAddedIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmPhFailedTblLastAddedIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.28
+      name: cisco.ccmPhFailedTblLastAddedIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmSystemVersion:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.29
+      name: cisco.ccmSystemVersion
+      syntax: DisplayString # SnmpAdminString
+    ccmInstallationId:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.30
+      name: cisco.ccmInstallationId
+      syntax: DisplayString # SnmpAdminString
+    ccmPartiallyRegisteredPhones:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.31
+      name: cisco.ccmPartiallyRegisteredPhones
+      syntax: Counter32
+    ccmH323TableEntries:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.32
+      name: cisco.ccmH323TableEntries
+      syntax: Integer32
+    ccmSIPTableEntries:
+      oid: .1.3.6.1.4.1.9.9.156.1.5.33
+      name: cisco.ccmSIPTableEntries
+      syntax: Integer32
+
+CISCO-CCM-MIB::ccmMediaDeviceEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmMediaDeviceEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.1
+      name: cisco.ccmMediaDeviceIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmMediaDeviceName
+  attributes:
+    ccmMediaDeviceName:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.2
+      name: cisco.ccmMediaDeviceName
+      syntax: DisplayString # SnmpAdminString
+    ccmMediaDeviceType:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.3
+      name: cisco.ccmMediaDeviceType
+      syntax: EnumInteger
+    ccmMediaDeviceDescription:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.4
+      name: cisco.ccmMediaDeviceDescription
+      syntax: DisplayString # SnmpAdminString
+    ccmMediaDeviceStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.5
+      name: cisco.ccmMediaDeviceStatus
+      syntax: EnumInteger
+    ccmMediaDeviceDevicePoolIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.6
+      name: cisco.ccmMediaDeviceDevicePoolIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmMediaDeviceInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.8
+      name: cisco.ccmMediaDeviceInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmMediaDeviceStatusReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.9
+      name: cisco.ccmMediaDeviceStatusReason
+      syntax: EnumInteger
+    ccmMediaDeviceTimeLastStatusUpdt:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.10
+      name: cisco.ccmMediaDeviceTimeLastStatusUpdt
+      syntax: DateAndTime
+    ccmMediaDeviceTimeLastRegistered:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.11
+      name: cisco.ccmMediaDeviceTimeLastRegistered
+      syntax: DateAndTime
+    ccmMediaDeviceProductTypeIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.12
+      name: cisco.ccmMediaDeviceProductTypeIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmMediaDeviceInetAddressIPv4:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.13
+      name: cisco.ccmMediaDeviceInetAddressIPv4
+      syntax: IpAddressNoSuffix # InetAddressIPv4
+    ccmMediaDeviceInetAddressIPv6:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.14
+      name: cisco.ccmMediaDeviceInetAddressIPv6
+      syntax: IpAddressNoSuffix # InetAddressIPv6
+    ccmMediaDeviceUnregReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.15
+      name: cisco.ccmMediaDeviceUnregReason
+      syntax: EnumInteger
+    ccmMediaDeviceRegFailReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.6.1.1.16
+      name: cisco.ccmMediaDeviceRegFailReason
+      syntax: EnumInteger
+
+CISCO-CCM-MIB::ccmGatekeeperEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmGatekeeperEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.7.1.1.1
+      name: cisco.ccmGatekeeperIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmGatekeeperName
+  attributes:
+    ccmGatekeeperName:
+      oid: .1.3.6.1.4.1.9.9.156.1.7.1.1.2
+      name: cisco.ccmGatekeeperName
+      syntax: DisplayString # SnmpAdminString
+    ccmGatekeeperType:
+      oid: .1.3.6.1.4.1.9.9.156.1.7.1.1.3
+      name: cisco.ccmGatekeeperType
+      syntax: EnumInteger
+    ccmGatekeeperDescription:
+      oid: .1.3.6.1.4.1.9.9.156.1.7.1.1.4
+      name: cisco.ccmGatekeeperDescription
+      syntax: DisplayString # SnmpAdminString
+    ccmGatekeeperStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.7.1.1.5
+      name: cisco.ccmGatekeeperStatus
+      syntax: EnumInteger
+    ccmGatekeeperDevicePoolIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.7.1.1.6
+      name: cisco.ccmGatekeeperDevicePoolIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmGatekeeperInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.7.1.1.8
+      name: cisco.ccmGatekeeperInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+
+CISCO-CCM-MIB::ccmCTIDeviceEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmCTIDeviceEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.1
+      name: cisco.ccmCTIDeviceIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmCTIDeviceName
+  attributes:
+    ccmCTIDeviceName:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.2
+      name: cisco.ccmCTIDeviceName
+      syntax: DisplayString # SnmpAdminString
+    ccmCTIDeviceType:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.3
+      name: cisco.ccmCTIDeviceType
+      syntax: EnumInteger
+    ccmCTIDeviceDescription:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.4
+      name: cisco.ccmCTIDeviceDescription
+      syntax: DisplayString # SnmpAdminString
+    ccmCTIDeviceStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.5
+      name: cisco.ccmCTIDeviceStatus
+      syntax: EnumInteger
+    ccmCTIDevicePoolIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.6
+      name: cisco.ccmCTIDevicePoolIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmCTIDeviceInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.8
+      name: cisco.ccmCTIDeviceInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmCTIDeviceAppInfo:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.9
+      name: cisco.ccmCTIDeviceAppInfo
+      syntax: DisplayString # SnmpAdminString
+    ccmCTIDeviceStatusReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.10
+      name: cisco.ccmCTIDeviceStatusReason
+      syntax: EnumInteger
+    ccmCTIDeviceTimeLastStatusUpdt:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.11
+      name: cisco.ccmCTIDeviceTimeLastStatusUpdt
+      syntax: DateAndTime
+    ccmCTIDeviceTimeLastRegistered:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.12
+      name: cisco.ccmCTIDeviceTimeLastRegistered
+      syntax: DateAndTime
+    ccmCTIDeviceProductTypeIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.13
+      name: cisco.ccmCTIDeviceProductTypeIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmCTIDeviceInetAddressIPv4:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.14
+      name: cisco.ccmCTIDeviceInetAddressIPv4
+      syntax: IpAddressNoSuffix # InetAddressIPv4
+    ccmCTIDeviceInetAddressIPv6:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.15
+      name: cisco.ccmCTIDeviceInetAddressIPv6
+      syntax: IpAddressNoSuffix # InetAddressIPv6
+    ccmCTIDeviceUnregReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.16
+      name: cisco.ccmCTIDeviceUnregReason
+      syntax: EnumInteger
+    ccmCTIDeviceRegFailReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.17
+      name: cisco.ccmCTIDeviceRegFailReason
+      syntax: EnumInteger
+
+# CISCO-CCM-MIB::ccmCTIDeviceDirNumEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmCTIDeviceDirNumEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.8.1.1.1
+#       name: cisco.ccmCTIDeviceIndex
+#       syntax: UnsignedAsID # CcmIndex
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.8.2.1.1
+#       name: cisco.ccmCTIDeviceDirNumIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmCTIDeviceDirNum
+#   attributes:
+#     ccmCTIDeviceDirNum:
+#       oid: .1.3.6.1.4.1.9.9.156.1.8.2.1.2
+#       name: cisco.ccmCTIDeviceDirNum
+#       syntax: DisplayString # SnmpAdminString
+
+# CISCO-CCM-MIB::ccmAlarmConfigInfo:
+#   mib: CISCO-CCM-MIB
+#   object: ccmAlarmConfigInfo
+#   discovery_attribute: ccmCallManagerAlarmEnable
+#   attributes:
+#     ccmCallManagerAlarmEnable:
+#       oid: .1.3.6.1.4.1.9.9.156.1.9.1
+#       name: cisco.ccmCallManagerAlarmEnable
+#       syntax: TruthValue
+#     ccmPhoneFailedAlarmInterval:
+#       oid: .1.3.6.1.4.1.9.9.156.1.9.2
+#       name: cisco.ccmPhoneFailedAlarmInterval
+#       syntax: TicksSec # TODO_TicksSec
+#     ccmPhoneFailedStorePeriod:
+#       oid: .1.3.6.1.4.1.9.9.156.1.9.3
+#       name: cisco.ccmPhoneFailedStorePeriod
+#       syntax: TicksSec # TODO_TicksSec
+#     ccmPhoneStatusUpdateAlarmInterv:
+#       oid: .1.3.6.1.4.1.9.9.156.1.9.4
+#       name: cisco.ccmPhoneStatusUpdateAlarmInterv
+#       syntax: TicksSec # TODO_TicksSec
+#     ccmPhoneStatusUpdateStorePeriod:
+#       oid: .1.3.6.1.4.1.9.9.156.1.9.5
+#       name: cisco.ccmPhoneStatusUpdateStorePeriod
+#       syntax: TicksSec # TODO_TicksSec
+#     ccmGatewayAlarmEnable:
+#       oid: .1.3.6.1.4.1.9.9.156.1.9.6
+#       name: cisco.ccmGatewayAlarmEnable
+#       syntax: TruthValue
+#     ccmMaliciousCallAlarmEnable:
+#       oid: .1.3.6.1.4.1.9.9.156.1.9.7
+#       name: cisco.ccmMaliciousCallAlarmEnable
+#       syntax: TruthValue
+
+CISCO-CCM-MIB::ccmH323DeviceEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmH323DeviceEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.1
+      name: cisco.ccmH323DevIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmH323DevName
+  attributes:
+    ccmH323DevName:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.2
+      name: cisco.ccmH323DevName
+      syntax: DisplayString # SnmpAdminString
+    ccmH323DevProductId:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.3
+      name: cisco.ccmH323DevProductId
+      syntax: EnumInteger
+    ccmH323DevDescription:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.4
+      name: cisco.ccmH323DevDescription
+      syntax: DisplayString # SnmpAdminString
+    ccmH323DevInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.6
+      name: cisco.ccmH323DevInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevCnfgGKInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.8
+      name: cisco.ccmH323DevCnfgGKInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevAltGK1InetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.10
+      name: cisco.ccmH323DevAltGK1InetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevAltGK2InetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.12
+      name: cisco.ccmH323DevAltGK2InetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevAltGK3InetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.14
+      name: cisco.ccmH323DevAltGK3InetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevAltGK4InetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.16
+      name: cisco.ccmH323DevAltGK4InetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevAltGK5InetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.18
+      name: cisco.ccmH323DevAltGK5InetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevActGKInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.20
+      name: cisco.ccmH323DevActGKInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.21
+      name: cisco.ccmH323DevStatus
+      syntax: EnumInteger
+    ccmH323DevStatusReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.22
+      name: cisco.ccmH323DevStatusReason
+      syntax: EnumInteger
+    ccmH323DevTimeLastStatusUpdt:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.23
+      name: cisco.ccmH323DevTimeLastStatusUpdt
+      syntax: DateAndTime
+    ccmH323DevTimeLastRegistered:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.24
+      name: cisco.ccmH323DevTimeLastRegistered
+      syntax: DateAndTime
+    ccmH323DevRmtCM1InetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.26
+      name: cisco.ccmH323DevRmtCM1InetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevRmtCM2InetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.28
+      name: cisco.ccmH323DevRmtCM2InetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevRmtCM3InetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.30
+      name: cisco.ccmH323DevRmtCM3InetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmH323DevProductTypeIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.31
+      name: cisco.ccmH323DevProductTypeIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmH323DevUnregReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.32
+      name: cisco.ccmH323DevUnregReason
+      syntax: EnumInteger
+    ccmH323DevRegFailReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.11.1.1.33
+      name: cisco.ccmH323DevRegFailReason
+      syntax: EnumInteger
+
+CISCO-CCM-MIB::ccmVoiceMailDeviceEntry:
+  mib: CISCO-CCM-MIB
+  object: ccmVoiceMailDeviceEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.1
+      name: cisco.ccmVMailDevIndex
+      syntax: UnsignedAsID # CcmIndex
+  discovery_attribute: ccmVMailDevName
+  attributes:
+    ccmVMailDevName:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.2
+      name: cisco.ccmVMailDevName
+      syntax: DisplayString # SnmpAdminString
+    ccmVMailDevProductId:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.3
+      name: cisco.ccmVMailDevProductId
+      syntax: EnumInteger
+    ccmVMailDevDescription:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.4
+      name: cisco.ccmVMailDevDescription
+      syntax: DisplayString # SnmpAdminString
+    ccmVMailDevStatus:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.5
+      name: cisco.ccmVMailDevStatus
+      syntax: EnumInteger
+    ccmVMailDevInetAddress:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.7
+      name: cisco.ccmVMailDevInetAddress
+      syntax: IpAddressNoSuffix # InetAddress
+    ccmVMailDevStatusReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.8
+      name: cisco.ccmVMailDevStatusReason
+      syntax: EnumInteger
+    ccmVMailDevTimeLastStatusUpdt:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.9
+      name: cisco.ccmVMailDevTimeLastStatusUpdt
+      syntax: DateAndTime
+    ccmVMailDevTimeLastRegistered:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.10
+      name: cisco.ccmVMailDevTimeLastRegistered
+      syntax: DateAndTime
+    ccmVMailDevProductTypeIndex:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.11
+      name: cisco.ccmVMailDevProductTypeIndex
+      syntax: UnsignedAsID # CcmIndexOrZero
+    ccmVMailDevUnregReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.12
+      name: cisco.ccmVMailDevUnregReason
+      syntax: EnumInteger
+    ccmVMailDevRegFailReason:
+      oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.13
+      name: cisco.ccmVMailDevRegFailReason
+      syntax: EnumInteger
+
+# CISCO-CCM-MIB::ccmVoiceMailDeviceDirNumEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmVoiceMailDeviceDirNumEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.12.1.1.1
+#       name: cisco.ccmVMailDevIndex
+#       syntax: UnsignedAsID # CcmIndex
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.12.2.1.1
+#       name: cisco.ccmVMailDevDirNumIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmVMailDevDirNum
+#   attributes:
+#     ccmVMailDevDirNum:
+#       oid: .1.3.6.1.4.1.9.9.156.1.12.2.1.2
+#       name: cisco.ccmVMailDevDirNum
+#       syntax: DisplayString # SnmpAdminString
+
+# CISCO-CCM-MIB::ccmQualityReportAlarmConfigInfo:
+#   mib: CISCO-CCM-MIB
+#   object: ccmQualityReportAlarmConfigInfo
+#   discovery_attribute: ccmQualityReportAlarmEnable
+#   attributes:
+#     ccmQualityReportAlarmEnable:
+#       oid: .1.3.6.1.4.1.9.9.156.1.13.1
+#       name: cisco.ccmQualityReportAlarmEnable
+#       syntax: TruthValue
+
+# CISCO-CCM-MIB::ccmSIPDeviceEntry:
+#   mib: CISCO-CCM-MIB
+#   object: ccmSIPDeviceEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.1
+#       name: cisco.ccmSIPDevIndex
+#       syntax: UnsignedAsID # CcmIndex
+#   discovery_attribute: ccmSIPDevName
+#   attributes:
+#     ccmSIPDevName:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.2
+#       name: cisco.ccmSIPDevName
+#       syntax: DisplayString # SnmpAdminString
+#     ccmSIPDevProductTypeIndex:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.3
+#       name: cisco.ccmSIPDevProductTypeIndex
+#       syntax: UnsignedAsID # CcmIndexOrZero
+#     ccmSIPDevDescription:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.4
+#       name: cisco.ccmSIPDevDescription
+#       syntax: DisplayString # SnmpAdminString
+#     ccmSIPDevInetAddress:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.6
+#       name: cisco.ccmSIPDevInetAddress
+#       syntax: IpAddressNoSuffix # InetAddress
+#     ccmSIPInTransportProtocolType:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.7
+#       name: cisco.ccmSIPInTransportProtocolType
+#       syntax: EnumInteger
+#     ccmSIPInPortNumber:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.8
+#       name: cisco.ccmSIPInPortNumber
+#       syntax: Integer32 # InetPortNumber
+#     ccmSIPOutTransportProtocolType:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.9
+#       name: cisco.ccmSIPOutTransportProtocolType
+#       syntax: EnumInteger
+#     ccmSIPOutPortNumber:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.10
+#       name: cisco.ccmSIPOutPortNumber
+#       syntax: Integer32 # InetPortNumber
+#     ccmSIPDevInetAddressIPv4:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.11
+#       name: cisco.ccmSIPDevInetAddressIPv4
+#       syntax: IpAddressNoSuffix # InetAddressIPv4
+#     ccmSIPDevInetAddressIPv6:
+#       oid: .1.3.6.1.4.1.9.9.156.1.14.1.1.12
+#       name: cisco.ccmSIPDevInetAddressIPv6
+#       syntax: IpAddressNoSuffix # InetAddressIPv6

--- a/objects/cisco/CISCO-CDP-MIB.yml
+++ b/objects/cisco/CISCO-CDP-MIB.yml
@@ -15,7 +15,7 @@ CISCO-CDP-MIB::cdpInterfaceEntry:
     cdpInterfaceMessageInterval:
       oid: .1.3.6.1.4.1.9.9.23.1.1.1.1.3
       name: cisco.cdpInterfaceMessageInterval
-      syntax: Integer
+      syntax: TicksSec
     cdpInterfaceGroup:
       oid: .1.3.6.1.4.1.9.9.23.1.1.1.1.4
       name: cisco.cdpInterfaceGroup
@@ -37,11 +37,11 @@ CISCO-CDP-MIB::cdpInterfaceExtEntry:
   attributes:
     cdpInterfaceExtendedTrust:
       oid: .1.3.6.1.4.1.9.9.23.1.1.2.1.1
-      name: cdpInterfaceExtendedTrust
+      name: cisco.cdpInterfaceExtendedTrust
       syntax: EnumInteger
     cdpInterfaceCosForUntrustedPort:
       oid: .1.3.6.1.4.1.9.9.23.1.1.2.1.2
-      name: cdpInterfaceCosForUntrustedPort
+      name: cisco.cdpInterfaceCosForUntrustedPort
       syntax: Unsigned32
 
 CISCO-CDP-MIB::cdpCacheEntry:
@@ -54,7 +54,7 @@ CISCO-CDP-MIB::cdpCacheEntry:
       syntax: InterfaceIndex
     - type: Integer32
       oid: .1.3.6.1.4.1.9.9.23.1.2.1.1.2
-      name:  cisco.cdpCacheDeviceIndex
+      name: cisco.cdpCacheDeviceIndex
       syntax: UnsignedAsID
   discovery_attribute: cdpCacheAddress
   attributes:
@@ -65,7 +65,7 @@ CISCO-CDP-MIB::cdpCacheEntry:
     cdpCacheAddress:
       oid: .1.3.6.1.4.1.9.9.23.1.2.1.1.4
       name: cisco.cdpCacheAddress
-      syntax: OctetString
+      syntax: OctetString # CiscoNetworkAddress
     cdpCacheVersion:
       oid: .1.3.6.1.4.1.9.9.23.1.2.1.1.5
       name: cisco.cdpCacheVersion

--- a/objects/cisco/CISCO-SESS-BORDER-CTRLR-EVENT-MIB.yml
+++ b/objects/cisco/CISCO-SESS-BORDER-CTRLR-EVENT-MIB.yml
@@ -1,0 +1,73 @@
+CISCO-SESS-BORDER-CTRLR-EVENT-MIB::ciscoSessBorderCtrlrMIBObjects:
+  mib: CISCO-SESS-BORDER-CTRLR-EVENT-MIB
+  object: ciscoSessBorderCtrlrMIBObjects
+  discovery_attribute: csbSourceAlertNotifEnabled
+  attributes:
+    csbSourceAlertNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.52
+      name: csbSourceAlertNotifEnabled
+      syntax: TruthValue
+    csbBlackListNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.53
+      name: csbBlackListNotifEnabled
+      syntax: TruthValue
+    csbAdjacencyStatusNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.54
+      name: csbAdjacencyStatusNotifEnabled
+      syntax: TruthValue
+    csbServiceStateNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.55
+      name: csbServiceStateNotifEnabled
+      syntax: TruthValue
+    csbCongestionAlarmNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.56
+      name: csbCongestionAlarmNotifEnabled
+      syntax: TruthValue
+    csbSLAViolationNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.57
+      name: csbSLAViolationNotifEnabled
+      syntax: TruthValue
+    csbRadiusConnectionStatusNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.58
+      name: csbRadiusConnectionStatusNotifEnabled
+      syntax: TruthValue
+    csbDiameterConnectionStatusNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.59
+      name: csbDiameterConnectionStatusNotifEnabled
+      syntax: TruthValue
+    csbH248ControllerStatusNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.60
+      name: csbH248ControllerStatusNotifEnabled
+      syntax: TruthValue
+    csbSLAViolationNotifEnabledRev1:
+      oid: .1.3.6.1.4.1.9.9.658.1.63
+      name: csbSLAViolationNotifEnabledRev1
+      syntax: TruthValue
+    csbQOSAlertUnansweredCallRatioNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.73
+      name: csbQOSAlertUnansweredCallRatioNotifEnabled
+      syntax: TruthValue
+    csbQOSAlertPercentPktDropNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.74
+      name: csbQOSAlertPercentPktDropNotifEnabled
+      syntax: TruthValue
+    csbQOSAlertRoundTripDelayNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.75
+      name: csbQOSAlertRoundTripDelayNotifEnabled
+      syntax: TruthValue
+    csbQOSAlertMoscqeNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.76
+      name: csbQOSAlertMoscqeNotifEnabled
+      syntax: TruthValue
+    csbQOSAlertLocalJitterNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.77
+      name: csbQOSAlertLocalJitterNotifEnabled
+      syntax: TruthValue
+    csbQOSAlertRemoteJitterNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.78
+      name: csbQOSAlertRemoteJitterNotifEnabled
+      syntax: TruthValue
+    csbQOSAlertPercentPktLostNotifEnabled:
+      oid: .1.3.6.1.4.1.9.9.658.1.79
+      name: csbQOSAlertPercentPktLostNotifEnabled
+      syntax: TruthValue

--- a/objects/cisco/CISCO-SESS-BORDER-CTRLR-EVENT-MIB.yml
+++ b/objects/cisco/CISCO-SESS-BORDER-CTRLR-EVENT-MIB.yml
@@ -5,69 +5,69 @@ CISCO-SESS-BORDER-CTRLR-EVENT-MIB::ciscoSessBorderCtrlrMIBObjects:
   attributes:
     csbSourceAlertNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.52
-      name: csbSourceAlertNotifEnabled
+      name: cisco.csbSourceAlertNotifEnabled
       syntax: TruthValue
     csbBlackListNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.53
-      name: csbBlackListNotifEnabled
+      name: cisco.csbBlackListNotifEnabled
       syntax: TruthValue
     csbAdjacencyStatusNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.54
-      name: csbAdjacencyStatusNotifEnabled
+      name: cisco.csbAdjacencyStatusNotifEnabled
       syntax: TruthValue
     csbServiceStateNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.55
-      name: csbServiceStateNotifEnabled
+      name: cisco.csbServiceStateNotifEnabled
       syntax: TruthValue
     csbCongestionAlarmNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.56
-      name: csbCongestionAlarmNotifEnabled
+      name: cisco.csbCongestionAlarmNotifEnabled
       syntax: TruthValue
     csbSLAViolationNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.57
-      name: csbSLAViolationNotifEnabled
+      name: cisco.csbSLAViolationNotifEnabled
       syntax: TruthValue
     csbRadiusConnectionStatusNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.58
-      name: csbRadiusConnectionStatusNotifEnabled
+      name: cisco.csbRadiusConnectionStatusNotifEnabled
       syntax: TruthValue
     csbDiameterConnectionStatusNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.59
-      name: csbDiameterConnectionStatusNotifEnabled
+      name: cisco.csbDiameterConnectionStatusNotifEnabled
       syntax: TruthValue
     csbH248ControllerStatusNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.60
-      name: csbH248ControllerStatusNotifEnabled
+      name: cisco.csbH248ControllerStatusNotifEnabled
       syntax: TruthValue
     csbSLAViolationNotifEnabledRev1:
       oid: .1.3.6.1.4.1.9.9.658.1.63
-      name: csbSLAViolationNotifEnabledRev1
+      name: cisco.csbSLAViolationNotifEnabledRev1
       syntax: TruthValue
     csbQOSAlertUnansweredCallRatioNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.73
-      name: csbQOSAlertUnansweredCallRatioNotifEnabled
+      name: cisco.csbQOSAlertUnansweredCallRatioNotifEnabled
       syntax: TruthValue
     csbQOSAlertPercentPktDropNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.74
-      name: csbQOSAlertPercentPktDropNotifEnabled
+      name: cisco.csbQOSAlertPercentPktDropNotifEnabled
       syntax: TruthValue
     csbQOSAlertRoundTripDelayNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.75
-      name: csbQOSAlertRoundTripDelayNotifEnabled
+      name: cisco.csbQOSAlertRoundTripDelayNotifEnabled
       syntax: TruthValue
     csbQOSAlertMoscqeNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.76
-      name: csbQOSAlertMoscqeNotifEnabled
+      name: cisco.csbQOSAlertMoscqeNotifEnabled
       syntax: TruthValue
     csbQOSAlertLocalJitterNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.77
-      name: csbQOSAlertLocalJitterNotifEnabled
+      name: cisco.csbQOSAlertLocalJitterNotifEnabled
       syntax: TruthValue
     csbQOSAlertRemoteJitterNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.78
-      name: csbQOSAlertRemoteJitterNotifEnabled
+      name: cisco.csbQOSAlertRemoteJitterNotifEnabled
       syntax: TruthValue
     csbQOSAlertPercentPktLostNotifEnabled:
       oid: .1.3.6.1.4.1.9.9.658.1.79
-      name: csbQOSAlertPercentPktLostNotifEnabled
+      name: cisco.csbQOSAlertPercentPktLostNotifEnabled
       syntax: TruthValue

--- a/objects/cisco/CISCO-SESS-BORDER-CTRLR-STATS-MIB.yml
+++ b/objects/cisco/CISCO-SESS-BORDER-CTRLR-STATS-MIB.yml
@@ -1,0 +1,417 @@
+CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbRadiusStatsEntry:
+  mib: CISCO-SESS-BORDER-CTRLR-STATS-MIB
+  object: csbRadiusStatsEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.1.1.1
+      name: cisco.csbCallStatsInstanceIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.2.1.1
+      name: cisco.csbCallStatsServiceIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.1
+      name: cisco.csbRadiusStatsEntIndex
+      syntax: Unsigned32
+  discovery_attribute: csbRadiusStatsClientName
+  attributes:
+    csbRadiusStatsClientName:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.2
+      name: cisco.csbRadiusStatsClientName
+      syntax: DisplayString # SnmpAdminString
+    csbRadiusStatsClientType:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.3
+      name: cisco.csbRadiusStatsClientType
+      syntax: EnumInteger
+    csbRadiusStatsSrvrName:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.4
+      name: cisco.csbRadiusStatsSrvrName
+      syntax: DisplayString # SnmpAdminString
+    csbRadiusStatsAcsReqs:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.5
+      name: cisco.csbRadiusStatsAcsReqs
+      syntax: Counter64
+    csbRadiusStatsAcsRtrns:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.6
+      name: cisco.csbRadiusStatsAcsRtrns
+      syntax: Counter64
+    csbRadiusStatsAcsAccpts:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.7
+      name: cisco.csbRadiusStatsAcsAccpts
+      syntax: Counter64
+    csbRadiusStatsAcsRejects:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.8
+      name: cisco.csbRadiusStatsAcsRejects
+      syntax: Counter64
+    csbRadiusStatsAcsChalls:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.9
+      name: cisco.csbRadiusStatsAcsChalls
+      syntax: Counter64
+    csbRadiusStatsActReqs:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.10
+      name: cisco.csbRadiusStatsActReqs
+      syntax: Counter64
+    csbRadiusStatsActRetrans:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.11
+      name: cisco.csbRadiusStatsActRetrans
+      syntax: Counter64
+    csbRadiusStatsActRsps:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.12
+      name: cisco.csbRadiusStatsActRsps
+      syntax: Counter64
+    csbRadiusStatsMalformedRsps:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.13
+      name: cisco.csbRadiusStatsMalformedRsps
+      syntax: Counter64
+    csbRadiusStatsBadAuths:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.14
+      name: cisco.csbRadiusStatsBadAuths
+      syntax: Counter64
+    csbRadiusStatsPending:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.15
+      name: cisco.csbRadiusStatsPending
+      syntax: Gauge32
+    csbRadiusStatsTimeouts:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.16
+      name: cisco.csbRadiusStatsTimeouts
+      syntax: Counter64
+    csbRadiusStatsUnknownType:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.17
+      name: cisco.csbRadiusStatsUnknownType
+      syntax: Counter64
+    csbRadiusStatsDropped:
+      oid: .1.3.6.1.4.1.9.9.757.1.1.1.18
+      name: cisco.csbRadiusStatsDropped
+      syntax: Counter64
+
+CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbRfBillRealmStatsEntry:
+  mib: CISCO-SESS-BORDER-CTRLR-STATS-MIB
+  object: csbRfBillRealmStatsEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.1.1.1
+      name: cisco.csbCallStatsInstanceIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.2.1.1
+      name: cisco.csbCallStatsServiceIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.1
+      name: cisco.csbRfBillRealmStatsIndex
+      syntax: Unsigned32
+    - type: OctetString
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.2
+      name: cisco.csbRfBillRealmStatsRealmName
+      syntax: DisplayString # SnmpAdminString
+  discovery_attribute: csbRfBillRealmStatsTotalStartAcrs
+  attributes:
+    csbRfBillRealmStatsTotalStartAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.3
+      name: cisco.csbRfBillRealmStatsTotalStartAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsTotalInterimAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.4
+      name: cisco.csbRfBillRealmStatsTotalInterimAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsTotalStopAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.5
+      name: cisco.csbRfBillRealmStatsTotalStopAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsTotalEventAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.6
+      name: cisco.csbRfBillRealmStatsTotalEventAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsSuccStartAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.7
+      name: cisco.csbRfBillRealmStatsSuccStartAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsSuccInterimAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.8
+      name: cisco.csbRfBillRealmStatsSuccInterimAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsSuccStopAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.9
+      name: cisco.csbRfBillRealmStatsSuccStopAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsSuccEventAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.10
+      name: cisco.csbRfBillRealmStatsSuccEventAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsFailStartAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.11
+      name: cisco.csbRfBillRealmStatsFailStartAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsFailInterimAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.12
+      name: cisco.csbRfBillRealmStatsFailInterimAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsFailStopAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.13
+      name: cisco.csbRfBillRealmStatsFailStopAcrs
+      syntax: Unsigned32
+    csbRfBillRealmStatsFailEventAcrs:
+      oid: .1.3.6.1.4.1.9.9.757.1.2.1.14
+      name: cisco.csbRfBillRealmStatsFailEventAcrs
+      syntax: Unsigned32
+
+CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbSIPMthdCurrentStatsEntry:
+  mib: CISCO-SESS-BORDER-CTRLR-STATS-MIB
+  object: csbSIPMthdCurrentStatsEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.1.1.1
+      name: cisco.csbCallStatsInstanceIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.2.1.1
+      name: cisco.csbCallStatsServiceIndex
+      syntax: Unsigned32
+    - type: OctetString
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.1
+      name: cisco.csbSIPMthdCurrentStatsAdjName
+      syntax: DisplayString # SnmpAdminString
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.2
+      name: cisco.csbSIPMthdCurrentStatsMethod
+      syntax: EnumInteger
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.3
+      name: cisco.csbSIPMthdCurrentStatsInterval
+      syntax: EnumInteger
+  discovery_attribute: csbSIPMthdCurrentStatsMethodName
+  attributes:
+    csbSIPMthdCurrentStatsMethodName:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.4
+      name: cisco.csbSIPMthdCurrentStatsMethodName
+      syntax: DisplayString # SnmpAdminString
+    csbSIPMthdCurrentStatsReqIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.5
+      name: cisco.csbSIPMthdCurrentStatsReqIn
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsReqOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.6
+      name: cisco.csbSIPMthdCurrentStatsReqOut
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp1xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.7
+      name: cisco.csbSIPMthdCurrentStatsResp1xxIn
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp1xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.8
+      name: cisco.csbSIPMthdCurrentStatsResp1xxOut
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp2xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.9
+      name: cisco.csbSIPMthdCurrentStatsResp2xxIn
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp2xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.10
+      name: cisco.csbSIPMthdCurrentStatsResp2xxOut
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp3xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.11
+      name: cisco.csbSIPMthdCurrentStatsResp3xxIn
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp3xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.12
+      name: cisco.csbSIPMthdCurrentStatsResp3xxOut
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp4xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.13
+      name: cisco.csbSIPMthdCurrentStatsResp4xxIn
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp4xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.14
+      name: cisco.csbSIPMthdCurrentStatsResp4xxOut
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp5xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.15
+      name: cisco.csbSIPMthdCurrentStatsResp5xxIn
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp5xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.16
+      name: cisco.csbSIPMthdCurrentStatsResp5xxOut
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp6xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.17
+      name: cisco.csbSIPMthdCurrentStatsResp6xxIn
+      syntax: Gauge32
+    csbSIPMthdCurrentStatsResp6xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.3.1.18
+      name: cisco.csbSIPMthdCurrentStatsResp6xxOut
+      syntax: Gauge32
+
+CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbSIPMthdHistoryStatsEntry:
+  mib: CISCO-SESS-BORDER-CTRLR-STATS-MIB
+  object: csbSIPMthdHistoryStatsEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.1.1.1
+      name: cisco.csbCallStatsInstanceIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.2.1.1
+      name: cisco.csbCallStatsServiceIndex
+      syntax: Unsigned32
+    - type: OctetString
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.1
+      name: cisco.csbSIPMthdHistoryStatsAdjName
+      syntax: DisplayString # SnmpAdminString
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.2
+      name: cisco.csbSIPMthdHistoryStatsMethod
+      syntax: EnumInteger
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.3
+      name: cisco.csbSIPMthdHistoryStatsInterval
+      syntax: EnumInteger
+  discovery_attribute: csbSIPMthdHistoryStatsMethodName
+  attributes:
+    csbSIPMthdHistoryStatsMethodName:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.4
+      name: cisco.csbSIPMthdHistoryStatsMethodName
+      syntax: DisplayString # SnmpAdminString
+    csbSIPMthdHistoryStatsReqIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.5
+      name: cisco.csbSIPMthdHistoryStatsReqIn
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsReqOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.6
+      name: cisco.csbSIPMthdHistoryStatsReqOut
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp1xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.7
+      name: cisco.csbSIPMthdHistoryStatsResp1xxIn
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp1xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.8
+      name: cisco.csbSIPMthdHistoryStatsResp1xxOut
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp2xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.9
+      name: cisco.csbSIPMthdHistoryStatsResp2xxIn
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp2xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.10
+      name: cisco.csbSIPMthdHistoryStatsResp2xxOut
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp3xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.11
+      name: cisco.csbSIPMthdHistoryStatsResp3xxIn
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp3xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.12
+      name: cisco.csbSIPMthdHistoryStatsResp3xxOut
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp4xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.13
+      name: cisco.csbSIPMthdHistoryStatsResp4xxIn
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp4xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.14
+      name: cisco.csbSIPMthdHistoryStatsResp4xxOut
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp5xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.15
+      name: cisco.csbSIPMthdHistoryStatsResp5xxIn
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp5xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.16
+      name: cisco.csbSIPMthdHistoryStatsResp5xxOut
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp6xxIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.17
+      name: cisco.csbSIPMthdHistoryStatsResp6xxIn
+      syntax: Gauge32
+    csbSIPMthdHistoryStatsResp6xxOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.4.1.18
+      name: cisco.csbSIPMthdHistoryStatsResp6xxOut
+      syntax: Gauge32
+
+CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbSIPMthdRCCurrentStatsEntry:
+  mib: CISCO-SESS-BORDER-CTRLR-STATS-MIB
+  object: csbSIPMthdRCCurrentStatsEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.1.1.1
+      name: cisco.csbCallStatsInstanceIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.2.1.1
+      name: cisco.csbCallStatsServiceIndex
+      syntax: Unsigned32
+    - type: OctetString
+      oid: .1.3.6.1.4.1.9.9.757.1.5.1.1
+      name: cisco.csbSIPMthdRCCurrentStatsAdjName
+      syntax: DisplayString # SnmpAdminString
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.757.1.5.1.2
+      name: cisco.csbSIPMthdRCCurrentStatsMethod
+      syntax: EnumInteger
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.757.1.5.1.3
+      name: cisco.csbSIPMthdRCCurrentStatsRespCode
+      syntax: Unsigned32
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.757.1.5.1.4
+      name: cisco.csbSIPMthdRCCurrentStatsInterval
+      syntax: EnumInteger
+  discovery_attribute: csbSIPMthdRCCurrentStatsMethodName
+  attributes:
+    csbSIPMthdRCCurrentStatsMethodName:
+      oid: .1.3.6.1.4.1.9.9.757.1.5.1.5
+      name: cisco.csbSIPMthdRCCurrentStatsMethodName
+      syntax: DisplayString # SnmpAdminString
+    csbSIPMthdRCCurrentStatsRespIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.5.1.6
+      name: cisco.csbSIPMthdRCCurrentStatsRespIn
+      syntax: Gauge32
+    csbSIPMthdRCCurrentStatsRespOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.5.1.7
+      name: cisco.csbSIPMthdRCCurrentStatsRespOut
+      syntax: Gauge32
+
+CISCO-SESS-BORDER-CTRLR-STATS-MIB::csbSIPMthdRCHistoryStatsEntry:
+  mib: CISCO-SESS-BORDER-CTRLR-STATS-MIB
+  object: csbSIPMthdRCHistoryStatsEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.1.1.1
+      name: cisco.csbCallStatsInstanceIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.657.1.2.1.1
+      name: cisco.csbCallStatsServiceIndex
+      syntax: Unsigned32
+    - type: OctetString
+      oid: .1.3.6.1.4.1.9.9.757.1.6.1.1
+      name: cisco.csbSIPMthdRCHistoryStatsAdjName
+      syntax: DisplayString # SnmpAdminString
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.757.1.6.1.2
+      name: cisco.csbSIPMthdRCHistoryStatsMethod
+      syntax: EnumInteger
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.757.1.6.1.4
+      name: cisco.csbSIPMthdRCHistoryStatsRespCode
+      syntax: Unsigned32
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.757.1.6.1.5
+      name: cisco.csbSIPMthdRCHistoryStatsInterval
+      syntax: EnumInteger
+  discovery_attribute: csbSIPMthdRCHistoryStatsRespIn
+  attributes:
+    csbSIPMthdRCHistoryStatsMethodName:
+      oid: .1.3.6.1.4.1.9.9.757.1.6.1.3
+      name: cisco.csbSIPMthdRCHistoryStatsMethodName
+      syntax: DisplayString # SnmpAdminString
+    csbSIPMthdRCHistoryStatsRespIn:
+      oid: .1.3.6.1.4.1.9.9.757.1.6.1.6
+      name: cisco.csbSIPMthdRCHistoryStatsRespIn
+      syntax: Gauge32
+    csbSIPMthdRCHistoryStatsRespOut:
+      oid: .1.3.6.1.4.1.9.9.757.1.6.1.7
+      name: cisco.csbSIPMthdRCHistoryStatsRespOut
+      syntax: Gauge32

--- a/objects/cisco/CISCO-SIP-UA-MIB.yml
+++ b/objects/cisco/CISCO-SIP-UA-MIB.yml
@@ -1,0 +1,1001 @@
+# CISCO-SIP-UA-MIB::cSipCfgBase:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgBase
+#   discovery_attribute: cSipCfgVersion
+#   attributes:
+#     cSipCfgVersion:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.1
+#       name: cisco.cSipCfgVersion
+#       syntax: DisplayString # SnmpAdminString
+#     cSipCfgTransport:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.2
+#       name: cisco.cSipCfgTransport
+#       syntax: EnumInteger
+#     cSipCfgUserLocationServerAddr:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.3
+#       name: cisco.cSipCfgUserLocationServerAddr
+#       syntax: DisplayString # SnmpAdminString
+#     cSipCfgMaxForwards:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.4
+#       name: cisco.cSipCfgMaxForwards
+#       syntax: Integer32
+#     cSipCfgBindSrcAddrInterface:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.5
+#       name: cisco.cSipCfgBindSrcAddrInterface
+#       syntax: InterfaceIndexOrZero
+#     cSipCfgBindSrcAddrScope:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.6
+#       name: cisco.cSipCfgBindSrcAddrScope
+#       syntax: EnumInteger
+#     cSipCfgDnsSrvQueryStringFormat:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.7
+#       name: cisco.cSipCfgDnsSrvQueryStringFormat
+#       syntax: EnumInteger
+#     cSipCfgRedirectionDisabled:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.8
+#       name: cisco.cSipCfgRedirectionDisabled
+#       syntax: TruthValue
+#     cSipCfgSymNatEnabled:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.10
+#       name: cisco.cSipCfgSymNatEnabled
+#       syntax: TruthValue
+#     cSipCfgSymNatDirectionRole:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.11
+#       name: cisco.cSipCfgSymNatDirectionRole
+#       syntax: EnumInteger
+#     cSipCfgSuspendResumeEnabled:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.13
+#       name: cisco.cSipCfgSuspendResumeEnabled
+#       syntax: TruthValue
+#     cSipCfgOfferCallHold:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.14
+#       name: cisco.cSipCfgOfferCallHold
+#       syntax: EnumInteger
+#     cSipCfgReasonHeaderOveride:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.15
+#       name: cisco.cSipCfgReasonHeaderOveride
+#       syntax: TruthValue
+#     cSipCfgMaximumForwards:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.16
+#       name: cisco.cSipCfgMaximumForwards
+#       syntax: Integer32
+
+# CISCO-SIP-UA-MIB::cSipCfgEarlyMediaEntry:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgEarlyMediaEntry
+#   index:
+#     - type: Integer
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.9.1.1
+#       name: cisco.cSipCfgEarlyMediaStatusCodeIndex
+#       syntax: Integer32 # CSipStatusCode
+#   discovery_attribute: cSipCfgEarlyMediaCutThruDisabled
+#   attributes:
+#     cSipCfgEarlyMediaCutThruDisabled:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.9.1.2
+#       name: cisco.cSipCfgEarlyMediaCutThruDisabled
+#       syntax: TruthValue
+
+# CISCO-SIP-UA-MIB::cSipCfgBindSourceAddrEntry:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgBindSourceAddrEntry
+#   index:
+#     - type: Integer32
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.12.1.1
+#       name: cisco.cSipCfgBindSourceAddrScope
+#       syntax: EnumInteger
+#   discovery_attribute: cSipCfgBindSourceAddrInterface
+#   attributes:
+#     cSipCfgBindSourceAddrInterface:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.1.12.1.2
+#       name: cisco.cSipCfgBindSourceAddrInterface
+#       syntax: InterfaceIndexOrZero
+
+# CISCO-SIP-UA-MIB::cSipCfgTimer:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgTimer
+#   discovery_attribute: cSipCfgTimerTrying
+#   attributes:
+#     cSipCfgTimerTrying:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.1
+#       name: cisco.cSipCfgTimerTrying
+#       syntax: TicksMilliSec
+#     cSipCfgTimerExpires:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.2
+#       name: cisco.cSipCfgTimerExpires
+#       syntax: TicksMilliSec
+#     cSipCfgTimerConnect:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.3
+#       name: cisco.cSipCfgTimerConnect
+#       syntax: TicksMilliSec
+#     cSipCfgTimerDisconnect:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.4
+#       name: cisco.cSipCfgTimerDisconnect
+#       syntax: TicksMilliSec
+#     cSipCfgTimerPrack:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.5
+#       name: cisco.cSipCfgTimerPrack
+#       syntax: TicksMilliSec
+#     cSipCfgTimerComet:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.6
+#       name: cisco.cSipCfgTimerComet
+#       syntax: TicksMilliSec
+#     cSipCfgTimerReliableRsp:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.7
+#       name: cisco.cSipCfgTimerReliableRsp
+#       syntax: TicksMilliSec
+#     cSipCfgTimerNotify:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.8
+#       name: cisco.cSipCfgTimerNotify
+#       syntax: TicksMilliSec
+#     cSipCfgTimerRefer:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.9
+#       name: cisco.cSipCfgTimerRefer
+#       syntax: TicksMilliSec
+#     cSipCfgTimerSessionTimer:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.10
+#       name: cisco.cSipCfgTimerSessionTimer
+#       syntax: TicksSec
+#     cSipCfgTimerHold:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.11
+#       name: cisco.cSipCfgTimerHold
+#       syntax: Integer32
+#     cSipCfgTimerInfo:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.12
+#       name: cisco.cSipCfgTimerInfo
+#       syntax: TicksMilliSec
+#     cSipCfgTimerConnectionAging:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.13
+#       name: cisco.cSipCfgTimerConnectionAging
+#       syntax: Integer32
+#     cSipCfgTimerBufferInvite:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.2.14
+#       name: cisco.cSipCfgTimerBufferInvite
+#       syntax: TicksMilliSec
+
+# CISCO-SIP-UA-MIB::cSipCfgRetry:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgRetry
+#   discovery_attribute: cSipCfgRetryInvite
+#   attributes:
+#     cSipCfgRetryInvite:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.1
+#       name: cisco.cSipCfgRetryInvite
+#       syntax: Integer32
+#     cSipCfgRetryBye:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.2
+#       name: cisco.cSipCfgRetryBye
+#       syntax: Integer32
+#     cSipCfgRetryCancel:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.3
+#       name: cisco.cSipCfgRetryCancel
+#       syntax: Integer32
+#     cSipCfgRetryRegister:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.4
+#       name: cisco.cSipCfgRetryRegister
+#       syntax: Integer32
+#     cSipCfgRetryResponse:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.5
+#       name: cisco.cSipCfgRetryResponse
+#       syntax: Integer32
+#     cSipCfgRetryPrack:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.6
+#       name: cisco.cSipCfgRetryPrack
+#       syntax: Integer32
+#     cSipCfgRetryComet:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.7
+#       name: cisco.cSipCfgRetryComet
+#       syntax: Integer32
+#     cSipCfgRetryReliableRsp:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.8
+#       name: cisco.cSipCfgRetryReliableRsp
+#       syntax: Integer32
+#     cSipCfgRetryNotify:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.9
+#       name: cisco.cSipCfgRetryNotify
+#       syntax: Integer32
+#     cSipCfgRetryRefer:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.10
+#       name: cisco.cSipCfgRetryRefer
+#       syntax: Integer32
+#     cSipCfgRetryInfo:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.11
+#       name: cisco.cSipCfgRetryInfo
+#       syntax: Integer32
+#     cSipCfgRetrySubscribe:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.3.12
+#       name: cisco.cSipCfgRetrySubscribe
+#       syntax: Integer32
+
+# CISCO-SIP-UA-MIB::cSipCfgPeer:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgPeer
+#   discovery_attribute: cSipCfgOutSessionTransport
+#   attributes:
+#     cSipCfgOutSessionTransport:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.2
+#       name: cisco.cSipCfgOutSessionTransport
+#       syntax: EnumInteger
+#     cSipCfgReliable1xxRspStr:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.3
+#       name: cisco.cSipCfgReliable1xxRspStr
+#       syntax: DisplayString # SnmpAdminString
+#     cSipCfgReliable1xxRspHdr:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.4
+#       name: cisco.cSipCfgReliable1xxRspHdr
+#       syntax: EnumInteger
+#     cSipCfgUrlType:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.5
+#       name: cisco.cSipCfgUrlType
+#       syntax: EnumInteger
+
+# CISCO-SIP-UA-MIB::cSipCfgPeerEntry:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgPeerEntry
+#   index:
+#     - type: Integer32
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.1.1.1
+#       name: cisco.cSipCfgPeerIndex
+#       syntax: Integer32
+#   discovery_attribute: cSipCfgPeerOutSessionTransport
+#   attributes:
+#     cSipCfgPeerOutSessionTransport:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.1.1.2
+#       name: cisco.cSipCfgPeerOutSessionTransport
+#       syntax: EnumInteger
+#     cSipCfgPeerReliable1xxRspStr:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.1.1.3
+#       name: cisco.cSipCfgPeerReliable1xxRspStr
+#       syntax: DisplayString # SnmpAdminString
+#     cSipCfgPeerReliable1xxRspHdr:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.1.1.4
+#       name: cisco.cSipCfgPeerReliable1xxRspHdr
+#       syntax: EnumInteger
+#     cSipCfgPeerUrlType:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.1.1.5
+#       name: cisco.cSipCfgPeerUrlType
+#       syntax: EnumInteger
+#     cSipCfgPeerSwitchTransEnabled:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.4.1.1.6
+#       name: cisco.cSipCfgPeerSwitchTransEnabled
+#       syntax: TruthValue
+
+# CISCO-SIP-UA-MIB::cSipCfgStatusCauseEntry:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgStatusCauseEntry
+#   index:
+#     - type: Integer
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.5.1.1.1
+#       name: cisco.cSipCfgStatusCodeIndex
+#       syntax: Integer32 # CSipStatusCode
+#   discovery_attribute: cSipCfgPstnCause
+#   attributes:
+#     cSipCfgPstnCause:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.5.1.1.2
+#       name: cisco.cSipCfgPstnCause
+#       syntax: Integer32
+#     cSipCfgStatusCauseStoreStatus:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.5.1.1.3
+#       name: cisco.cSipCfgStatusCauseStoreStatus
+#       syntax: EnumInteger
+
+# CISCO-SIP-UA-MIB::cSipCfgCauseStatusEntry:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgCauseStatusEntry
+#   index:
+#     - type: Integer32
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.5.2.1.1
+#       name: cisco.cSipCfgPstnCauseIndex
+#       syntax: Integer32
+#   discovery_attribute: cSipCfgStatusCode
+#   attributes:
+#     cSipCfgStatusCode:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.5.2.1.2
+#       name: cisco.cSipCfgStatusCode
+#       syntax: Integer32 # CSipStatusCode
+#     cSipCfgCauseStatusStoreStatus:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.5.2.1.3
+#       name: cisco.cSipCfgCauseStatusStoreStatus
+#       syntax: EnumInteger
+
+# CISCO-SIP-UA-MIB::cSipCfgAaa:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgAaa
+#   discovery_attribute: cSipCfgAaaUsername
+#   attributes:
+#     cSipCfgAaaUsername:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.6.1
+#       name: cisco.cSipCfgAaaUsername
+#       syntax: EnumInteger
+
+# CISCO-SIP-UA-MIB::cSipCfgVoiceServiceVoip:
+#   mib: CISCO-SIP-UA-MIB
+#   object: cSipCfgVoiceServiceVoip
+#   discovery_attribute: cSipCfgHeaderPassingEnabled
+#   attributes:
+#     cSipCfgHeaderPassingEnabled:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.7.1
+#       name: cisco.cSipCfgHeaderPassingEnabled
+#       syntax: TruthValue
+#     cSipCfgMaxSubscriptionAccept:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.7.2
+#       name: cisco.cSipCfgMaxSubscriptionAccept
+#       syntax: Unsigned32
+#     cSipCfgMaxSubscriptionOriginate:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.7.3
+#       name: cisco.cSipCfgMaxSubscriptionOriginate
+#       syntax: Unsigned32
+#     cSipCfgSwitchTransportEnabled:
+#       oid: .1.3.6.1.4.1.9.9.152.1.1.7.4
+#       name: cisco.cSipCfgSwitchTransportEnabled
+#       syntax: TruthValue
+
+CISCO-SIP-UA-MIB::cSipStatsInfo:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsInfo
+  discovery_attribute: cSipStatsInfoTryingIns
+  attributes:
+    cSipStatsInfoTryingIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.1
+      name: cisco.cSipStatsInfoTryingIns
+      syntax: Counter32
+    cSipStatsInfoTryingOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.2
+      name: cisco.cSipStatsInfoTryingOuts
+      syntax: Counter32
+    cSipStatsInfoRingingIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.3
+      name: cisco.cSipStatsInfoRingingIns
+      syntax: Counter32
+    cSipStatsInfoRingingOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.4
+      name: cisco.cSipStatsInfoRingingOuts
+      syntax: Counter32
+    cSipStatsInfoForwardedIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.5
+      name: cisco.cSipStatsInfoForwardedIns
+      syntax: Counter32
+    cSipStatsInfoForwardedOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.6
+      name: cisco.cSipStatsInfoForwardedOuts
+      syntax: Counter32
+    cSipStatsInfoQueuedIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.7
+      name: cisco.cSipStatsInfoQueuedIns
+      syntax: Counter32
+    cSipStatsInfoQueuedOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.8
+      name: cisco.cSipStatsInfoQueuedOuts
+      syntax: Counter32
+    cSipStatsInfoSessionProgIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.9
+      name: cisco.cSipStatsInfoSessionProgIns
+      syntax: Counter32
+    cSipStatsInfoSessionProgOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.1.10
+      name: cisco.cSipStatsInfoSessionProgOuts
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsSuccess:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsSuccess
+  discovery_attribute: cSipStatsSuccessOkIns
+  attributes:
+    cSipStatsSuccessOkIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.2.1
+      name: cisco.cSipStatsSuccessOkIns
+      syntax: Counter32
+    cSipStatsSuccessOkOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.2.2
+      name: cisco.cSipStatsSuccessOkOuts
+      syntax: Counter32
+    cSipStatsSuccessAcceptedIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.2.3
+      name: cisco.cSipStatsSuccessAcceptedIns
+      syntax: Counter32
+    cSipStatsSuccessAcceptedOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.2.4
+      name: cisco.cSipStatsSuccessAcceptedOuts
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsSuccessOkEntry:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsSuccessOkEntry
+  index:
+    - type: OctetString
+      oid: .1.3.6.1.4.1.9.9.152.1.2.2.5.1.1
+      name: cisco.cSipStatsSuccessOkMethod
+      syntax: DisplayString # CSipMethodStr
+  discovery_attribute: cSipStatsSuccessOkInbounds
+  attributes:
+    cSipStatsSuccessOkInbounds:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.2.5.1.2
+      name: cisco.cSipStatsSuccessOkInbounds
+      syntax: Counter32
+    cSipStatsSuccessOkOutbounds:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.2.5.1.3
+      name: cisco.cSipStatsSuccessOkOutbounds
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsRedirect:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsRedirect
+  discovery_attribute: cSipStatsRedirMultipleChoices
+  attributes:
+    cSipStatsRedirMultipleChoices:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.3.1
+      name: cisco.cSipStatsRedirMultipleChoices
+      syntax: Counter32
+    cSipStatsRedirMovedPerms:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.3.2
+      name: cisco.cSipStatsRedirMovedPerms
+      syntax: Counter32
+    cSipStatsRedirMovedTemps:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.3.3
+      name: cisco.cSipStatsRedirMovedTemps
+      syntax: Counter32
+    cSipStatsRedirSeeOthers:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.3.4
+      name: cisco.cSipStatsRedirSeeOthers
+      syntax: Counter32
+    cSipStatsRedirUseProxys:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.3.5
+      name: cisco.cSipStatsRedirUseProxys
+      syntax: Counter32
+    cSipStatsRedirAltServices:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.3.6
+      name: cisco.cSipStatsRedirAltServices
+      syntax: Counter32
+    cSipStatsRedirMovedTempsIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.3.7
+      name: cisco.cSipStatsRedirMovedTempsIns
+      syntax: Counter32
+    cSipStatsRedirMovedTempsOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.3.8
+      name: cisco.cSipStatsRedirMovedTempsOuts
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsErrClient:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsErrClient
+  discovery_attribute: cSipStatsClientBadRequestIns
+  attributes:
+    cSipStatsClientBadRequestIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.1
+      name: cisco.cSipStatsClientBadRequestIns
+      syntax: Counter32
+    cSipStatsClientBadRequestOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.2
+      name: cisco.cSipStatsClientBadRequestOuts
+      syntax: Counter32
+    cSipStatsClientUnauthorizedIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.3
+      name: cisco.cSipStatsClientUnauthorizedIns
+      syntax: Counter32
+    cSipStatsClientUnauthorizedOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.4
+      name: cisco.cSipStatsClientUnauthorizedOuts
+      syntax: Counter32
+    cSipStatsClientPaymentReqdIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.5
+      name: cisco.cSipStatsClientPaymentReqdIns
+      syntax: Counter32
+    cSipStatsClientPaymentReqdOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.6
+      name: cisco.cSipStatsClientPaymentReqdOuts
+      syntax: Counter32
+    cSipStatsClientForbiddenIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.7
+      name: cisco.cSipStatsClientForbiddenIns
+      syntax: Counter32
+    cSipStatsClientForbiddenOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.8
+      name: cisco.cSipStatsClientForbiddenOuts
+      syntax: Counter32
+    cSipStatsClientNotFoundIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.9
+      name: cisco.cSipStatsClientNotFoundIns
+      syntax: Counter32
+    cSipStatsClientNotFoundOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.10
+      name: cisco.cSipStatsClientNotFoundOuts
+      syntax: Counter32
+    cSipStatsClientMethNotAllowedIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.11
+      name: cisco.cSipStatsClientMethNotAllowedIns
+      syntax: Counter32
+    cSipStatsClientMethNotAllowedOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.12
+      name: cisco.cSipStatsClientMethNotAllowedOuts
+      syntax: Counter32
+    cSipStatsClientNotAcceptableIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.13
+      name: cisco.cSipStatsClientNotAcceptableIns
+      syntax: Counter32
+    cSipStatsClientNotAcceptableOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.14
+      name: cisco.cSipStatsClientNotAcceptableOuts
+      syntax: Counter32
+    cSipStatsClientProxyAuthReqdIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.15
+      name: cisco.cSipStatsClientProxyAuthReqdIns
+      syntax: Counter32
+    cSipStatsClientProxyAuthReqdOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.16
+      name: cisco.cSipStatsClientProxyAuthReqdOuts
+      syntax: Counter32
+    cSipStatsClientReqTimeoutIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.17
+      name: cisco.cSipStatsClientReqTimeoutIns
+      syntax: Counter32
+    cSipStatsClientReqTimeoutOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.18
+      name: cisco.cSipStatsClientReqTimeoutOuts
+      syntax: Counter32
+    cSipStatsClientConflictIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.19
+      name: cisco.cSipStatsClientConflictIns
+      syntax: Counter32
+    cSipStatsClientConflictOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.20
+      name: cisco.cSipStatsClientConflictOuts
+      syntax: Counter32
+    cSipStatsClientGoneIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.21
+      name: cisco.cSipStatsClientGoneIns
+      syntax: Counter32
+    cSipStatsClientGoneOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.22
+      name: cisco.cSipStatsClientGoneOuts
+      syntax: Counter32
+    cSipStatsClientLengthRequiredIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.23
+      name: cisco.cSipStatsClientLengthRequiredIns
+      syntax: Counter32
+    cSipStatsClientLengthRequiredOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.24
+      name: cisco.cSipStatsClientLengthRequiredOuts
+      syntax: Counter32
+    cSipStatsClientReqEntTooLargeIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.25
+      name: cisco.cSipStatsClientReqEntTooLargeIns
+      syntax: Counter32
+    cSipStatsClientReqEntTooLargeOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.26
+      name: cisco.cSipStatsClientReqEntTooLargeOuts
+      syntax: Counter32
+    cSipStatsClientReqURITooLargeIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.27
+      name: cisco.cSipStatsClientReqURITooLargeIns
+      syntax: Counter32
+    cSipStatsClientReqURITooLargeOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.28
+      name: cisco.cSipStatsClientReqURITooLargeOuts
+      syntax: Counter32
+    cSipStatsClientNoSupMediaTypeIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.29
+      name: cisco.cSipStatsClientNoSupMediaTypeIns
+      syntax: Counter32
+    cSipStatsClientNoSupMediaTypeOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.30
+      name: cisco.cSipStatsClientNoSupMediaTypeOuts
+      syntax: Counter32
+    cSipStatsClientBadExtensionIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.31
+      name: cisco.cSipStatsClientBadExtensionIns
+      syntax: Counter32
+    cSipStatsClientBadExtensionOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.32
+      name: cisco.cSipStatsClientBadExtensionOuts
+      syntax: Counter32
+    cSipStatsClientTempNotAvailIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.33
+      name: cisco.cSipStatsClientTempNotAvailIns
+      syntax: Counter32
+    cSipStatsClientTempNotAvailOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.34
+      name: cisco.cSipStatsClientTempNotAvailOuts
+      syntax: Counter32
+    cSipStatsClientCallLegNoExistIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.35
+      name: cisco.cSipStatsClientCallLegNoExistIns
+      syntax: Counter32
+    cSipStatsClientCallLegNoExistOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.36
+      name: cisco.cSipStatsClientCallLegNoExistOuts
+      syntax: Counter32
+    cSipStatsClientLoopDetectedIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.37
+      name: cisco.cSipStatsClientLoopDetectedIns
+      syntax: Counter32
+    cSipStatsClientLoopDetectedOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.38
+      name: cisco.cSipStatsClientLoopDetectedOuts
+      syntax: Counter32
+    cSipStatsClientTooManyHopsIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.39
+      name: cisco.cSipStatsClientTooManyHopsIns
+      syntax: Counter32
+    cSipStatsClientTooManyHopsOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.40
+      name: cisco.cSipStatsClientTooManyHopsOuts
+      syntax: Counter32
+    cSipStatsClientAddrIncompleteIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.41
+      name: cisco.cSipStatsClientAddrIncompleteIns
+      syntax: Counter32
+    cSipStatsClientAddrIncompleteOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.42
+      name: cisco.cSipStatsClientAddrIncompleteOuts
+      syntax: Counter32
+    cSipStatsClientAmbiguousIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.43
+      name: cisco.cSipStatsClientAmbiguousIns
+      syntax: Counter32
+    cSipStatsClientAmbiguousOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.44
+      name: cisco.cSipStatsClientAmbiguousOuts
+      syntax: Counter32
+    cSipStatsClientBusyHereIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.45
+      name: cisco.cSipStatsClientBusyHereIns
+      syntax: Counter32
+    cSipStatsClientBusyHereOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.46
+      name: cisco.cSipStatsClientBusyHereOuts
+      syntax: Counter32
+    cSipStatsClientReqTermIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.47
+      name: cisco.cSipStatsClientReqTermIns
+      syntax: Counter32
+    cSipStatsClientReqTermOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.48
+      name: cisco.cSipStatsClientReqTermOuts
+      syntax: Counter32
+    cSipStatsClientNoAcceptHereIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.49
+      name: cisco.cSipStatsClientNoAcceptHereIns
+      syntax: Counter32
+    cSipStatsClientNoAcceptHereOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.50
+      name: cisco.cSipStatsClientNoAcceptHereOuts
+      syntax: Counter32
+    cSipStatsClientBadEventIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.51
+      name: cisco.cSipStatsClientBadEventIns
+      syntax: Counter32
+    cSipStatsClientBadEventOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.52
+      name: cisco.cSipStatsClientBadEventOuts
+      syntax: Counter32
+    cSipStatsClientSTTooSmallIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.53
+      name: cisco.cSipStatsClientSTTooSmallIns
+      syntax: Counter32
+    cSipStatsClientSTTooSmallOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.54
+      name: cisco.cSipStatsClientSTTooSmallOuts
+      syntax: Counter32
+    cSipStatsClientReqPendingIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.55
+      name: cisco.cSipStatsClientReqPendingIns
+      syntax: Counter32
+    cSipStatsClientReqPendingOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.4.56
+      name: cisco.cSipStatsClientReqPendingOuts
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsErrServer:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsErrServer
+  discovery_attribute: cSipStatsServerIntErrorIns
+  attributes:
+    cSipStatsServerIntErrorIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.1
+      name: cisco.cSipStatsServerIntErrorIns
+      syntax: Counter32
+    cSipStatsServerIntErrorOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.2
+      name: cisco.cSipStatsServerIntErrorOuts
+      syntax: Counter32
+    cSipStatsServerNotImplementedIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.3
+      name: cisco.cSipStatsServerNotImplementedIns
+      syntax: Counter32
+    cSipStatsServerNotImplementedOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.4
+      name: cisco.cSipStatsServerNotImplementedOuts
+      syntax: Counter32
+    cSipStatsServerBadGatewayIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.5
+      name: cisco.cSipStatsServerBadGatewayIns
+      syntax: Counter32
+    cSipStatsServerBadGatewayOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.6
+      name: cisco.cSipStatsServerBadGatewayOuts
+      syntax: Counter32
+    cSipStatsServerServiceUnavailIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.7
+      name: cisco.cSipStatsServerServiceUnavailIns
+      syntax: Counter32
+    cSipStatsServerServiceUnavailOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.8
+      name: cisco.cSipStatsServerServiceUnavailOuts
+      syntax: Counter32
+    cSipStatsServerGatewayTimeoutIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.9
+      name: cisco.cSipStatsServerGatewayTimeoutIns
+      syntax: Counter32
+    cSipStatsServerGatewayTimeoutOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.10
+      name: cisco.cSipStatsServerGatewayTimeoutOuts
+      syntax: Counter32
+    cSipStatsServerBadSipVersionIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.11
+      name: cisco.cSipStatsServerBadSipVersionIns
+      syntax: Counter32
+    cSipStatsServerBadSipVersionOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.12
+      name: cisco.cSipStatsServerBadSipVersionOuts
+      syntax: Counter32
+    cSipStatsServerPrecondFailureIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.13
+      name: cisco.cSipStatsServerPrecondFailureIns
+      syntax: Counter32
+    cSipStatsServerPrecondFailureOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.5.14
+      name: cisco.cSipStatsServerPrecondFailureOuts
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsGlobalFail:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsGlobalFail
+  discovery_attribute: cSipStatsGlobalBusyEverywhereIns
+  attributes:
+    cSipStatsGlobalBusyEverywhereIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.6.1
+      name: cisco.cSipStatsGlobalBusyEverywhereIns
+      syntax: Counter32
+    cSipStatsGlobalBusyEverywhereOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.6.2
+      name: cisco.cSipStatsGlobalBusyEverywhereOuts
+      syntax: Counter32
+    cSipStatsGlobalDeclineIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.6.3
+      name: cisco.cSipStatsGlobalDeclineIns
+      syntax: Counter32
+    cSipStatsGlobalDeclineOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.6.4
+      name: cisco.cSipStatsGlobalDeclineOuts
+      syntax: Counter32
+    cSipStatsGlobalNotAnywhereIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.6.5
+      name: cisco.cSipStatsGlobalNotAnywhereIns
+      syntax: Counter32
+    cSipStatsGlobalNotAnywhereOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.6.6
+      name: cisco.cSipStatsGlobalNotAnywhereOuts
+      syntax: Counter32
+    cSipStatsGlobalNotAcceptableIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.6.7
+      name: cisco.cSipStatsGlobalNotAcceptableIns
+      syntax: Counter32
+    cSipStatsGlobalNotAcceptableOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.6.8
+      name: cisco.cSipStatsGlobalNotAcceptableOuts
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsTraffic:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsTraffic
+  discovery_attribute: cSipStatsTrafficInviteIns
+  attributes:
+    cSipStatsTrafficInviteIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.1
+      name: cisco.cSipStatsTrafficInviteIns
+      syntax: Counter32
+    cSipStatsTrafficInviteOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.2
+      name: cisco.cSipStatsTrafficInviteOuts
+      syntax: Counter32
+    cSipStatsTrafficAckIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.3
+      name: cisco.cSipStatsTrafficAckIns
+      syntax: Counter32
+    cSipStatsTrafficAckOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.4
+      name: cisco.cSipStatsTrafficAckOuts
+      syntax: Counter32
+    cSipStatsTrafficByeIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.5
+      name: cisco.cSipStatsTrafficByeIns
+      syntax: Counter32
+    cSipStatsTrafficByeOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.6
+      name: cisco.cSipStatsTrafficByeOuts
+      syntax: Counter32
+    cSipStatsTrafficCancelIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.7
+      name: cisco.cSipStatsTrafficCancelIns
+      syntax: Counter32
+    cSipStatsTrafficCancelOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.8
+      name: cisco.cSipStatsTrafficCancelOuts
+      syntax: Counter32
+    cSipStatsTrafficOptionsIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.9
+      name: cisco.cSipStatsTrafficOptionsIns
+      syntax: Counter32
+    cSipStatsTrafficOptionsOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.10
+      name: cisco.cSipStatsTrafficOptionsOuts
+      syntax: Counter32
+    cSipStatsTrafficRegisterIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.11
+      name: cisco.cSipStatsTrafficRegisterIns
+      syntax: Counter32
+    cSipStatsTrafficRegisterOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.12
+      name: cisco.cSipStatsTrafficRegisterOuts
+      syntax: Counter32
+    cSipStatsTrafficCometIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.13
+      name: cisco.cSipStatsTrafficCometIns
+      syntax: Counter32
+    cSipStatsTrafficCometOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.14
+      name: cisco.cSipStatsTrafficCometOuts
+      syntax: Counter32
+    cSipStatsTrafficPrackIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.15
+      name: cisco.cSipStatsTrafficPrackIns
+      syntax: Counter32
+    cSipStatsTrafficPrackOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.16
+      name: cisco.cSipStatsTrafficPrackOuts
+      syntax: Counter32
+    cSipStatsTrafficReferIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.17
+      name: cisco.cSipStatsTrafficReferIns
+      syntax: Counter32
+    cSipStatsTrafficReferOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.18
+      name: cisco.cSipStatsTrafficReferOuts
+      syntax: Counter32
+    cSipStatsTrafficNotifyIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.19
+      name: cisco.cSipStatsTrafficNotifyIns
+      syntax: Counter32
+    cSipStatsTrafficNotifyOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.20
+      name: cisco.cSipStatsTrafficNotifyOuts
+      syntax: Counter32
+    cSipStatsTrafficInfoIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.21
+      name: cisco.cSipStatsTrafficInfoIns
+      syntax: Counter32
+    cSipStatsTrafficInfoOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.22
+      name: cisco.cSipStatsTrafficInfoOuts
+      syntax: Counter32
+    cSipStatsTrafficSubscribeIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.23
+      name: cisco.cSipStatsTrafficSubscribeIns
+      syntax: Counter32
+    cSipStatsTrafficSubscribeOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.24
+      name: cisco.cSipStatsTrafficSubscribeOuts
+      syntax: Counter32
+    cSipStatsTrafficUpdateIns:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.25
+      name: cisco.cSipStatsTrafficUpdateIns
+      syntax: Counter32
+    cSipStatsTrafficUpdateOuts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.7.26
+      name: cisco.cSipStatsTrafficUpdateOuts
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsRetry:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsRetry
+  discovery_attribute: cSipStatsRetryInvites
+  attributes:
+    cSipStatsRetryInvites:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.1
+      name: cisco.cSipStatsRetryInvites
+      syntax: Counter32
+    cSipStatsRetryByes:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.2
+      name: cisco.cSipStatsRetryByes
+      syntax: Counter32
+    cSipStatsRetryCancels:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.3
+      name: cisco.cSipStatsRetryCancels
+      syntax: Counter32
+    cSipStatsRetryRegisters:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.4
+      name: cisco.cSipStatsRetryRegisters
+      syntax: Counter32
+    cSipStatsRetryResponses:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.5
+      name: cisco.cSipStatsRetryResponses
+      syntax: Counter32
+    cSipStatsRetryPracks:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.6
+      name: cisco.cSipStatsRetryPracks
+      syntax: Counter32
+    cSipStatsRetryComets:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.7
+      name: cisco.cSipStatsRetryComets
+      syntax: Counter32
+    cSipStatsRetryReliable1xxRsps:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.8
+      name: cisco.cSipStatsRetryReliable1xxRsps
+      syntax: Counter32
+    cSipStatsRetryNotifys:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.9
+      name: cisco.cSipStatsRetryNotifys
+      syntax: Counter32
+    cSipStatsRetryRefers:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.10
+      name: cisco.cSipStatsRetryRefers
+      syntax: Counter32
+    cSipStatsRetryInfo:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.11
+      name: cisco.cSipStatsRetryInfo
+      syntax: Counter32
+    cSipStatsRetrySubscribe:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.8.12
+      name: cisco.cSipStatsRetrySubscribe
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsMisc:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsMisc
+  discovery_attribute: cSipStatsMisc3xxMappedTo4xxRsps
+  attributes:
+    cSipStatsMisc3xxMappedTo4xxRsps:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.9.1
+      name: cisco.cSipStatsMisc3xxMappedTo4xxRsps
+      syntax: Counter32
+
+CISCO-SIP-UA-MIB::cSipStatsConnection:
+  mib: CISCO-SIP-UA-MIB
+  object: cSipStatsConnection
+  discovery_attribute: cSipStatsConnTCPSendFailures
+  attributes:
+    cSipStatsConnTCPSendFailures:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.10.1
+      name: cisco.cSipStatsConnTCPSendFailures
+      syntax: Counter32
+    cSipStatsConnUDPSendFailures:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.10.2
+      name: cisco.cSipStatsConnUDPSendFailures
+      syntax: Counter32
+    cSipStatsConnTCPRemoteClosures:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.10.3
+      name: cisco.cSipStatsConnTCPRemoteClosures
+      syntax: Counter32
+    cSipStatsConnUDPCreateFailures:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.10.4
+      name: cisco.cSipStatsConnUDPCreateFailures
+      syntax: Counter32
+    cSipStatsConnTCPCreateFailures:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.10.5
+      name: cisco.cSipStatsConnTCPCreateFailures
+      syntax: Counter32
+    cSipStatsConnUDPInactiveTimeouts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.10.6
+      name: cisco.cSipStatsConnUDPInactiveTimeouts
+      syntax: Counter32
+    cSipStatsConnTCPInactiveTimeouts:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.10.7
+      name: cisco.cSipStatsConnTCPInactiveTimeouts
+      syntax: Counter32
+    cSipStatsActiveUDPConnections:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.10.8
+      name: cisco.cSipStatsActiveUDPConnections
+      syntax: Gauge32
+    cSipStatsActiveTCPConnections:
+      oid: .1.3.6.1.4.1.9.9.152.1.2.10.9
+      name: cisco.cSipStatsActiveTCPConnections
+      syntax: Gauge32

--- a/objects/cisco/CISCO-SYSLOG-MIB.yml
+++ b/objects/cisco/CISCO-SYSLOG-MIB.yml
@@ -1,0 +1,88 @@
+CISCO-SYSLOG-MIB::clogBasic:
+  mib: CISCO-SYSLOG-MIB
+  object: clogBasic
+  discovery_attribute: clogNotificationsSent
+  attributes:
+    clogNotificationsSent:
+      oid: .1.3.6.1.4.1.9.9.41.1.1.1
+      name: cisco.clogNotificationsSent
+      syntax: Counter32
+    clogNotificationsEnabled:
+      oid: .1.3.6.1.4.1.9.9.41.1.1.2
+      name: cisco.clogNotificationsEnabled
+      syntax: TruthValue
+    clogMaxSeverity:
+      oid: .1.3.6.1.4.1.9.9.41.1.1.3
+      name: cisco.clogMaxSeverity
+      syntax: EnumInteger
+    clogMsgIgnores:
+      oid: .1.3.6.1.4.1.9.9.41.1.1.4
+      name: cisco.clogMsgIgnores
+      syntax: Counter32
+    clogMsgDrops:
+      oid: .1.3.6.1.4.1.9.9.41.1.1.5
+      name: cisco.clogMsgDrops
+      syntax: Counter32
+    clogOriginIDType:
+      oid: .1.3.6.1.4.1.9.9.41.1.1.6
+      name: cisco.clogOriginIDType
+      syntax: EnumInteger
+    clogOriginID:
+      oid: .1.3.6.1.4.1.9.9.41.1.1.7
+      name: cisco.clogOriginID
+      syntax: DisplayString # SnmpAdminString
+
+CISCO-SYSLOG-MIB::clogHistory:
+  mib: CISCO-SYSLOG-MIB
+  object: clogHistory
+  discovery_attribute: clogHistTableMaxLength
+  attributes:
+    clogHistTableMaxLength:
+      oid: .1.3.6.1.4.1.9.9.41.1.2.1
+      name: cisco.clogHistTableMaxLength
+      syntax: Integer32
+    clogHistMsgsFlushed:
+      oid: .1.3.6.1.4.1.9.9.41.1.2.2
+      name: cisco.clogHistMsgsFlushed
+      syntax: Counter32
+
+# CISCO-SYSLOG-MIB::clogHistoryEntry:
+#   mib: CISCO-SYSLOG-MIB
+#   object: clogHistoryEntry
+#   index:
+#     - type: Integer32
+#       oid: .1.3.6.1.4.1.9.9.41.1.2.3.1.1
+#       name: cisco.clogHistIndex
+#       syntax: Integer32
+#   discovery_attribute: clogHistFacility
+#   attributes:
+#     clogHistFacility:
+#       oid: .1.3.6.1.4.1.9.9.41.1.2.3.1.2
+#       name: cisco.clogHistFacility
+#       syntax: DisplayString
+#     clogHistSeverity:
+#       oid: .1.3.6.1.4.1.9.9.41.1.2.3.1.3
+#       name: cisco.clogHistSeverity
+#       syntax: EnumInteger
+#     clogHistMsgName:
+#       oid: .1.3.6.1.4.1.9.9.41.1.2.3.1.4
+#       name: cisco.clogHistMsgName
+#       syntax: DisplayString
+#     clogHistMsgText:
+#       oid: .1.3.6.1.4.1.9.9.41.1.2.3.1.5
+#       name: cisco.clogHistMsgText
+#       syntax: DisplayString
+#     clogHistTimestamp:
+#       oid: .1.3.6.1.4.1.9.9.41.1.2.3.1.6
+#       name: cisco.clogHistTimestamp
+#       syntax: TimeStamp
+
+# CISCO-SYSLOG-MIB::clogServer:
+#   mib: CISCO-SYSLOG-MIB
+#   object: clogServer
+#   discovery_attribute: clogMaxServers
+#   attributes:
+#     clogMaxServers:
+#       oid: .1.3.6.1.4.1.9.9.41.1.3.1
+#       name: cisco.clogMaxServers
+#       syntax: Unsigned32

--- a/objects/cisco/CISCO-TELEPRESENCE-CALL-MIB.yml
+++ b/objects/cisco/CISCO-TELEPRESENCE-CALL-MIB.yml
@@ -1,0 +1,529 @@
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcObjects:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcObjects
+#   discovery_attribute: ctpcStatNotifyEnable
+#   attributes:
+#     ctpcStatNotifyEnable:
+#       oid: .1.3.6.1.4.1.9.9.644.1.1.1
+#       name: cisco.ctpcStatNotifyEnable
+#       syntax: TruthValue
+#     ctpcMgmtSysConnNotifyEnable:
+#       oid: .1.3.6.1.4.1.9.9.644.1.1.2
+#       name: cisco.ctpcMgmtSysConnNotifyEnable
+#       syntax: TruthValue
+
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcInfoObjects:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcInfoObjects
+#   discovery_attribute: ctpcLocalAddr
+#   attributes:
+#     ctpcLocalAddr:
+#       oid: .1.3.6.1.4.1.9.9.644.1.2.2
+#       name: cisco.ctpcLocalAddr
+#       syntax: IpAddressNoSuffix # InetAddress
+#     ctpcMode:
+#       oid: .1.3.6.1.4.1.9.9.644.1.2.4
+#       name: cisco.ctpcMode
+#       syntax: EnumInteger
+#     ctpcActiveMgmtSysIndex:
+#       oid: .1.3.6.1.4.1.9.9.644.1.2.5
+#       name: cisco.ctpcActiveMgmtSysIndex
+#       syntax: Unsigned32
+#     ctpcTxDscpTelepresenceConfigured:
+#       oid: .1.3.6.1.4.1.9.9.644.1.2.7
+#       name: cisco.ctpcTxDscpTelepresenceConfigured
+#       syntax: Integer32 # Dscp
+#     ctpcTxDscpAudioConfigured:
+#       oid: .1.3.6.1.4.1.9.9.644.1.2.8
+#       name: cisco.ctpcTxDscpAudioConfigured
+#       syntax: Integer32 # Dscp
+
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcLocalDirNumEntry:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcLocalDirNumEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.644.1.2.3.1.1
+#       name: cisco.ctpcLocalDirNumIndex
+#       syntax: Unsigned32
+#   discovery_attribute: ctpcLocalDirNum
+#   attributes:
+#     ctpcLocalDirNum:
+#       oid: .1.3.6.1.4.1.9.9.644.1.2.3.1.2
+#       name: cisco.ctpcLocalDirNum
+#       syntax: OctetString # CtpcE164Address
+#     ctpcExtNumberMask:
+#       oid: .1.3.6.1.4.1.9.9.644.1.2.3.1.3
+#       name: cisco.ctpcExtNumberMask
+#       syntax: DisplayString # SnmpAdminString
+
+CISCO-TELEPRESENCE-CALL-MIB::ctpcMgmtSysEntry:
+  mib: CISCO-TELEPRESENCE-CALL-MIB
+  object: ctpcMgmtSysEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.644.1.2.6.1.1
+      name: cisco.ctpcMgmtSysIndex
+      syntax: Unsigned32
+  discovery_attribute: ctpcMgmtSysAddr
+  attributes:
+    ctpcMgmtSysAddr:
+      oid: .1.3.6.1.4.1.9.9.644.1.2.6.1.3
+      name: cisco.ctpcMgmtSysAddr
+      syntax: IpAddressNoSuffix # InetAddress
+    ctpcMgmtSysConnStatus:
+      oid: .1.3.6.1.4.1.9.9.644.1.2.6.1.4
+      name: cisco.ctpcMgmtSysConnStatus
+      syntax: EnumInteger
+    ctpcMgmtSysSIPRespCode:
+      oid: .1.3.6.1.4.1.9.9.644.1.2.6.1.5
+      name: cisco.ctpcMgmtSysSIPRespCode
+      syntax: Unsigned32
+
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcStatMonitoredEntry:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcStatMonitoredEntry
+#   index:
+#     - type: Integer
+#       oid: .1.3.6.1.4.1.9.9.644.1.3.1.1.1
+#       name: cisco.ctpcStatMonitoredType
+#       syntax: EnumInteger
+#     - type: Integer32
+#       oid: .1.3.6.1.4.1.9.9.644.1.3.1.1.2
+#       name: cisco.ctpcStatMonitoredStreamType
+#       syntax: EnumInteger
+#   discovery_attribute: ctpcStatMonitoredUnit
+#   attributes:
+#     ctpcStatMonitoredUnit:
+#       oid: .1.3.6.1.4.1.9.9.644.1.3.1.1.3
+#       name: cisco.ctpcStatMonitoredUnit
+#       syntax: EnumInteger
+#     ctpcStatRisingThreshold:
+#       oid: .1.3.6.1.4.1.9.9.644.1.3.1.1.4
+#       name: cisco.ctpcStatRisingThreshold
+#       syntax: Unsigned32
+#     ctpcStatFallingThreshold:
+#       oid: .1.3.6.1.4.1.9.9.644.1.3.1.1.5
+#       name: cisco.ctpcStatFallingThreshold
+#       syntax: Unsigned32
+#     ctpcStatStartupAlarm:
+#       oid: .1.3.6.1.4.1.9.9.644.1.3.1.1.6
+#       name: cisco.ctpcStatStartupAlarm
+#       syntax: EnumInteger
+
+CISCO-TELEPRESENCE-CALL-MIB::ctpcStatObjects:
+  mib: CISCO-TELEPRESENCE-CALL-MIB
+  object: ctpcStatObjects
+  discovery_attribute: ctpcStatOverallCalls
+  attributes:
+    ctpcStatOverallCalls:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.1
+      name: cisco.ctpcStatOverallCalls
+      syntax: Unsigned32
+    ctpcStatOverallCallTime:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.2
+      name: cisco.ctpcStatOverallCallTime
+      syntax: TicksSec
+    ctpcStatTotalCalls:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.3
+      name: cisco.ctpcStatTotalCalls
+      syntax: Unsigned32
+    ctpcStatTotalCallTime:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.4
+      name: cisco.ctpcStatTotalCallTime
+      syntax: TicksSec
+    ctpcSamplePeriod:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.5
+      name: cisco.ctpcSamplePeriod
+      syntax: TicksSec
+    ctpcTableSize:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.6
+      name: cisco.ctpcTableSize
+      syntax: Integer32
+    ctpcTableLastIndex:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.7
+      name: cisco.ctpcTableLastIndex
+      syntax: Unsigned32
+
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcEntry:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.1
+#       name: cisco.ctpcIndex
+#       syntax: Unsigned32
+#   discovery_attribute: ctpcRemoteDirNum
+#   attributes:
+#     ctpcRemoteDirNum:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.2
+#       name: cisco.ctpcRemoteDirNum
+#       syntax: OctetString # CtpcE164Address
+#     ctpcLocalSIPCallId:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.3
+#       name: cisco.ctpcLocalSIPCallId
+#       syntax: DisplayString # SnmpAdminString
+#     ctpcTxDestAddr:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.5
+#       name: cisco.ctpcTxDestAddr
+#       syntax: IpAddressNoSuffix # InetAddress
+#     ctpcStartDateAndTime:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.6
+#       name: cisco.ctpcStartDateAndTime
+#       syntax: DateAndTime
+#     ctpcDuration:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.7
+#       name: cisco.ctpcDuration
+#       syntax: TicksSec
+#     ctpcType:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.8
+#       name: cisco.ctpcType
+#       syntax: EnumInteger
+#     ctpcSecurity:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.9
+#       name: cisco.ctpcSecurity
+#       syntax: EnumInteger
+#     ctpcDirection:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.10
+#       name: cisco.ctpcDirection
+#       syntax: EnumInteger
+#     ctpcState:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.11
+#       name: cisco.ctpcState
+#       syntax: EnumInteger
+#     ctpcInitialBitRate:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.12
+#       name: cisco.ctpcInitialBitRate
+#       syntax: Unsigned32
+#     ctpcLatestBitRate:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.13
+#       name: cisco.ctpcLatestBitRate
+#       syntax: Unsigned32
+#     ctpcAttributes:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.15
+#       name: cisco.ctpcAttributes
+#       syntax: EnumInteger
+#     ctpcRemoteDevice:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.16
+#       name: cisco.ctpcRemoteDevice
+#       syntax: EnumInteger
+#     ctpcCallTermReason:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.17
+#       name: cisco.ctpcCallTermReason
+#       syntax: EnumInteger
+
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcStatStreamTypeEntry:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcStatStreamTypeEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.1
+#       name: cisco.ctpcIndex
+#       syntax: Unsigned32
+#     - type: Integer
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.1
+#       name: cisco.ctpcStreamType
+#       syntax: EnumInteger
+#   discovery_attribute: ctpcAvgPeriodLatency
+#   attributes:
+#     ctpcAvgPeriodLatency:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.2
+#       name: cisco.ctpcAvgPeriodLatency
+#       syntax: TicksMilliSec
+#     ctpcAvgCallLatency:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.3
+#       name: cisco.ctpcAvgCallLatency
+#       syntax: TicksMilliSec
+#     ctpcMaxPeriodLatency:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.4
+#       name: cisco.ctpcMaxPeriodLatency
+#       syntax: TicksMilliSec
+#     ctpcMaxCallLatency:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.5
+#       name: cisco.ctpcMaxCallLatency
+#       syntax: TicksMilliSec
+#     ctpcMaxCallLatencyRecTime:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.6
+#       name: cisco.ctpcMaxCallLatencyRecTime
+#       syntax: TicksSec
+#     ctpcMediaSrcPort:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.7
+#       name: cisco.ctpcMediaSrcPort
+#       syntax: Unsigned32
+#     ctpcMediaDestPort:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.8
+#       name: cisco.ctpcMediaDestPort
+#       syntax: Unsigned32
+#     ctpcRxDscpCurrent:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.9
+#       name: cisco.ctpcRxDscpCurrent
+#       syntax: Integer32 # Dscp
+#     ctpcRxDscpPrevious:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.10
+#       name: cisco.ctpcRxDscpPrevious
+#       syntax: Integer32 # Dscp
+#     ctpcRxCoSCurrent:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.11
+#       name: cisco.ctpcRxCoSCurrent
+#       syntax: Integer # QosLayer2Cos
+#     ctpcRxCoSPrevious:
+#       oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.12
+#       name: cisco.ctpcRxCoSPrevious
+#       syntax: Integer # QosLayer2Cos
+
+CISCO-TELEPRESENCE-CALL-MIB::ctpcStatStreamSourceEntry:
+  mib: CISCO-TELEPRESENCE-CALL-MIB
+  object: ctpcStatStreamSourceEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.644.1.4.8.1.1
+      name: cisco.ctpcIndex
+      syntax: Unsigned32
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.644.1.4.9.1.1
+      name: cisco.ctpcStreamType
+      syntax: EnumInteger
+    - type: Integer
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.1
+      name: cisco.ctpcStreamSource
+      syntax: EnumInteger
+  discovery_attribute: ctpcTxActive
+  attributes:
+    ctpcTxActive:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.2
+      name: cisco.ctpcTxActive
+      syntax: TruthValue
+    ctpcTxTotalBytes:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.3
+      name: cisco.ctpcTxTotalBytes
+      syntax: BytesB
+    ctpcTxTotalPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.4
+      name: cisco.ctpcTxTotalPackets
+      syntax: Counter64
+    ctpcTxLostPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.5
+      name: cisco.ctpcTxLostPackets
+      syntax: Counter64
+    ctpcTxPeriodLostPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.6
+      name: cisco.ctpcTxPeriodLostPackets
+      syntax: Gauge32
+    ctpcTxCallLostPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.7
+      name: cisco.ctpcTxCallLostPackets
+      syntax: Gauge32
+    ctpcTxIDRPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.8
+      name: cisco.ctpcTxIDRPackets
+      syntax: Counter64
+    ctpcTxShapingWindow:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.9
+      name: cisco.ctpcTxShapingWindow
+      syntax: TicksMilliSec # TODO_TicksMilliSec
+    ctpcRxActive:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.10
+      name: cisco.ctpcRxActive
+      syntax: TruthValue
+    ctpcRxTotalBytes:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.11
+      name: cisco.ctpcRxTotalBytes
+      syntax: BytesB
+    ctpcRxTotalPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.12
+      name: cisco.ctpcRxTotalPackets
+      syntax: Counter64
+    ctpcRxLostPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.13
+      name: cisco.ctpcRxLostPackets
+      syntax: Counter64
+    ctpcRxPeriodLostPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.14
+      name: cisco.ctpcRxPeriodLostPackets
+      syntax: Gauge32
+    ctpcRxCallLostPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.15
+      name: cisco.ctpcRxCallLostPackets
+      syntax: Gauge32
+    ctpcRxOutOfOrderPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.16
+      name: cisco.ctpcRxOutOfOrderPackets
+      syntax: Counter64
+    ctpcRxDuplicatePackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.17
+      name: cisco.ctpcRxDuplicatePackets
+      syntax: Counter64
+    ctpcRxLatePackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.18
+      name: cisco.ctpcRxLatePackets
+      syntax: Counter64
+    ctpcRxIDRPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.19
+      name: cisco.ctpcRxIDRPackets
+      syntax: Counter64
+    ctpcRxShapingWindow:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.20
+      name: cisco.ctpcRxShapingWindow
+      syntax: TicksMilliSec
+    ctpcRxCallAuthFailure:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.21
+      name: cisco.ctpcRxCallAuthFailure
+      syntax: Counter64
+    ctpcAvgPeriodJitter:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.22
+      name: cisco.ctpcAvgPeriodJitter
+      syntax: TicksMilliSec
+    ctpcAvgCallJitter:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.23
+      name: cisco.ctpcAvgCallJitter
+      syntax: TicksMilliSec
+    ctpcMaxPeriodJitter:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.24
+      name: cisco.ctpcMaxPeriodJitter
+      syntax: TicksMilliSec
+    ctpcMaxCallJitter:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.25
+      name: cisco.ctpcMaxCallJitter
+      syntax: TicksMilliSec
+    ctpcMaxCallJitterRecTime:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.26
+      name: cisco.ctpcMaxCallJitterRecTime
+      syntax: TicksSec
+    ctpcTxCodec:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.27
+      name: cisco.ctpcTxCodec
+      syntax: EnumInteger
+    ctpcTxFrameRate:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.28
+      name: cisco.ctpcTxFrameRate
+      syntax: Unsigned32
+    ctpcRxCodec:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.29
+      name: cisco.ctpcRxCodec
+      syntax: EnumInteger
+    ctpcRxFrameRate:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.30
+      name: cisco.ctpcRxFrameRate
+      syntax: Unsigned32
+    ctpcTxVideoHorzPixels:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.31
+      name: cisco.ctpcTxVideoHorzPixels
+      syntax: Gauge32
+    ctpcTxVideoVertPixels:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.32
+      name: cisco.ctpcTxVideoVertPixels
+      syntax: Gauge32
+    ctpcRxVideoHorzPixels:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.33
+      name: cisco.ctpcRxVideoHorzPixels
+      syntax: Gauge32
+    ctpcRxVideoVertPixels:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.34
+      name: cisco.ctpcRxVideoVertPixels
+      syntax: Gauge32
+    ctpcTxCallBitRate:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.35
+      name: cisco.ctpcTxCallBitRate
+      syntax: BandwidthKBits
+    ctpcTxPeriodBitRate:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.36
+      name: cisco.ctpcTxPeriodBitRate
+      syntax: BandwidthKBits
+    ctpcRxCallBitRate:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.37
+      name: cisco.ctpcRxCallBitRate
+      syntax: BandwidthKBits
+    ctpcRxPeriodBitRate:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.38
+      name: cisco.ctpcRxPeriodBitRate
+      syntax: BandwidthKBits
+    ctpcRxMaxPeriodLostPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.39
+      name: cisco.ctpcRxMaxPeriodLostPackets
+      syntax: Gauge32
+    ctpcRxMaxCallLostPackets:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.40
+      name: cisco.ctpcRxMaxCallLostPackets
+      syntax: Gauge32
+    ctpcRxMaxCallLostPacketsRecTime:
+      oid: .1.3.6.1.4.1.9.9.644.1.4.10.1.41
+      name: cisco.ctpcRxMaxCallLostPacketsRecTime
+      syntax: TicksSec
+
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcStatEventHistory:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcStatEventHistory
+#   discovery_attribute: ctpcStatEventHistTableSize
+#   attributes:
+#     ctpcStatEventHistTableSize:
+#       oid: .1.3.6.1.4.1.9.9.644.1.5.1
+#       name: cisco.ctpcStatEventHistTableSize
+#       syntax: Unsigned32
+#     ctpcStatEventHistLastIndex:
+#       oid: .1.3.6.1.4.1.9.9.644.1.5.2
+#       name: cisco.ctpcStatEventHistLastIndex
+#       syntax: Unsigned32
+
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcStatEventHistoryEntry:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcStatEventHistoryEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.644.1.5.3.1.1
+#       name: cisco.ctpcStatEventHistoryIndex
+#       syntax: Unsigned32
+#   discovery_attribute: ctpcStatEventMonObjectInst
+#   attributes:
+#     ctpcStatEventMonObjectInst:
+#       oid: .1.3.6.1.4.1.9.9.644.1.5.3.1.2
+#       name: cisco.ctpcStatEventMonObjectInst
+#       syntax: VariablePointer
+#     ctpcStatEventCrossedValue:
+#       oid: .1.3.6.1.4.1.9.9.644.1.5.3.1.3
+#       name: cisco.ctpcStatEventCrossedValue
+#       syntax: Counter64 # Unsigned64
+#     ctpcStatEventCrossedType:
+#       oid: .1.3.6.1.4.1.9.9.644.1.5.3.1.4
+#       name: cisco.ctpcStatEventCrossedType
+#       syntax: EnumInteger
+#     ctpcStatEventTimeStamp:
+#       oid: .1.3.6.1.4.1.9.9.644.1.5.3.1.5
+#       name: cisco.ctpcStatEventTimeStamp
+#       syntax: TimeTicks
+
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcMgmtSysConnEventHistory:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcMgmtSysConnEventHistory
+#   discovery_attribute: ctpcMgmtSysConnEventHistTableSize
+#   attributes:
+#     ctpcMgmtSysConnEventHistTableSize:
+#       oid: .1.3.6.1.4.1.9.9.644.1.6.1
+#       name: cisco.ctpcMgmtSysConnEventHistTableSize
+#       syntax: Unsigned32
+#     ctpcMgmtSysConnEventHistLastIndex:
+#       oid: .1.3.6.1.4.1.9.9.644.1.6.2
+#       name: cisco.ctpcMgmtSysConnEventHistLastIndex
+#       syntax: Unsigned32
+
+# CISCO-TELEPRESENCE-CALL-MIB::ctpcMgmtSysConnEventHistoryEntry:
+#   mib: CISCO-TELEPRESENCE-CALL-MIB
+#   object: ctpcMgmtSysConnEventHistoryEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.644.1.6.3.1.1
+#       name: cisco.ctpcMgmtSysConnEventHistoryIndex
+#       syntax: Unsigned32
+#   discovery_attribute: ctpcMgmtSysConnEventStatus
+#   attributes:
+#     ctpcMgmtSysConnEventStatus:
+#       oid: .1.3.6.1.4.1.9.9.644.1.6.3.1.2
+#       name: cisco.ctpcMgmtSysConnEventStatus
+#       syntax: EnumInteger
+#     ctpcMgmtSysConnEventSIPRespCode:
+#       oid: .1.3.6.1.4.1.9.9.644.1.6.3.1.3
+#       name: cisco.ctpcMgmtSysConnEventSIPRespCode
+#       syntax: Unsigned32
+#     ctpcMgmtSysConnEventTimeStamp:
+#       oid: .1.3.6.1.4.1.9.9.644.1.6.3.1.4
+#       name: cisco.ctpcMgmtSysConnEventTimeStamp
+#       syntax: TimeTicks

--- a/objects/cisco/CISCO-TELEPRESENCE-MIB.yml
+++ b/objects/cisco/CISCO-TELEPRESENCE-MIB.yml
@@ -1,0 +1,340 @@
+CISCO-TELEPRESENCE-MIB::ctpObjects:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctpObjects
+  discovery_attribute: ctpPeripheralErrorNotifyEnable
+  attributes:
+    ctpPeripheralErrorNotifyEnable:
+      oid: .1.3.6.1.4.1.9.9.643.1.1.1
+      name: cisco.ctpPeripheralErrorNotifyEnable
+      syntax: TruthValue
+    ctpSysUserAuthFailNotifyEnable:
+      oid: .1.3.6.1.4.1.9.9.643.1.1.2
+      name: cisco.ctpSysUserAuthFailNotifyEnable
+      syntax: TruthValue
+    ctpSystemReset:
+      oid: .1.3.6.1.4.1.9.9.643.1.1.3
+      name: cisco.ctpSystemReset
+      syntax: EnumInteger
+    ctpPeriStatusChangeNotifyEnable:
+      oid: .1.3.6.1.4.1.9.9.643.1.1.4
+      name: cisco.ctpPeriStatusChangeNotifyEnable
+      syntax: TruthValue
+    ctpVlanId:
+      oid: .1.3.6.1.4.1.9.9.643.1.1.5
+      name: cisco.ctpVlanId
+      syntax: Unsigned32
+    ctpDefaultGateway:
+      oid: .1.3.6.1.4.1.9.9.643.1.1.7
+      name: cisco.ctpDefaultGateway
+      syntax: IpAddressNoSuffix # InetAddress
+
+CISCO-TELEPRESENCE-MIB::ctpPeripheralStatusEntry:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctpPeripheralStatusEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.1
+      name: cisco.ctpPeripheralIndex
+      syntax: Unsigned32
+  discovery_attribute: ctpPeripheralDescription
+  attributes:
+    ctpPeripheralDescription:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.2
+      name: cisco.ctpPeripheralDescription
+      syntax: DisplayString # SnmpAdminString
+    ctpPeripheralStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.3
+      name: cisco.ctpPeripheralStatus
+      syntax: EnumInteger
+    ctpPeripheralDeviceCategory:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.4
+      name: cisco.ctpPeripheralDeviceCategory
+      syntax: EnumInteger
+    ctpPeripheralDeviceNumber:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.5
+      name: cisco.ctpPeripheralDeviceNumber
+      syntax: Unsigned32
+
+CISCO-TELEPRESENCE-MIB::ctpEtherPeripheralStatusEntry:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctpEtherPeripheralStatusEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.1
+      name: cisco.ctpPeripheralIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.2.1.1
+      name: cisco.ctpEtherPeripheralIndex
+      syntax: Unsigned32
+  discovery_attribute: ctpEtherPeripheralIfIndex
+  attributes:
+    ctpEtherPeripheralIfIndex:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.2.1.2
+      name: cisco.ctpEtherPeripheralIfIndex
+      syntax: InterfaceIndexOrZero
+    ctpEtherPeripheralAddr:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.2.1.4
+      name: cisco.ctpEtherPeripheralAddr
+      syntax: IpAddressNoSuffix # InetAddress
+    ctpEtherPeripheralStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.2.1.5
+      name: cisco.ctpEtherPeripheralStatus
+      syntax: EnumInteger
+
+CISCO-TELEPRESENCE-MIB::ctpHDMIPeripheralStatusEntry:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctpHDMIPeripheralStatusEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.1
+      name: cisco.ctpPeripheralIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.3.1.1
+      name: cisco.ctpHDMIPeripheralIndex
+      syntax: Unsigned32
+  discovery_attribute: ctpHDMIPeripheralCableStatus
+  attributes:
+    ctpHDMIPeripheralCableStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.3.1.2
+      name: cisco.ctpHDMIPeripheralCableStatus
+      syntax: EnumInteger
+    ctpHDMIPeripheralPowerStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.3.1.3
+      name: cisco.ctpHDMIPeripheralPowerStatus
+      syntax: EnumInteger
+
+CISCO-TELEPRESENCE-MIB::ctpDVIPeripheralStatusEntry:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctpDVIPeripheralStatusEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.1
+      name: cisco.ctpPeripheralIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.4.1.1
+      name: cisco.ctpDVIPeripheralIndex
+      syntax: Unsigned32
+  discovery_attribute: ctpDVIPeripheralCableStatus
+  attributes:
+    ctpDVIPeripheralCableStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.4.1.2
+      name: cisco.ctpDVIPeripheralCableStatus
+      syntax: EnumInteger
+
+CISCO-TELEPRESENCE-MIB::ctpRS232PeripheralStatusEntry:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctpRS232PeripheralStatusEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.1
+      name: cisco.ctpPeripheralIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.5.1.1
+      name: cisco.ctpRS232PeripheralIndex
+      syntax: Unsigned32
+  discovery_attribute: ctpRS232PortIndex
+  attributes:
+    ctpRS232PortIndex:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.5.1.2
+      name: cisco.ctpRS232PortIndex
+      syntax: InterfaceIndexOrZero
+    ctpRS232PeripheralConnStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.5.1.3
+      name: cisco.ctpRS232PeripheralConnStatus
+      syntax: EnumInteger
+
+CISCO-TELEPRESENCE-MIB::ctpPeripheralAttributeEntry:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctpPeripheralAttributeEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.1
+      name: cisco.ctpPeripheralIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.6.1.1
+      name: cisco.ctpPeripheralAttributeIndex
+      syntax: Unsigned32
+  discovery_attribute: ctpPeripheralAttributeDescr
+  attributes:
+    ctpPeripheralAttributeDescr:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.6.1.2
+      name: cisco.ctpPeripheralAttributeDescr
+      syntax: EnumInteger
+    ctpPeripheralAttributeValue:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.6.1.3
+      name: cisco.ctpPeripheralAttributeValue
+      syntax: Unsigned32
+
+CISCO-TELEPRESENCE-MIB::ctpUSBPeripheralStatusEntry:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctpUSBPeripheralStatusEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.1
+      name: cisco.ctpPeripheralIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.7.1.1
+      name: cisco.ctpUSBPeripheralIndex
+      syntax: Unsigned32
+  discovery_attribute: ctpUSBPeripheralCableStatus
+  attributes:
+    ctpUSBPeripheralCableStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.7.1.2
+      name: cisco.ctpUSBPeripheralCableStatus
+      syntax: EnumInteger
+    ctpUSBPeripheralPowerStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.7.1.3
+      name: cisco.ctpUSBPeripheralPowerStatus
+      syntax: EnumInteger
+    ctpUSBPeripheralPortType:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.7.1.4
+      name: cisco.ctpUSBPeripheralPortType
+      syntax: EnumInteger
+    ctpUSBPeripheralPortRate:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.7.1.5
+      name: cisco.ctpUSBPeripheralPortRate
+      syntax: EnumInteger
+
+CISCO-TELEPRESENCE-MIB::ctp802dot11PeripheralStatusEntry:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctp802dot11PeripheralStatusEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.1
+      name: cisco.ctpPeripheralIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.8.1.1
+      name: cisco.ctp802dot11PeripheralIndex
+      syntax: Unsigned32
+  discovery_attribute: ctp802dot11PeripheralIfIndex
+  attributes:
+    ctp802dot11PeripheralIfIndex:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.8.1.2
+      name: cisco.ctp802dot11PeripheralIfIndex
+      syntax: InterfaceIndexOrZero
+    ctp802dot11PeripheralAddr:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.8.1.4
+      name: cisco.ctp802dot11PeripheralAddr
+      syntax: IpAddressNoSuffix # InetAddress
+    ctp802dot11PeripheralLinkStrength:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.8.1.5
+      name: cisco.ctp802dot11PeripheralLinkStrength
+      syntax: Unsigned32
+    ctp802dot11PeripheralLinkStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.8.1.6
+      name: cisco.ctp802dot11PeripheralLinkStatus
+      syntax: EnumInteger
+
+CISCO-TELEPRESENCE-MIB::ctpDPPeripheralStatusEntry:
+  mib: CISCO-TELEPRESENCE-MIB
+  object: ctpDPPeripheralStatusEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.1.1.1
+      name: cisco.ctpPeripheralIndex
+      syntax: Unsigned32
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.643.1.2.9.1.1
+      name: cisco.ctpDPPeripheralIndex
+      syntax: Unsigned32
+  discovery_attribute: ctpDPPeripheralCableStatus
+  attributes:
+    ctpDPPeripheralCableStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.9.1.2
+      name: cisco.ctpDPPeripheralCableStatus
+      syntax: EnumInteger
+    ctpDPPeripheralPowerStatus:
+      oid: .1.3.6.1.4.1.9.9.643.1.2.9.1.3
+      name: cisco.ctpDPPeripheralPowerStatus
+      syntax: EnumInteger
+
+# CISCO-TELEPRESENCE-MIB::ctpEventHistory:
+#   mib: CISCO-TELEPRESENCE-MIB
+#   object: ctpEventHistory
+#   discovery_attribute: ctpPeripheralErrorHistTableSize
+#   attributes:
+#     ctpPeripheralErrorHistTableSize:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.1
+#       name: cisco.ctpPeripheralErrorHistTableSize
+#       syntax: Unsigned32
+#     ctpPeripheralErrorHistLastIndex:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.2
+#       name: cisco.ctpPeripheralErrorHistLastIndex
+#       syntax: Unsigned32
+#     ctpSysUserAuthFailHistTableSize:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.4
+#       name: cisco.ctpSysUserAuthFailHistTableSize
+#       syntax: Unsigned32
+#     ctpSysUserAuthFailHistLastIndex:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.5
+#       name: cisco.ctpSysUserAuthFailHistLastIndex
+#       syntax: Unsigned32
+
+# CISCO-TELEPRESENCE-MIB::ctpPeripheralErrorHistoryEntry:
+#   mib: CISCO-TELEPRESENCE-MIB
+#   object: ctpPeripheralErrorHistoryEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.3.1.1
+#       name: cisco.ctpPeripheralErrorHistoryIndex
+#       syntax: Unsigned32
+#   discovery_attribute: ctpPeripheralErrorIndex
+#   attributes:
+#     ctpPeripheralErrorIndex:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.3.1.2
+#       name: cisco.ctpPeripheralErrorIndex
+#       syntax: Unsigned32
+#     ctpPeripheralErrorStatus:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.3.1.3
+#       name: cisco.ctpPeripheralErrorStatus
+#       syntax: EnumInteger
+#     ctpPeripheralErrorTimeStamp:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.3.1.4
+#       name: cisco.ctpPeripheralErrorTimeStamp
+#       syntax: TimeStamp
+#     ctpPeripheralErrorDeviceCategory:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.3.1.5
+#       name: cisco.ctpPeripheralErrorDeviceCategory
+#       syntax: EnumInteger
+#     ctpPeripheralErrorDeviceNumber:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.3.1.6
+#       name: cisco.ctpPeripheralErrorDeviceNumber
+#       syntax: Unsigned32
+
+# CISCO-TELEPRESENCE-MIB::ctpSysUserAuthFailHistoryEntry:
+#   mib: CISCO-TELEPRESENCE-MIB
+#   object: ctpSysUserAuthFailHistoryEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.6.1.1
+#       name: cisco.ctpSysUserAuthFailHistoryIndex
+#       syntax: Unsigned32
+#   discovery_attribute: ctpSysUserAuthFailSourceAddr
+#   attributes:
+#     ctpSysUserAuthFailSourceAddr:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.6.1.3
+#       name: cisco.ctpSysUserAuthFailSourceAddr
+#       syntax: IpAddressNoSuffix # InetAddress
+#     ctpSysUserAuthFailSourcePort:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.6.1.4
+#       name: cisco.ctpSysUserAuthFailSourcePort
+#       syntax: Unsigned32
+#     ctpSysUserAuthFailUserName:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.6.1.5
+#       name: cisco.ctpSysUserAuthFailUserName
+#       syntax: DisplayString # SnmpAdminString
+#     ctpSysUserAuthFailAccessProtocol:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.6.1.6
+#       name: cisco.ctpSysUserAuthFailAccessProtocol
+#       syntax: EnumInteger
+#     ctpSysUserAuthFailTimeStamp:
+#       oid: .1.3.6.1.4.1.9.9.643.1.3.6.1.7
+#       name: cisco.ctpSysUserAuthFailTimeStamp
+#       syntax: TimeStamp

--- a/objects/cisco/CISCO-UNITY-MIB.yml
+++ b/objects/cisco/CISCO-UNITY-MIB.yml
@@ -1,0 +1,171 @@
+# CISCO-UNITY-MIB::ciscoUnityEntry:
+#   mib: CISCO-UNITY-MIB
+#   object: ciscoUnityEntry
+#   index:
+#     - type: Unsigned32
+#       oid: .1.3.6.1.4.1.9.9.385.1.1.1.1.1
+#       name: cisco.unityIndex
+#       syntax: Unsigned32 # CiscoUnityIndex
+#   discovery_attribute: ciscoUnityName
+#   attributes:
+#     ciscoUnityName:
+#       oid: .1.3.6.1.4.1.9.9.385.1.1.1.1.2
+#       name: cisco.unityName
+#       syntax: DisplayString # SnmpAdminString
+#     ciscoUnityVersion:
+#       oid: .1.3.6.1.4.1.9.9.385.1.1.1.1.3
+#       name: cisco.unityVersion
+#       syntax: DisplayString # SnmpAdminString
+
+CISCO-UNITY-MIB::ciscoUnityPortEntry:
+  mib: CISCO-UNITY-MIB
+  object: ciscoUnityPortEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.1
+      name: cisco.unityPortIndex
+      syntax: Unsigned32 # CiscoUnityIndex
+  discovery_attribute: ciscoUnityPortNumber
+  attributes:
+    ciscoUnityPortNumber:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.2
+      name: cisco.unityPortNumber
+      syntax: Unsigned32
+    ciscoUnityPortIntegration:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.3
+      name: cisco.unityPortIntegration
+      syntax: DisplayString # SnmpAdminString
+    ciscoUnityPortExtension:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.4
+      name: cisco.unityPortExtension
+      syntax: DisplayString # SnmpAdminString
+    ciscoUnityPortEnabled:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.5
+      name: cisco.unityPortEnabled
+      syntax: TruthValue
+    ciscoUnityPortAnswerCalls:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.6
+      name: cisco.unityPortAnswerCalls
+      syntax: TruthValue
+    ciscoUnityPortMessageNotif:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.7
+      name: cisco.unityPortMessageNotif
+      syntax: TruthValue
+    ciscoUnityPortDialoutMWI:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.8
+      name: cisco.unityPortDialoutMWI
+      syntax: TruthValue
+    ciscoUnityPortAMISDelivery:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.9
+      name: cisco.unityPortAMISDelivery
+      syntax: TruthValue
+    ciscoUnityPortTRAPConnection:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.10
+      name: cisco.unityPortTRAPConnection
+      syntax: TruthValue
+    ciscoUnityPortActivity:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.11
+      name: cisco.unityPortActivity
+      syntax: DisplayString # SnmpAdminString
+    ciscoUnityPortObjectId:
+      oid: .1.3.6.1.4.1.9.9.385.1.1.2.1.12
+      name: cisco.unityPortObjectId
+      syntax: DisplayString # SnmpAdminString
+
+CISCO-UNITY-MIB::ciscoUnityGlobalInfo:
+  mib: CISCO-UNITY-MIB
+  object: ciscoUnityGlobalInfo
+  discovery_attribute: ciscoUnityServerState
+  attributes:
+    ciscoUnityServerState:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.1
+      name: cisco.unityServerState
+      syntax: EnumInteger
+    ciscoUnityPorts:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.2
+      name: cisco.unityPorts
+      syntax: Unsigned32
+    ciscoUnityPortsActive:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.3
+      name: cisco.unityPortsActive
+      syntax: Unsigned32
+    ciscoUnityPortsInbound:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.4
+      name: cisco.unityPortsInbound
+      syntax: Unsigned32
+    ciscoUnityPortsInboundActive:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.5
+      name: cisco.unityPortsInboundActive
+      syntax: Unsigned32
+    ciscoUnityPortsOutbound:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.6
+      name: cisco.unityPortsOutbound
+      syntax: Unsigned32
+    ciscoUnityPortsOutboundActive:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.7
+      name: cisco.unityPortsOutboundActive
+      syntax: Unsigned32
+    ciscoUnityLicLanguagesMax:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.8
+      name: cisco.unityLicLanguagesMax
+      syntax: Unsigned32
+    ciscoUnityLicTTSSessionsMax:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.9
+      name: cisco.unityLicTTSSessionsMax
+      syntax: Unsigned32
+    ciscoUnityLicSubscribersMax:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.10
+      name: cisco.unityLicSubscribersMax
+      syntax: Unsigned32
+    ciscoUnityLicUMSubscribersMax:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.11
+      name: cisco.unityLicUMSubscribersMax
+      syntax: Unsigned32
+    ciscoUnityLicVMISubscribersMax:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.12
+      name: cisco.unityLicVMISubscribersMax
+      syntax: Unsigned32
+    ciscoUnityLicVoicePortsMax:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.13
+      name: cisco.unityLicVoicePortsMax
+      syntax: Unsigned32
+    ciscoUnityLicBridgeSessionsMax:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.14
+      name: cisco.unityLicBridgeSessionsMax
+      syntax: Unsigned32
+    ciscoUnityLicAMISIsLicensed:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.15
+      name: cisco.unityLicAMISIsLicensed
+      syntax: TruthValue
+    ciscoUnityLicMaxMsgRecLenIsLic:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.16
+      name: cisco.unityLicMaxMsgRecLenIsLic
+      syntax: TruthValue
+    ciscoUnityLicPoolingIsEnabled:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.17
+      name: cisco.unityLicPoolingIsEnabled
+      syntax: TruthValue
+    ciscoUnityLicVPIMIsLicensed:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.18
+      name: cisco.unityLicVPIMIsLicensed
+      syntax: TruthValue
+    ciscoUnityLicPrimaryServerIsLic:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.19
+      name: cisco.unityLicPrimaryServerIsLic
+      syntax: TruthValue
+    ciscoUnityLicSecondServerIsLic:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.20
+      name: cisco.unityLicSecondServerIsLic
+      syntax: TruthValue
+    ciscoUnityLicUtilSecondServer:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.21
+      name: cisco.unityLicUtilSecondServer
+      syntax: Unsigned32
+    ciscoUnityLicUtilSubs:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.22
+      name: cisco.unityLicUtilSubs
+      syntax: Unsigned32
+    ciscoUnityLicUtilVMISubs:
+      oid: .1.3.6.1.4.1.9.9.385.1.2.23
+      name: cisco.unityLicUtilVMISubs
+      syntax: Unsigned32

--- a/objects/cisco/CISCO-VOICE-APPS-MIB.yml
+++ b/objects/cisco/CISCO-VOICE-APPS-MIB.yml
@@ -1,0 +1,26 @@
+CISCO-VOICE-APPS-MIB::cvaWorkflowInstallEntry:
+  mib: CISCO-VOICE-APPS-MIB
+  object: cvaWorkflowInstallEntry
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.190.1.1.1.1.1
+      name: cvaWorkflowInstallIndex
+      syntax: Unsigned32
+  discovery_attribute: cvaWorkflowInstallName
+  attributes:
+    cvaWorkflowInstallName:
+      oid: .1.3.6.1.4.1.9.9.190.1.1.1.1.2
+      name: cvaWorkflowInstallName
+      syntax: DisplayString # SnmpAdminString
+    cvaWorkflowInstallLocator:
+      oid: .1.3.6.1.4.1.9.9.190.1.1.1.1.3
+      name: cvaWorkflowInstallLocator
+      syntax: DisplayString # OctetString
+    cvaWorkflowInstallScriptName:
+      oid: .1.3.6.1.4.1.9.9.190.1.1.1.1.4
+      name: cvaWorkflowInstallScriptName
+      syntax: DisplayString # SnmpAdminString
+    cvaWorkflowInstallEnable:
+      oid: .1.3.6.1.4.1.9.9.190.1.1.1.1.5
+      name: cvaWorkflowInstallEnable
+      syntax: TruthValue


### PR DESCRIPTION
Added objects, object groups and device groups for...

- CISCO-CCM-MIB
- CISCO-CDP-MIB
- CISCO-SESSION-BORDER-CONTROLLER-EVENT-MIB
- CISCO-SESSION-BORDER-CONTROLLER-STATS-MIB
- CISCO-SIP-UA-MIB
- CISCO-SYSLOG-MIB
- CISCO-TELEPRESENCE-CALL-MIB
- CISCO-TELEPRESENCE-MIB
- CISCO-UNITY-MIB
- CISCO-VOICE-APPS-MIB

Definitions load successfully by `snmpcoll`.