### PR TITLE
Rename SysObjectID to DeviceGroupName and update references

### DIFF
--- a/cmd/validate/main.go
+++ b/cmd/validate/main.go
@@ -36,11 +36,11 @@ func main() {
 		log.Printf("Validated %d oid enums", len(oidEnums))
 	}
 
-	sysObjectIDs, sysErr := reader.Read[def.SysObjectID]("autodiscover")
+	sysObjectIDMapping, sysErr := reader.Read[def.DeviceGroupName]("autodiscover")
 	if sysErr != nil {
 		log.Println(sysErr)
 	} else {
-		log.Printf("Validated %d sysObjectID", len(sysObjectIDs))
+		log.Printf("Validated %d sysObjectIDs", len(sysObjectIDMapping))
 	}
 
 	if enterprisesErr != nil || defErr != nil || enumErr != nil || sysErr != nil {

--- a/pkg/def/devicegroup.go
+++ b/pkg/def/devicegroup.go
@@ -14,15 +14,15 @@ func (d DeviceGroup) Type() string {
 	return "device_group"
 }
 
-// SysObjectID is a string that represents the device group for a specific sysObjectID.
-type SysObjectID string
+// DeviceGroupName is a string that represents the name of a device group.
+type DeviceGroupName string
 
-func (s SysObjectID) Type() string {
-	return "sys_object_id"
+func (d DeviceGroupName) Type() string {
+	return "device_group"
 }
 
-func (s SysObjectID) Validate() error {
-	if s == "" {
+func (d DeviceGroupName) Validate() error {
+	if d == "" {
 		return fmt.Errorf("device group cannot be empty")
 	}
 	return nil

--- a/pkg/def/devicegroup_test.go
+++ b/pkg/def/devicegroup_test.go
@@ -41,32 +41,32 @@ func TestDeviceGroup_Type(t *testing.T) {
 	assert.Equal(t, "device_group", deviceGroup.Type())
 }
 
-func TestSysObjectID_Type(t *testing.T) {
-	sysObjectID := SysObjectID("sysObjectID")
-	assert.Equal(t, "sys_object_id", sysObjectID.Type())
+func TestDeviceGroupName_Type(t *testing.T) {
+	dg := DeviceGroupName("device_group")
+	assert.Equal(t, "device_group", dg.Type())
 }
 
 func TestSysObjectID_Validate(t *testing.T) {
 	tests := []struct {
-		name        string
-		sysObjectID SysObjectID
-		expected    error
+		name            string
+		deviceGroupName DeviceGroupName
+		expected        error
 	}{
 		{
-			name:        "valid sysObjectID",
-			sysObjectID: SysObjectID("sysObjectID"),
-			expected:    nil,
+			name:            "valid deviceGroupName",
+			deviceGroupName: DeviceGroupName("deviceGroupName"),
+			expected:        nil,
 		},
 		{
-			name:        "empty sysObjectID",
-			sysObjectID: SysObjectID(""),
-			expected:    fmt.Errorf("device group cannot be empty"),
+			name:            "empty deviceGroupName",
+			deviceGroupName: DeviceGroupName(""),
+			expected:        fmt.Errorf("device group cannot be empty"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.sysObjectID.Validate())
+			assert.Equal(t, tt.expected, tt.deviceGroupName.Validate())
 		})
 	}
 }


### PR DESCRIPTION
Replaced the SysObjectID type with DeviceGroupName for clearer semantics. Adjusted all related methods, validations, and test cases to reflect the new name. Updated relevant parts of the validation logic to ensure consistent usage of the renamed type.