### PR TITLE
Add "metric" field support for object attributes

### DIFF
--- a/pkg/def/object.go
+++ b/pkg/def/object.go
@@ -33,6 +33,8 @@ type ObjectAttribute struct {
 	Tag        bool                    `yaml:"tag,omitempty" json:"tag,omitempty"`
 	Name       string                  `yaml:"name,omitempty" json:"name,omitempty"`
 	Syntax     string                  `yaml:"syntax,omitempty" json:"syntax,omitempty"`
+	Semantics  string                  `yaml:"semantics,omitempty" json:"semantics,omitempty"`
+	Metric     string                  `yaml:"metric,omitempty" json:"metric,omitempty"`
 	Rediscover string                  `yaml:"rediscover,omitempty" json:"rediscover,omitempty"`
 	Overrides  ObjectAttributeOverride `yaml:"overrides,omitempty" json:"overrides,omitempty"`
 }

--- a/pkg/def/schemas/object.json
+++ b/pkg/def/schemas/object.json
@@ -423,6 +423,12 @@
                 "WavelengthNanoMeter"
               ]
             },
+            "metric": {
+              "enum": [
+                "gauge",
+                "counter"
+              ]
+            },
             "rediscover": {
               "enum": [
                 "OnReset",


### PR DESCRIPTION
This commit introduces a new "metric" field for object attributes, allowing enumeration of "gauge" and "counter" values. It updates schema definitions, object logic, and tests to validate the new field and handle potential errors during validation. This enhancement ensures improved metric handling within the object schema.