### PR TITLE
Add ValidateDevices to export device validation

### DIFF
--- a/pkg/def/device.go
+++ b/pkg/def/device.go
@@ -1,5 +1,34 @@
 package def
 
+import (
+	"fmt"
+	"strings"
+)
+
+func ValidateDevices(d map[string]Device) error {
+	invalidDefinitions := make([]string, 0)
+
+	// Ensure every device has a unique IP address.
+	for deviceName, device := range d {
+		for otherDeviceName, otherDevice := range d {
+			if deviceName != otherDeviceName && device.IP == otherDevice.IP {
+				errorMsg := fmt.Sprintf("device %s has the same IP address (%s) as device %s", deviceName, device.IP, otherDeviceName)
+				invalidDefinitions = append(invalidDefinitions, errorMsg)
+			}
+		}
+	}
+
+	if len(invalidDefinitions) > 0 {
+		return fmt.Errorf("found %d invalid device definitions:\n%s",
+			len(invalidDefinitions),
+			strings.Join(invalidDefinitions, "\n"),
+		)
+
+	}
+
+	return nil
+}
+
 type Device struct {
 	IP                 string         `yaml:"ip,omitempty" json:"ip,omitempty"`
 	Port               uint16         `yaml:"port,omitempty" json:"port,omitempty"`

--- a/pkg/def/device_test.go
+++ b/pkg/def/device_test.go
@@ -1,10 +1,66 @@
 package def
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestValidateDevices(t *testing.T) {
+	tests := []struct {
+		name     string
+		devices  map[string]Device
+		expected error
+	}{
+		{
+			name: "valid devices",
+			devices: map[string]Device{
+				"device1": {
+					IP: "192.168.1.1",
+				},
+				"device2": {
+					IP: "192.168.1.2",
+				},
+			},
+		},
+		{
+			name: "duplicate IP addresses",
+			devices: map[string]Device{
+				"device1": {
+					IP: "192.168.1.1",
+				},
+				"device2": {
+					IP: "192.168.1.1", // Same IP as device1
+				},
+			},
+			expected: fmt.Errorf("found 2 invalid device definitions:\ndevice device1 has the same IP address (192.168.1.1) as device device2\ndevice device2 has the same IP address (192.168.1.1) as device device1"),
+		},
+		{
+			name:    "empty device map",
+			devices: map[string]Device{},
+		},
+		{
+			name: "single device",
+			devices: map[string]Device{
+				"device1": {
+					IP: "192.168.1.1",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDevices(tt.devices)
+			if tt.expected == nil {
+				assert.Nil(t, err)
+			} else {
+				assert.Equal(t, tt.expected.Error(), err.Error())
+			}
+		})
+	}
+}
 
 func TestDevice_Validate(t *testing.T) {
 	tests := []struct {

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -175,17 +175,12 @@ func validateSNMPDefinitions(
 	objectGroups map[string]def.ObjectGroup,
 	objects map[string]def.Object,
 ) error {
-	invalidDefinitions := make([]string, 0)
-
-	// Ensure every device has a unique IP address.
-	for deviceName, device := range devices {
-		for otherDeviceName, otherDevice := range devices {
-			if deviceName != otherDeviceName && device.IP == otherDevice.IP {
-				errorMsg := fmt.Sprintf("device %s has the same IP address (%s) as device %s", deviceName, device.IP, otherDeviceName)
-				invalidDefinitions = append(invalidDefinitions, errorMsg)
-			}
-		}
+	err := def.ValidateDevices(devices)
+	if err != nil {
+		return fmt.Errorf("failed to validate devices: %w", err)
 	}
+
+	invalidDefinitions := make([]string, 0)
 
 	// Ensure every object group in every device group is defined.
 	for deviceGroupName, deviceGroup := range deviceGroups {

--- a/pkg/reader/reader_test.go
+++ b/pkg/reader/reader_test.go
@@ -291,7 +291,7 @@ func TestValidateSNMPDefinitions(t *testing.T) {
 			objects: map[string]def.Object{
 				"object1": {},
 			},
-			wantErr: "device device2 has the same IP address (192.168.1.1) as device device1",
+			wantErr: "failed to validate devices: found 2 invalid device definitions:\ndevice device1 has the same IP address (192.168.1.1) as device device2",
 		},
 		{
 			name: "undefined object group",
@@ -343,9 +343,6 @@ func TestValidateSNMPDefinitions(t *testing.T) {
 				"device1": {
 					IP: "192.168.1.1",
 				},
-				"device2": {
-					IP: "192.168.1.1", // Same IP as device1
-				},
 			},
 			deviceGroups: map[string]def.DeviceGroup{
 				"device_group1": {
@@ -360,7 +357,7 @@ func TestValidateSNMPDefinitions(t *testing.T) {
 			objects: map[string]def.Object{
 				"object1": {},
 			},
-			wantErr: "found 4 invalid definitions",
+			wantErr: "found 2 invalid definitions:",
 		},
 	}
 


### PR DESCRIPTION
Introduced the `ValidateDevices` function to ensure all devices have unique IP addresses. Updated relevant validation logic and tests to reflect this change, improving error reporting for duplicate IP scenarios.