### PR TITLE
update IETF objects (Adding support for TSDS in snmpcoll)

### DIFF
--- a/objects/arista/ARISTA-BGP4V2-MIB.yml
+++ b/objects/arista/ARISTA-BGP4V2-MIB.yml
@@ -12,6 +12,7 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2DiscontinuityEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.1.1.1
       name: bgp.peer.discontinuity_time
       syntax: TimeStamp
+      metric: counter
 
 ARISTA-BGP4V2-MIB::aristaBgp4V2PeerEntry:
   mib: ARISTA-BGP4V2-MIB
@@ -94,6 +95,7 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2PeerErrorsEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.3.1.3
       name: bgp.peer.last_error.time.in
       syntax: TimeStamp
+      metric: counter
     aristaBgp4V2PeerLastErrorReceivedText:
       oid: .1.3.6.1.4.1.30065.4.1.1.3.1.4
       name: bgp.peer.last_error.text.in
@@ -114,6 +116,7 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2PeerErrorsEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.3.1.8
       name: bgp.peer.last_error.time.out
       syntax: TimeStamp
+      metric: counter
     aristaBgp4V2PeerLastErrorSentText:
       oid: .1.3.6.1.4.1.30065.4.1.1.3.1.9
       name: bgp.peer.last_error.text.out
@@ -133,10 +136,12 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2PeerEventTimesEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.4.1.1
       name: bgp.peer.fsm.established.duration
       syntax: Gauge32
+      metric: gauge
     aristaBgp4V2PeerInUpdatesElapsedTime:
       oid: .1.3.6.1.4.1.30065.4.1.1.4.1.2
       name: bgp.peer.last_update.elapsed
       syntax: Gauge32
+      metric: gauge
 
 ARISTA-BGP4V2-MIB::aristaBgp4V2PeerConfiguredTimersEntry:
   mib: ARISTA-BGP4V2-MIB
@@ -148,22 +153,27 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2PeerConfiguredTimersEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.5.1.1
       name: bgp.peer.connect_retry.config.interval
       syntax: Unsigned32
+      metric: gauge
     aristaBgp4V2PeerHoldTimeConfigured:
       oid: .1.3.6.1.4.1.30065.4.1.1.5.1.2
       name: bgp.peer.hold_time.config.interval
       syntax: Unsigned32
+      metric: gauge
     aristaBgp4V2PeerKeepAliveConfigured:
       oid: .1.3.6.1.4.1.30065.4.1.1.5.1.3
       name: bgp.peer.keep_alive.config.interval
       syntax: Unsigned32
+      metric: gauge
     aristaBgp4V2PeerMinASOrigInterval:
       oid: .1.3.6.1.4.1.30065.4.1.1.5.1.4
       name: bgp.peer.min_as_origin.config.interval
       syntax: Unsigned32
+      metric: gauge
     aristaBgp4V2PeerMinRouteAdverInterval:
       oid: .1.3.6.1.4.1.30065.4.1.1.5.1.5
       name: bgp.peer.min_route_advert.config.interval
       syntax: Unsigned32
+      metric: gauge
 
 ARISTA-BGP4V2-MIB::aristaBgp4V2PeerNegotiatedTimersEntry:
   mib: ARISTA-BGP4V2-MIB
@@ -175,10 +185,12 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2PeerNegotiatedTimersEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.6.1.1
       name: bgp.peer.hold_time.interval
       syntax: Unsigned32
+      metric: gauge
     aristaBgp4V2PeerKeepAlive:
       oid: .1.3.6.1.4.1.30065.4.1.1.6.1.2
       name: bgp.peer.keep_alive.interval
       syntax: Unsigned32
+      metric: gauge
 
 ARISTA-BGP4V2-MIB::aristaBgp4V2PeerCountersEntry:
   mib: ARISTA-BGP4V2-MIB
@@ -190,22 +202,27 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2PeerCountersEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.7.1.1
       name: bgp.peer.msgs.update.in
       syntax: Counter32
+      metric: counter
     aristaBgp4V2PeerOutUpdates:
       oid: .1.3.6.1.4.1.30065.4.1.1.7.1.2
       name: bgp.peer.msgs.update.out
       syntax: Counter32
+      metric: counter
     aristaBgp4V2PeerInTotalMessages:
       oid: .1.3.6.1.4.1.30065.4.1.1.7.1.3
       name: bgp.peer.msgs.in
       syntax: Counter32
+      metric: counter
     aristaBgp4V2PeerOutTotalMessages:
       oid: .1.3.6.1.4.1.30065.4.1.1.7.1.4
       name: bgp.peer.msgs.out
       syntax: Counter32
+      metric: counter
     aristaBgp4V2PeerFsmEstablishedTransitions:
       oid: .1.3.6.1.4.1.30065.4.1.1.7.1.5
       name: bgp.peer.fsm.established.transitions
       syntax: Counter32
+      metric: counter
 
 ARISTA-BGP4V2-MIB::aristaBgp4V2PrefixGaugesEntry:
   mib: ARISTA-BGP4V2-MIB
@@ -237,14 +254,17 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2PrefixGaugesEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.8.1.3
       name: bgp.prefixes.in
       syntax: Gauge32
+      metric: gauge
     aristaBgp4V2PrefixInPrefixesAccepted:
       oid: .1.3.6.1.4.1.30065.4.1.1.8.1.4
       name: bgp.prefixes.accept.in
       syntax: Gauge32
+      metric: gauge
     aristaBgp4V2PrefixOutPrefixes:
       oid: .1.3.6.1.4.1.30065.4.1.1.8.1.5
       name: bgp.prefixes.out
       syntax: Gauge32
+      metric: gauge
 
 ARISTA-BGP4V2-MIB::aristaBgp4V2NlriEntry:
   mib: ARISTA-BGP4V2-MIB
@@ -296,6 +316,7 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2NlriEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.9.1.8
       name: bgp.nlri.local_pref_calc
       syntax: Unsigned32
+      metric: gauge
     aristaBgp4V2NlriOrigin:
       oid: .1.3.6.1.4.1.30065.4.1.1.9.1.9
       name: bgp.nlri.path_attr.origin.type
@@ -312,10 +333,12 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2NlriEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.9.1.15
       name: bgp.nlri.path_attr.local_pref
       syntax: Unsigned32
+      metric: gauge
     aristaBgp4V2NlriMed:
       oid: .1.3.6.1.4.1.30065.4.1.1.9.1.17
       name: bgp.nlri.path_attr.med
       syntax: Unsigned32
+      metric: gauge
     aristaBgp4V2NlriAtomicAggregate:
       oid: .1.3.6.1.4.1.30065.4.1.1.9.1.18
       name: bgp.nlri.path_attr.atomic_aggregate
@@ -332,6 +355,7 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2NlriEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.9.1.22
       name: bgp.as_path.hop_count
       syntax: Unsigned32
+      metric: gauge
     aristaBgp4V2NlriAsPathString:
       oid: .1.3.6.1.4.1.30065.4.1.1.9.1.23
       name: bgp.as_path.path
@@ -371,7 +395,9 @@ ARISTA-BGP4V2-MIB::aristaBgp4V2PrefixEvpnNlriGaugesEntry:
       oid: .1.3.6.1.4.1.30065.4.1.1.11.1.2
       name: bgp.evpn_nlri.prefixes.in
       syntax: Gauge32
+      metric: gauge
     aristaBgp4V2PrefixNlriInPrefixesAccepted:
       oid: .1.3.6.1.4.1.30065.4.1.1.11.1.3
       name: bgp.evpn_nlri.prefixes.accept.in
       syntax: Gauge32
+      metric: gauge

--- a/objects/cisco/CISCO-BGP4-MIB.yml
+++ b/objects/cisco/CISCO-BGP4-MIB.yml
@@ -89,26 +89,32 @@ CISCO-BGP4-MIB::cbgpPeerEntry:
       oid: .1.3.6.1.4.1.9.9.187.1.2.1.1.1
       name: bgp.peer.prefixes.accept
       syntax: Counter32
+      metric: counter
     cbgpPeerPrefixDenied:
       oid: .1.3.6.1.4.1.9.9.187.1.2.1.1.2
       name: bgp.peer.prefixes.deny
       syntax: Counter32
+      metric: counter
     cbgpPeerPrefixLimit:
       oid: .1.3.6.1.4.1.9.9.187.1.2.1.1.3
       name: bgp.peer.prefixes.max
       syntax: Unsigned32
+      metric: gauge
     cbgpPeerPrefixAdvertised:
       oid: .1.3.6.1.4.1.9.9.187.1.2.1.1.4
       name: bgp.peer.prefixes.advert
       syntax: Counter32
+      metric: counter
     cbgpPeerPrefixSuppressed:
       oid: .1.3.6.1.4.1.9.9.187.1.2.1.1.5
       name: bgp.peer.prefixes.suppress
       syntax: Counter32
+      metric: counter
     cbgpPeerPrefixWithdrawn:
       oid: .1.3.6.1.4.1.9.9.187.1.2.1.1.6
       name: bgp.peer.prefixes.withdraw
       syntax: Counter32
+      metric: counter
     cbgpPeerLastErrorTxt:
       oid: .1.3.6.1.4.1.9.9.187.1.2.1.1.7
       name: bgp.peer.last_error.msg
@@ -140,26 +146,32 @@ CISCO-BGP4-MIB::cbgpPeerAddrFamilyPrefixEntry:
       oid: .1.3.6.1.4.1.9.9.187.1.2.4.1.1
       name: bgp.peer.prefixes.accept
       syntax: Counter32
+      metric: counter
     cbgpPeerDeniedPrefixes:
       oid: .1.3.6.1.4.1.9.9.187.1.2.4.1.2
       name: bgp.peer.prefixes.deny
-      syntax: Gauge32
+      syntax: Counter32
+      metric: counter
     cbgpPeerPrefixAdminLimit:
       oid: .1.3.6.1.4.1.9.9.187.1.2.4.1.3
       name: bgp.peer.prefixes.max
       syntax: Unsigned32
+      metric: gauge
     cbgpPeerAdvertisedPrefixes:
       oid: .1.3.6.1.4.1.9.9.187.1.2.4.1.6
       name: bgp.peer.prefixes.advert
-      syntax: Gauge32
+      syntax: Counter32
+      metric: counter
     cbgpPeerSuppressedPrefixes:
       oid: .1.3.6.1.4.1.9.9.187.1.2.4.1.7
       name: bgp.peer.prefixes.suppress
-      syntax: Gauge32
+      syntax: Counter32
+      metric: counter
     cbgpPeerWithdrawnPrefixes:
       oid: .1.3.6.1.4.1.9.9.187.1.2.4.1.8
       name: bgp.peer.prefixes.withdraw
-      syntax: Gauge32
+      syntax: Counter32
+      metric: counter
 
 CISCO-BGP4-MIB::cbgpPeer2Entry:
   mib: CISCO-BGP4-MIB
@@ -219,62 +231,76 @@ CISCO-BGP4-MIB::cbgpPeer2Entry:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.13
       name: bgp.peer.msgs.update.in
       syntax: Counter32
+      metric: counter
     cbgpPeer2OutUpdates:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.14
       name: bgp.peer.msgs.update.out
       syntax: Counter32
+      metric: counter
     cbgpPeer2InTotalMessages:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.15
       name: bgp.peer.msgs.in
       syntax: Counter32
+      metric: counter
     cbgpPeer2OutTotalMessages:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.16
       name: bgp.peer.msgs.out
       syntax: Counter32
+      metric: counter
     cbgpPeer2LastError:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.17
-      name: bgp.peer.last_error.in
+      name: bgp.peer.last_error
       syntax: OctetString
     cbgpPeer2FsmEstablishedTransitions:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.18
       name: bgp.peer.fsm.established.transitions
       syntax: Counter32
+      metric: counter
     cbgpPeer2FsmEstablishedTime:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.19
       name: bgp.peer.fsm.established.duration
       syntax: Gauge32
+      metric: gauge
     cbgpPeer2ConnectRetryInterval:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.20
       name: bgp.peer.connect_retry.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer2HoldTime:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.21
       name: bgp.peer.hold_time.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer2KeepAlive:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.22
       name: bgp.peer.keep_alive.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer2HoldTimeConfigured:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.23
       name: bgp.peer.hold_time.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer2KeepAliveConfigured:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.24
       name: bgp.peer.keep_alive.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer2MinASOriginationInterval:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.25
       name: bgp.peer.min_as_origin.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer2MinRouteAdvertisementInterval:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.26
       name: bgp.peer.min_route_advert.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer2InUpdateElapsedTime:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.27
       name: bgp.peer.last_update.elapsed
       syntax: Gauge32
+      metric: gauge
     cbgpPeer2LastErrorTxt:
       oid: .1.3.6.1.4.1.9.9.187.1.2.5.1.28
       name: bgp.peer.last_error.msg
@@ -310,26 +336,32 @@ CISCO-BGP4-MIB::cbgpPeer2AddrFamilyPrefixEntry:
       oid: .1.3.6.1.4.1.9.9.187.1.2.8.1.1
       name: bgp.peer.prefixes.accept
       syntax: Counter32
+      metric: counter
     cbgpPeer2DeniedPrefixes:
       oid: .1.3.6.1.4.1.9.9.187.1.2.8.1.2
       name: bgp.peer.prefixes.deny
-      syntax: Gauge32
+      syntax: Counter32
+      metric: counter
     cbgpPeer2PrefixAdminLimit:
       oid: .1.3.6.1.4.1.9.9.187.1.2.8.1.3
       name: bgp.peer.prefixes.max
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer2AdvertisedPrefixes:
       oid: .1.3.6.1.4.1.9.9.187.1.2.8.1.6
       name: bgp.peer.prefixes.advert
-      syntax: Gauge32
+      syntax: Counter32
+      metric: counter
     cbgpPeer2SuppressedPrefixes:
       oid: .1.3.6.1.4.1.9.9.187.1.2.8.1.7
       name: bgp.peer.prefixes.suppress
-      syntax: Gauge32
+      syntax: Counter32
+      metric: counter
     cbgpPeer2WithdrawnPrefixes:
       oid: .1.3.6.1.4.1.9.9.187.1.2.8.1.8
       name: bgp.peer.prefixes.withdraw
-      syntax: Gauge32
+      syntax: Counter32
+      metric: counter
 
 CISCO-BGP4-MIB::cbgpPeer3Entry:
   mib: CISCO-BGP4-MIB
@@ -398,62 +430,76 @@ CISCO-BGP4-MIB::cbgpPeer3Entry:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.15
       name: bgp.peer.msgs.update.in
       syntax: Counter32
+      metric: counter
     cbgpPeer3OutUpdates:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.16
       name: bgp.peer.msgs.update.out
       syntax: Counter32
+      metric: counter
     cbgpPeer3InTotalMessages:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.17
       name: bgp.peer.msgs.in
       syntax: Counter32
+      metric: counter
     cbgpPeer3OutTotalMessages:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.18
       name: bgp.peer.msgs.out
       syntax: Counter32
+      metric: counter
     cbgpPeer3LastError:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.19
-      name: bgp.peer.last_error.in
+      name: bgp.peer.last_error
       syntax: OctetString
     cbgpPeer3FsmEstablishedTransitions:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.20
       name: bgp.peer.fsm.established.transitions
       syntax: Counter32
+      metric: counter
     cbgpPeer3FsmEstablishedTime:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.21
       name: bgp.peer.fsm.established.duration
       syntax: Gauge32
+      metric: gauge
     cbgpPeer3ConnectRetryInterval:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.22
       name: bgp.peer.connect_retry.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer3HoldTime:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.23
       name: bgp.peer.hold_time.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer3KeepAlive:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.24
       name: bgp.peer.keep_alive.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer3HoldTimeConfigured:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.25
       name: bgp.peer.hold_time.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer3KeepAliveConfigured:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.26
       name: bgp.peer.keep_alive.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer3MinASOriginationInterval:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.27
       name: bgp.peer.min_as_origin.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer3MinRouteAdvertisementInterval:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.28
       name: bgp.peer.min_route_advert.config.interval
       syntax: Unsigned32
+      metric: gauge
     cbgpPeer3InUpdateElapsedTime:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.29
       name: bgp.peer.last_update.elapsed
       syntax: Gauge32
+      metric: gauge
     cbgpPeer3LastErrorTxt:
       oid: .1.3.6.1.4.1.9.9.187.1.2.9.1.30
       name: bgp.peer.last_error.msg

--- a/objects/cisco/CISCO-OSPF-MIB.yml
+++ b/objects/cisco/CISCO-OSPF-MIB.yml
@@ -26,6 +26,7 @@ CISCO-OSPF-MIB::cospfGeneralGroup:
       oid: .1.3.6.1.4.1.9.10.99.1.4
       name: ospf.lsdb.opaque_as_scope.lsas
       syntax: Gauge32
+      metric: gauge
     cospfOpaqueASLsaCksumSum:
       oid: .1.3.6.1.4.1.9.10.99.1.5
       name: ospf.lsdb.opaque_as_scope.checksum
@@ -41,6 +42,7 @@ CISCO-OSPF-MIB::cospfAreaEntry:
       oid: .1.3.6.1.4.1.9.10.99.2.1.1
       name: ospf.area.lsdb.opaque_area_scope.lsas
       syntax: Gauge32
+      metric: gauge
     cospfOpaqueAreaLsaCksumSum:
       oid: .1.3.6.1.4.1.9.10.99.2.1.2
       name: ospf.area.lsdb.opaque_area_scope.checksum
@@ -63,6 +65,7 @@ CISCO-OSPF-MIB::cospfAreaEntry:
       oid: .1.3.6.1.4.1.9.10.99.2.1.5
       name: ospf.area.nssa_translator.events
       syntax: Counter32
+      metric: counter
       overrides:
         object: OSPF-MIB::ospfAreaEntry
         attribute: ospfAreaNssaTranslatorEvents
@@ -77,6 +80,7 @@ CISCO-OSPF-MIB::cospfIfEntry:
       oid: .1.3.6.1.4.1.9.10.99.4.1.1
       name: ospf.netif.lsdb.link_local.lsas
       syntax: Gauge32
+      metric: counter
     cospfIfLsaCksumSum:
       oid: .1.3.6.1.4.1.9.10.99.4.1.2
       name: ospf.netif.lsdb.link_local.checksum
@@ -92,6 +96,7 @@ CISCO-OSPF-MIB::cospfVirtIfEntry:
       oid: .1.3.6.1.4.1.9.10.99.5.1.1
       name: ospf.virt_netif.lsdb.link_local.lsas
       syntax: Gauge32
+      metric: gauge
     cospfVirtIfLsaCksumSum:
       oid: .1.3.6.1.4.1.9.10.99.5.1.2
       name: ospf.virt_netif.lsdb.link_local.checksum
@@ -119,14 +124,17 @@ CISCO-OSPF-MIB::cospfShamLinkEntry:
       oid: .1.3.6.1.4.1.9.10.99.6.1.4
       name: ospf.sham_link.retrans_interval
       syntax: Unsigned32
+      metric: gauge
     cospfShamLinkHelloInterval:
       oid: .1.3.6.1.4.1.9.10.99.6.1.5
       name: ospf.sham_link.hello_interval
       syntax: Unsigned32
+      metric: gauge
     cospfShamLinkRtrDeadInterval:
       oid: .1.3.6.1.4.1.9.10.99.6.1.6
       name: ospf.sham_link.router_dead_interval
       syntax: Unsigned32
+      metric: gauge
     cospfShamLinkState:
       oid: .1.3.6.1.4.1.9.10.99.6.1.7
       name: ospf.sham_link.state
@@ -135,10 +143,12 @@ CISCO-OSPF-MIB::cospfShamLinkEntry:
       oid: .1.3.6.1.4.1.9.10.99.6.1.8
       name: ospf.sham_link.events
       syntax: Counter32
+      metric: counter
     cospfShamLinkMetric:
       oid: .1.3.6.1.4.1.9.10.99.6.1.9
       name: ospf.sham_link.metric
       syntax: Unsigned32
+      metric: gauge
 
 CISCO-OSPF-MIB::cospfShamLinkNbrEntry:
   mib: CISCO-OSPF-MIB
@@ -183,10 +193,12 @@ CISCO-OSPF-MIB::cospfShamLinkNbrEntry:
       oid: .1.3.6.1.4.1.9.10.99.10.1.7
       name: ospf.sham_link.neighbor.events
       syntax: Counter32
+      metric: counter
     cospfShamLinkNbrLsRetransQLen:
       oid: .1.3.6.1.4.1.9.10.99.10.1.8
       name: ospf.sham_link.neighbor.link_state_retrans_queue
       syntax: Gauge32
+      metric: gauge
     cospfShamLinkNbrHelloSuppressed:
       oid: .1.3.6.1.4.1.9.10.99.10.1.9
       name: ospf.sham_link.neighbor.hello_suppress
@@ -222,14 +234,17 @@ CISCO-OSPF-MIB::cospfShamLinksEntry:
       oid: .1.3.6.1.4.1.9.10.99.11.1.6
       name: ospf.sham_link.retrans_interval
       syntax: Unsigned32
+      metric: gauge
     cospfShamLinksHelloInterval:
       oid: .1.3.6.1.4.1.9.10.99.11.1.7
       name: ospf.sham_link.hello_interval
       syntax: Unsigned32
+      metric: gauge
     cospfShamLinksRtrDeadInterval:
       oid: .1.3.6.1.4.1.9.10.99.11.1.8
       name: ospf.sham_link.router_dead_interval
       syntax: Unsigned32
+      metric: gauge
     cospfShamLinksState:
       oid: .1.3.6.1.4.1.9.10.99.11.1.9
       name: ospf.sham_link.state
@@ -238,7 +253,9 @@ CISCO-OSPF-MIB::cospfShamLinksEntry:
       oid: .1.3.6.1.4.1.9.10.99.11.1.10
       name: ospf.sham_link.events
       syntax: Counter32
+      metric: counter
     cospfShamLinksMetric:
       oid: .1.3.6.1.4.1.9.10.99.11.1.11
       name: ospf.sham_link.metric
       syntax: Unsigned32
+      metric: gauge

--- a/objects/ietf/ADSL-LINE-MIB.yml
+++ b/objects/ietf/ADSL-LINE-MIB.yml
@@ -72,10 +72,12 @@ ADSL-LINE-MIB::adslAtucPhysEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.2.1.4
       name: ietf.adslAtucCurrSnrMgn
       syntax: SignalDeciDBm
+      metric: gauge
     adslAtucCurrAtn:
       oid: .1.3.6.1.2.1.10.94.1.1.2.1.5
       name: ietf.adslAtucCurrAtn
       syntax: SignalDeciDBm
+      metric: gauge
     adslAtucCurrStatus:
       oid: .1.3.6.1.2.1.10.94.1.1.2.1.6
       name: ietf.adslAtucCurrStatus
@@ -84,10 +86,12 @@ ADSL-LINE-MIB::adslAtucPhysEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.2.1.7
       name: ietf.adslAtucCurrOutputPwr
       syntax: SignalDeciDBm
+      metric: gauge
     adslAtucCurrAttainableRate:
       oid: .1.3.6.1.2.1.10.94.1.1.2.1.8
       name: ietf.adslAtucCurrAttainableRate
       syntax: BandwidthBits
+      metric: gauge
 
 ADSL-LINE-MIB::adslAturPhysEntry:
   mib: ADSL-LINE-MIB
@@ -111,10 +115,12 @@ ADSL-LINE-MIB::adslAturPhysEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.3.1.4
       name: ietf.adslAturCurrSnrMgn
       syntax: SignalDeciDBm
+      metric: gauge
     adslAturCurrAtn:
       oid: .1.3.6.1.2.1.10.94.1.1.3.1.5
       name: ietf.adslAturCurrAtn
       syntax: SignalDeciDBm
+      metric: gauge
     adslAturCurrStatus:
       oid: .1.3.6.1.2.1.10.94.1.1.3.1.6
       name: ietf.adslAturCurrStatus
@@ -123,10 +129,12 @@ ADSL-LINE-MIB::adslAturPhysEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.3.1.7
       name: ietf.adslAturCurrOutputPwr
       syntax: SignalDeciDBm
+      metric: gauge
     adslAturCurrAttainableRate:
       oid: .1.3.6.1.2.1.10.94.1.1.3.1.8
       name: ietf.adslAturCurrAttainableRate
       syntax: BandwidthBits
+      metric: gauge
 
 ADSL-LINE-MIB::adslAtucChanEntry:
   mib: ADSL-LINE-MIB
@@ -138,18 +146,22 @@ ADSL-LINE-MIB::adslAtucChanEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.4.1.1
       name: ietf.adslAtucChanInterleaveDelay
       syntax: TicksMilliSec
+      metric: gauge
     adslAtucChanCurrTxRate:
       oid: .1.3.6.1.2.1.10.94.1.1.4.1.2
       name: ietf.adslAtucChanCurrTxRate
       syntax: BandwidthBits
+      metric: gauge
     adslAtucChanPrevTxRate:
       oid: .1.3.6.1.2.1.10.94.1.1.4.1.3
       name: ietf.adslAtucChanPrevTxRate
       syntax: BandwidthBits
+      metric: gauge
     adslAtucChanCrcBlockLength:
       oid: .1.3.6.1.2.1.10.94.1.1.4.1.4
       name: ietf.adslAtucChanCrcBlockLength
       syntax: BytesB
+      metric: gauge
 
 ADSL-LINE-MIB::adslAturChanEntry:
   mib: ADSL-LINE-MIB
@@ -161,18 +173,22 @@ ADSL-LINE-MIB::adslAturChanEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.5.1.1
       name: ietf.adslAturChanInterleaveDelay
       syntax: TicksMilliSec
+      metric: gauge
     adslAturChanCurrTxRate:
       oid: .1.3.6.1.2.1.10.94.1.1.5.1.2
       name: ietf.adslAturChanCurrTxRate
       syntax: BandwidthBits
+      metric: gauge
     adslAturChanPrevTxRate:
       oid: .1.3.6.1.2.1.10.94.1.1.5.1.3
       name: ietf.adslAturChanPrevTxRate
       syntax: BandwidthBits
+      metric: gauge
     adslAturChanCrcBlockLength:
       oid: .1.3.6.1.2.1.10.94.1.1.5.1.4
       name: ietf.adslAturChanCrcBlockLength
       syntax: BytesB
+      metric: gauge
 
 ADSL-LINE-MIB::adslAtucPerfDataEntry:
   mib: ADSL-LINE-MIB
@@ -184,118 +200,32 @@ ADSL-LINE-MIB::adslAtucPerfDataEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.6.1.1
       name: ietf.adslAtucPerfLofs
       syntax: Counter32
+      metric: counter
     adslAtucPerfLoss:
       oid: .1.3.6.1.2.1.10.94.1.1.6.1.2
       name: ietf.adslAtucPerfLoss
       syntax: Counter32
+      metric: counter
     adslAtucPerfLols:
       oid: .1.3.6.1.2.1.10.94.1.1.6.1.3
       name: ietf.adslAtucPerfLols
       syntax: Counter32
+      metric: counter
     adslAtucPerfLprs:
       oid: .1.3.6.1.2.1.10.94.1.1.6.1.4
       name: ietf.adslAtucPerfLprs
       syntax: Counter32
+      metric: counter
     adslAtucPerfESs:
       oid: .1.3.6.1.2.1.10.94.1.1.6.1.5
       name: ietf.adslAtucPerfESs
       syntax: Counter32
+      metric: counter
     adslAtucPerfInits:
       oid: .1.3.6.1.2.1.10.94.1.1.6.1.6
       name: ietf.adslAtucPerfInits
       syntax: Counter32
-    # adslAtucPerfValidIntervals:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.7
-    #   name: ietf.adslAtucPerfValidIntervals
-    #   syntax: Integer32
-    # adslAtucPerfInvalidIntervals:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.8
-    #   name: ietf.adslAtucPerfInvalidIntervals
-    #   syntax: Integer32
-    # adslAtucPerfCurr15MinTimeElapsed:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.9
-    #   name: ietf.adslAtucPerfCurr15MinTimeElapsed
-    #   syntax: TicksSec
-    # adslAtucPerfCurr15MinLofs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.10
-    #   name: ietf.adslAtucPerfCurr15MinLofs
-    #   syntax: TicksSec
-    # adslAtucPerfCurr15MinLoss:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.11
-    #   name: ietf.adslAtucPerfCurr15MinLoss
-    #   syntax: TicksSec
-    # adslAtucPerfCurr15MinLols:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.12
-    #   name: ietf.adslAtucPerfCurr15MinLols
-    #   syntax: TicksSec
-    # adslAtucPerfCurr15MinLprs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.13
-    #   name: ietf.adslAtucPerfCurr15MinLprs
-    #   syntax: TicksSec
-    # adslAtucPerfCurr15MinESs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.14
-    #   name: ietf.adslAtucPerfCurr15MinESs
-    #   syntax: TicksSec
-    # adslAtucPerfCurr15MinInits:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.15
-    #   name: ietf.adslAtucPerfCurr15MinInits
-    #   syntax: Gauge32
-    # adslAtucPerfCurr1DayTimeElapsed:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.16
-    #   name: ietf.adslAtucPerfCurr1DayTimeElapsed
-    #   syntax: TicksSec
-    # adslAtucPerfCurr1DayLofs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.17
-    #   name: ietf.adslAtucPerfCurr1DayLofs
-    #   syntax: TicksSec
-    # adslAtucPerfCurr1DayLoss:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.18
-    #   name: ietf.adslAtucPerfCurr1DayLoss
-    #   syntax: TicksSec
-    # adslAtucPerfCurr1DayLols:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.19
-    #   name: ietf.adslAtucPerfCurr1DayLols
-    #   syntax: TicksSec
-    # adslAtucPerfCurr1DayLprs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.20
-    #   name: ietf.adslAtucPerfCurr1DayLprs
-    #   syntax: TicksSec
-    # adslAtucPerfCurr1DayESs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.21
-    #   name: ietf.adslAtucPerfCurr1DayESs
-    #   syntax: TicksSec
-    # adslAtucPerfCurr1DayInits:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.22
-    #   name: ietf.adslAtucPerfCurr1DayInits
-    #   syntax: Gauge32
-    # adslAtucPerfPrev1DayMoniSecs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.23
-    #   name: ietf.adslAtucPerfPrev1DayMoniSecs
-    #   syntax: TicksSec
-    # adslAtucPerfPrev1DayLofs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.24
-    #   name: ietf.adslAtucPerfPrev1DayLofs
-    #   syntax: TicksSec
-    # adslAtucPerfPrev1DayLoss:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.25
-    #   name: ietf.adslAtucPerfPrev1DayLoss
-    #   syntax: TicksSec
-    # adslAtucPerfPrev1DayLols:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.26
-    #   name: ietf.adslAtucPerfPrev1DayLols
-    #   syntax: TicksSec
-    # adslAtucPerfPrev1DayLprs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.27
-    #   name: ietf.adslAtucPerfPrev1DayLprs
-    #   syntax: TicksSec
-    # adslAtucPerfPrev1DayESs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.28
-    #   name: ietf.adslAtucPerfPrev1DayESs
-    #   syntax: TicksSec
-    # adslAtucPerfPrev1DayInits:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.6.1.29
-    #   name: ietf.adslAtucPerfPrev1DayInits
-    #   syntax: Gauge32
+      metric: counter
 
 ADSL-LINE-MIB::adslAturPerfDataEntry:
   mib: ADSL-LINE-MIB
@@ -307,164 +237,22 @@ ADSL-LINE-MIB::adslAturPerfDataEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.7.1.1
       name: ietf.adslAturPerfLofs
       syntax: Counter32
+      metric: counter
     adslAturPerfLoss:
       oid: .1.3.6.1.2.1.10.94.1.1.7.1.2
       name: ietf.adslAturPerfLoss
       syntax: Counter32
+      metric: counter
     adslAturPerfLprs:
       oid: .1.3.6.1.2.1.10.94.1.1.7.1.3
       name: ietf.adslAturPerfLprs
       syntax: Counter32
+      metric: counter
     adslAturPerfESs:
       oid: .1.3.6.1.2.1.10.94.1.1.7.1.4
       name: ietf.adslAturPerfESs
       syntax: Counter32
-    # adslAturPerfValidIntervals:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.5
-    #   name: ietf.adslAturPerfValidIntervals
-    #   syntax: Integer32
-    # adslAturPerfInvalidIntervals:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.6
-    #   name: ietf.adslAturPerfInvalidIntervals
-    #   syntax: Integer32
-    # adslAturPerfCurr15MinTimeElapsed:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.7
-    #   name: ietf.adslAturPerfCurr15MinTimeElapsed
-    #   syntax: TicksSec
-    # adslAturPerfCurr15MinLofs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.8
-    #   name: ietf.adslAturPerfCurr15MinLofs
-    #   syntax: TicksSec
-    # adslAturPerfCurr15MinLoss:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.9
-    #   name: ietf.adslAturPerfCurr15MinLoss
-    #   syntax: TicksSec
-    # adslAturPerfCurr15MinLprs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.10
-    #   name: ietf.adslAturPerfCurr15MinLprs
-    #   syntax: TicksSec
-    # adslAturPerfCurr15MinESs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.11
-    #   name: ietf.adslAturPerfCurr15MinESs
-    #   syntax: TicksSec
-    # adslAturPerfCurr1DayTimeElapsed:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.12
-    #   name: ietf.adslAturPerfCurr1DayTimeElapsed
-    #   syntax: TicksSec
-    # adslAturPerfCurr1DayLofs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.13
-    #   name: ietf.adslAturPerfCurr1DayLofs
-    #   syntax: TicksSec
-    # adslAturPerfCurr1DayLoss:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.14
-    #   name: ietf.adslAturPerfCurr1DayLoss
-    #   syntax: TicksSec
-    # adslAturPerfCurr1DayLprs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.15
-    #   name: ietf.adslAturPerfCurr1DayLprs
-    #   syntax: TicksSec
-    # adslAturPerfCurr1DayESs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.16
-    #   name: ietf.adslAturPerfCurr1DayESs
-    #   syntax: TicksSec
-    # adslAturPerfPrev1DayMoniSecs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.17
-    #   name: ietf.adslAturPerfPrev1DayMoniSecs
-    #   syntax: TicksSec
-    # adslAturPerfPrev1DayLofs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.18
-    #   name: ietf.adslAturPerfPrev1DayLofs
-    #   syntax: TicksSec
-    # adslAturPerfPrev1DayLoss:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.19
-    #   name: ietf.adslAturPerfPrev1DayLoss
-    #   syntax: TicksSec
-    # adslAturPerfPrev1DayLprs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.20
-    #   name: ietf.adslAturPerfPrev1DayLprs
-    #   syntax: TicksSec
-    # adslAturPerfPrev1DayESs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.7.1.21
-    #   name: ietf.adslAturPerfPrev1DayESs
-    #   syntax: TicksSec
-
-# ADSL-LINE-MIB::adslAtucIntervalEntry:
-#   mib: ADSL-LINE-MIB
-#   object: adslAtucIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.94.1.1.8.1.1
-#       name: ietf.adslAtucIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: adslAtucIntervalLofs
-#   attributes:
-#     adslAtucIntervalLofs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.8.1.2
-#       name: ietf.adslAtucIntervalLofs
-#       syntax: TicksSec
-#     adslAtucIntervalLoss:
-#       oid: .1.3.6.1.2.1.10.94.1.1.8.1.3
-#       name: ietf.adslAtucIntervalLoss
-#       syntax: TicksSec
-#     adslAtucIntervalLols:
-#       oid: .1.3.6.1.2.1.10.94.1.1.8.1.4
-#       name: ietf.adslAtucIntervalLols
-#       syntax: TicksSec
-#     adslAtucIntervalLprs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.8.1.5
-#       name: ietf.adslAtucIntervalLprs
-#       syntax: TicksSec
-#     adslAtucIntervalESs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.8.1.6
-#       name: ietf.adslAtucIntervalESs
-#       syntax: TicksSec
-#     adslAtucIntervalInits:
-#       oid: .1.3.6.1.2.1.10.94.1.1.8.1.7
-#       name: ietf.adslAtucIntervalInits
-#       syntax: Gauge32
-#     adslAtucIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.94.1.1.8.1.8
-#       name: ietf.adslAtucIntervalValidData
-#       syntax: TruthValue
-
-# ADSL-LINE-MIB::adslAturIntervalEntry:
-#   mib: ADSL-LINE-MIB
-#   object: adslAturIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.94.1.1.9.1.1
-#       name: ietf.adslAturIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: adslAturIntervalLofs
-#   attributes:
-#     adslAturIntervalLofs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.9.1.2
-#       name: ietf.adslAturIntervalLofs
-#       syntax: TicksSec
-#     adslAturIntervalLoss:
-#       oid: .1.3.6.1.2.1.10.94.1.1.9.1.3
-#       name: ietf.adslAturIntervalLoss
-#       syntax: TicksSec
-#     adslAturIntervalLprs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.9.1.4
-#       name: ietf.adslAturIntervalLprs
-#       syntax: TicksSec
-#     adslAturIntervalESs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.9.1.5
-#       name: ietf.adslAturIntervalESs
-#       syntax: TicksSec
-#     adslAturIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.94.1.1.9.1.6
-#       name: ietf.adslAturIntervalValidData
-#       syntax: TruthValue
+      metric: counter
 
 ADSL-LINE-MIB::adslAtucChanPerfDataEntry:
   mib: ADSL-LINE-MIB
@@ -476,86 +264,22 @@ ADSL-LINE-MIB::adslAtucChanPerfDataEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.10.1.1
       name: ietf.adslAtucChanReceivedBlks
       syntax: Counter32
+      metric: counter
     adslAtucChanTransmittedBlks:
       oid: .1.3.6.1.2.1.10.94.1.1.10.1.2
       name: ietf.adslAtucChanTransmittedBlks
       syntax: Counter32
+      metric: counter
     adslAtucChanCorrectedBlks:
       oid: .1.3.6.1.2.1.10.94.1.1.10.1.3
       name: ietf.adslAtucChanCorrectedBlks
       syntax: Counter32
+      metric: counter
     adslAtucChanUncorrectBlks:
       oid: .1.3.6.1.2.1.10.94.1.1.10.1.4
       name: ietf.adslAtucChanUncorrectBlks
       syntax: Counter32
-    # adslAtucChanPerfValidIntervals:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.5
-    #   name: ietf.adslAtucChanPerfValidIntervals
-    #   syntax: Integer32
-    # adslAtucChanPerfInvalidIntervals:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.6
-    #   name: ietf.adslAtucChanPerfInvalidIntervals
-    #   syntax: Integer32
-    # adslAtucChanPerfCurr15MinTimeElapsed:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.7
-    #   name: ietf.adslAtucChanPerfCurr15MinTimeElapsed
-    #   syntax: TicksSec
-    # adslAtucChanPerfCurr15MinReceivedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.8
-    #   name: ietf.adslAtucChanPerfCurr15MinReceivedBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfCurr15MinTransmittedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.9
-    #   name: ietf.adslAtucChanPerfCurr15MinTransmittedBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfCurr15MinCorrectedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.10
-    #   name: ietf.adslAtucChanPerfCurr15MinCorrectedBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfCurr15MinUncorrectBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.11
-    #   name: ietf.adslAtucChanPerfCurr15MinUncorrectBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfCurr1DayTimeElapsed:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.12
-    #   name: ietf.adslAtucChanPerfCurr1DayTimeElapsed
-    #   syntax: TicksSec
-    # adslAtucChanPerfCurr1DayReceivedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.13
-    #   name: ietf.adslAtucChanPerfCurr1DayReceivedBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfCurr1DayTransmittedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.14
-    #   name: ietf.adslAtucChanPerfCurr1DayTransmittedBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfCurr1DayCorrectedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.15
-    #   name: ietf.adslAtucChanPerfCurr1DayCorrectedBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfCurr1DayUncorrectBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.16
-    #   name: ietf.adslAtucChanPerfCurr1DayUncorrectBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfPrev1DayMoniSecs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.17
-    #   name: ietf.adslAtucChanPerfPrev1DayMoniSecs
-    #   syntax: TicksSec
-    # adslAtucChanPerfPrev1DayReceivedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.18
-    #   name: ietf.adslAtucChanPerfPrev1DayReceivedBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfPrev1DayTransmittedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.19
-    #   name: ietf.adslAtucChanPerfPrev1DayTransmittedBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfPrev1DayCorrectedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.20
-    #   name: ietf.adslAtucChanPerfPrev1DayCorrectedBlks
-    #   syntax: Gauge32
-    # adslAtucChanPerfPrev1DayUncorrectBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.10.1.21
-    #   name: ietf.adslAtucChanPerfPrev1DayUncorrectBlks
-    #   syntax: Gauge32
+      metric: counter
 
 ADSL-LINE-MIB::adslAturChanPerfDataEntry:
   mib: ADSL-LINE-MIB
@@ -567,359 +291,19 @@ ADSL-LINE-MIB::adslAturChanPerfDataEntry:
       oid: .1.3.6.1.2.1.10.94.1.1.11.1.1
       name: ietf.adslAturChanReceivedBlks
       syntax: Counter32
+      metric: counter
     adslAturChanTransmittedBlks:
       oid: .1.3.6.1.2.1.10.94.1.1.11.1.2
       name: ietf.adslAturChanTransmittedBlks
       syntax: Counter32
+      metric: counter
     adslAturChanCorrectedBlks:
       oid: .1.3.6.1.2.1.10.94.1.1.11.1.3
       name: ietf.adslAturChanCorrectedBlks
       syntax: Counter32
+      metric: counter
     adslAturChanUncorrectBlks:
       oid: .1.3.6.1.2.1.10.94.1.1.11.1.4
       name: ietf.adslAturChanUncorrectBlks
       syntax: Counter32
-    # adslAturChanPerfValidIntervals:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.5
-    #   name: ietf.adslAturChanPerfValidIntervals
-    #   syntax: Integer32
-    # adslAturChanPerfInvalidIntervals:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.6
-    #   name: ietf.adslAturChanPerfInvalidIntervals
-    #   syntax: Integer32
-    # adslAturChanPerfCurr15MinTimeElapsed:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.7
-    #   name: ietf.adslAturChanPerfCurr15MinTimeElapsed
-    #   syntax: TicksSec
-    # adslAturChanPerfCurr15MinReceivedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.8
-    #   name: ietf.adslAturChanPerfCurr15MinReceivedBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfCurr15MinTransmittedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.9
-    #   name: ietf.adslAturChanPerfCurr15MinTransmittedBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfCurr15MinCorrectedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.10
-    #   name: ietf.adslAturChanPerfCurr15MinCorrectedBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfCurr15MinUncorrectBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.11
-    #   name: ietf.adslAturChanPerfCurr15MinUncorrectBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfCurr1DayTimeElapsed:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.12
-    #   name: ietf.adslAturChanPerfCurr1DayTimeElapsed
-    #   syntax: TicksSec
-    # adslAturChanPerfCurr1DayReceivedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.13
-    #   name: ietf.adslAturChanPerfCurr1DayReceivedBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfCurr1DayTransmittedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.14
-    #   name: ietf.adslAturChanPerfCurr1DayTransmittedBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfCurr1DayCorrectedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.15
-    #   name: ietf.adslAturChanPerfCurr1DayCorrectedBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfCurr1DayUncorrectBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.16
-    #   name: ietf.adslAturChanPerfCurr1DayUncorrectBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfPrev1DayMoniSecs:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.17
-    #   name: ietf.adslAturChanPerfPrev1DayMoniSecs
-    #   syntax: TicksSec
-    # adslAturChanPerfPrev1DayReceivedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.18
-    #   name: ietf.adslAturChanPerfPrev1DayReceivedBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfPrev1DayTransmittedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.19
-    #   name: ietf.adslAturChanPerfPrev1DayTransmittedBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfPrev1DayCorrectedBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.20
-    #   name: ietf.adslAturChanPerfPrev1DayCorrectedBlks
-    #   syntax: Gauge32
-    # adslAturChanPerfPrev1DayUncorrectBlks:
-    #   oid: .1.3.6.1.2.1.10.94.1.1.11.1.21
-    #   name: ietf.adslAturChanPerfPrev1DayUncorrectBlks
-    #   syntax: Gauge32
-
-# ADSL-LINE-MIB::adslAtucChanIntervalEntry:
-#   mib: ADSL-LINE-MIB
-#   object: adslAtucChanIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.94.1.1.12.1.1
-#       name: ietf.adslAtucChanIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: adslAtucChanIntervalReceivedBlks
-#   attributes:
-#     adslAtucChanIntervalReceivedBlks:
-#       oid: .1.3.6.1.2.1.10.94.1.1.12.1.2
-#       name: ietf.adslAtucChanIntervalReceivedBlks
-#       syntax: Gauge32
-#     adslAtucChanIntervalTransmittedBlks:
-#       oid: .1.3.6.1.2.1.10.94.1.1.12.1.3
-#       name: ietf.adslAtucChanIntervalTransmittedBlks
-#       syntax: Gauge32
-#     adslAtucChanIntervalCorrectedBlks:
-#       oid: .1.3.6.1.2.1.10.94.1.1.12.1.4
-#       name: ietf.adslAtucChanIntervalCorrectedBlks
-#       syntax: Gauge32
-#     adslAtucChanIntervalUncorrectBlks:
-#       oid: .1.3.6.1.2.1.10.94.1.1.12.1.5
-#       name: ietf.adslAtucChanIntervalUncorrectBlks
-#       syntax: Gauge32
-#     adslAtucChanIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.94.1.1.12.1.6
-#       name: ietf.adslAtucChanIntervalValidData
-#       syntax: TruthValue
-
-# ADSL-LINE-MIB::adslAturChanIntervalEntry:
-#   mib: ADSL-LINE-MIB
-#   object: adslAturChanIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.94.1.1.13.1.1
-#       name: ietf.adslAturChanIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: adslAturChanIntervalReceivedBlks
-#   attributes:
-#     adslAturChanIntervalReceivedBlks:
-#       oid: .1.3.6.1.2.1.10.94.1.1.13.1.2
-#       name: ietf.adslAturChanIntervalReceivedBlks
-#       syntax: Gauge32
-#     adslAturChanIntervalTransmittedBlks:
-#       oid: .1.3.6.1.2.1.10.94.1.1.13.1.3
-#       name: ietf.adslAturChanIntervalTransmittedBlks
-#       syntax: Gauge32
-#     adslAturChanIntervalCorrectedBlks:
-#       oid: .1.3.6.1.2.1.10.94.1.1.13.1.4
-#       name: ietf.adslAturChanIntervalCorrectedBlks
-#       syntax: Gauge32
-#     adslAturChanIntervalUncorrectBlks:
-#       oid: .1.3.6.1.2.1.10.94.1.1.13.1.5
-#       name: ietf.adslAturChanIntervalUncorrectBlks
-#       syntax: PerfIntervalCount
-#     adslAturChanIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.94.1.1.13.1.6
-#       name: ietf.adslAturChanIntervalValidData
-#       syntax: TruthValue
-
-# ADSL-LINE-MIB::adslLineConfProfileEntry:
-#   mib: ADSL-LINE-MIB
-#   object: adslLineConfProfileEntry
-#   index:
-#     - type: ImplicitOctetString
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.1
-#       name: ietf.adslLineConfProfileName
-#       syntax: DisplayString # SnmpAdminString
-#   discovery_attribute: adslAtucConfRateMode
-#   attributes:
-#     adslAtucConfRateMode:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.2
-#       name: ietf.adslAtucConfRateMode
-#       syntax: EnumInteger
-#     adslAtucConfRateChanRatio:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.3
-#       name: ietf.adslAtucConfRateChanRatio
-#       syntax: Percent100
-#     adslAtucConfTargetSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.4
-#       name: ietf.adslAtucConfTargetSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAtucConfMaxSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.5
-#       name: ietf.adslAtucConfMaxSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAtucConfMinSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.6
-#       name: ietf.adslAtucConfMinSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAtucConfDownshiftSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.7
-#       name: ietf.adslAtucConfDownshiftSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAtucConfUpshiftSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.8
-#       name: ietf.adslAtucConfUpshiftSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAtucConfMinUpshiftTime:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.9
-#       name: ietf.adslAtucConfMinUpshiftTime
-#       syntax: TicksSec
-#     adslAtucConfMinDownshiftTime:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.10
-#       name: ietf.adslAtucConfMinDownshiftTime
-#       syntax: TicksSec
-#     adslAtucChanConfFastMinTxRate:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.11
-#       name: ietf.adslAtucChanConfFastMinTxRate
-#       syntax: BandwidthBits
-#     adslAtucChanConfInterleaveMinTxRate:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.12
-#       name: ietf.adslAtucChanConfInterleaveMinTxRate
-#       syntax: BandwidthBits
-#     adslAtucChanConfFastMaxTxRate:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.13
-#       name: ietf.adslAtucChanConfFastMaxTxRate
-#       syntax: BandwidthBits
-#     adslAtucChanConfInterleaveMaxTxRate:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.14
-#       name: ietf.adslAtucChanConfInterleaveMaxTxRate
-#       syntax: BandwidthBits
-#     adslAtucChanConfMaxInterleaveDelay:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.15
-#       name: ietf.adslAtucChanConfMaxInterleaveDelay
-#       syntax: TicksMilliSec
-#     adslAturConfRateMode:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.16
-#       name: ietf.adslAturConfRateMode
-#       syntax: EnumInteger
-#     adslAturConfRateChanRatio:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.17
-#       name: ietf.adslAturConfRateChanRatio
-#       syntax: Percent100
-#     adslAturConfTargetSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.18
-#       name: ietf.adslAturConfTargetSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAturConfMaxSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.19
-#       name: ietf.adslAturConfMaxSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAturConfMinSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.20
-#       name: ietf.adslAturConfMinSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAturConfDownshiftSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.21
-#       name: ietf.adslAturConfDownshiftSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAturConfUpshiftSnrMgn:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.22
-#       name: ietf.adslAturConfUpshiftSnrMgn
-#       syntax: SignalDeciDBm
-#     adslAturConfMinUpshiftTime:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.23
-#       name: ietf.adslAturConfMinUpshiftTime
-#       syntax: TicksSec
-#     adslAturConfMinDownshiftTime:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.24
-#       name: ietf.adslAturConfMinDownshiftTime
-#       syntax: TicksSec
-#     adslAturChanConfFastMinTxRate:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.25
-#       name: ietf.adslAturChanConfFastMinTxRate
-#       syntax: BandwidthBits
-#     adslAturChanConfInterleaveMinTxRate:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.26
-#       name: ietf.adslAturChanConfInterleaveMinTxRate
-#       syntax: BandwidthBits
-#     adslAturChanConfFastMaxTxRate:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.27
-#       name: ietf.adslAturChanConfFastMaxTxRate
-#       syntax: BandwidthBits
-#     adslAturChanConfInterleaveMaxTxRate:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.28
-#       name: ietf.adslAturChanConfInterleaveMaxTxRate
-#       syntax: BandwidthBits
-#     adslAturChanConfMaxInterleaveDelay:
-#       oid: .1.3.6.1.2.1.10.94.1.1.14.1.29
-#       name: ietf.adslAturChanConfMaxInterleaveDelay
-#       syntax: TicksMilliSec
-
-# ADSL-LINE-MIB::adslLineAlarmConfProfileEntry:
-#   mib: ADSL-LINE-MIB
-#   object: adslLineAlarmConfProfileEntry
-#   index:
-#     - type: ImplicitOctetString
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.1
-#       name: ietf.adslLineAlarmConfProfileName
-#       syntax: DisplayString # SnmpAdminString
-#   discovery_attribute: adslAtucThresh15MinLofs
-#   attributes:
-#     adslAtucThresh15MinLofs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.2
-#       name: ietf.adslAtucThresh15MinLofs
-#       syntax: TicksSec
-#     adslAtucThresh15MinLoss:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.3
-#       name: ietf.adslAtucThresh15MinLoss
-#       syntax: TicksSec
-#     adslAtucThresh15MinLols:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.4
-#       name: ietf.adslAtucThresh15MinLols
-#       syntax: TicksSec
-#     adslAtucThresh15MinLprs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.5
-#       name: ietf.adslAtucThresh15MinLprs
-#       syntax: TicksSec
-#     adslAtucThresh15MinESs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.6
-#       name: ietf.adslAtucThresh15MinESs
-#       syntax: TicksSec
-#     adslAtucThreshFastRateUp:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.7
-#       name: ietf.adslAtucThreshFastRateUp
-#       syntax: BandwidthBits
-#     adslAtucThreshInterleaveRateUp:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.8
-#       name: ietf.adslAtucThreshInterleaveRateUp
-#       syntax: BandwidthBits
-#     adslAtucThreshFastRateDown:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.9
-#       name: ietf.adslAtucThreshFastRateDown
-#       syntax: BandwidthBits
-#     adslAtucThreshInterleaveRateDown:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.10
-#       name: ietf.adslAtucThreshInterleaveRateDown
-#       syntax: BandwidthBits
-#     adslAtucInitFailureTrapEnable:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.11
-#       name: ietf.adslAtucInitFailureTrapEnable
-#       syntax: EnumInteger
-#     adslAturThresh15MinLofs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.12
-#       name: ietf.adslAturThresh15MinLofs
-#       syntax: TicksSec
-#     adslAturThresh15MinLoss:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.13
-#       name: ietf.adslAturThresh15MinLoss
-#       syntax: TicksSec
-#     adslAturThresh15MinLprs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.14
-#       name: ietf.adslAturThresh15MinLprs
-#       syntax: TicksSec
-#     adslAturThresh15MinESs:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.15
-#       name: ietf.adslAturThresh15MinESs
-#       syntax: TicksSec
-#     adslAturThreshFastRateUp:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.16
-#       name: ietf.adslAturThreshFastRateUp
-#       syntax: BandwidthBits
-#     adslAturThreshInterleaveRateUp:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.17
-#       name: ietf.adslAturThreshInterleaveRateUp
-#       syntax: BandwidthBits
-#     adslAturThreshFastRateDown:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.18
-#       name: ietf.adslAturThreshFastRateDown
-#       syntax: BandwidthBits
-#     adslAturThreshInterleaveRateDown:
-#       oid: .1.3.6.1.2.1.10.94.1.1.15.1.19
-#       name: ietf.adslAturThreshInterleaveRateDown
-#       syntax: BandwidthBits
+      metric: counter

--- a/objects/ietf/BGP4-MIB.yml
+++ b/objects/ietf/BGP4-MIB.yml
@@ -62,18 +62,22 @@ BGP4-MIB::bgpPeerEntry:
       oid: .1.3.6.1.2.1.15.3.1.10
       name: bgp.peer.msgs.update.in
       syntax: Counter32
+      metric: counter
     bgpPeerOutUpdates:
       oid: .1.3.6.1.2.1.15.3.1.11
       name: bgp.peer.msgs.update.out
       syntax: Counter32
+      metric: counter
     bgpPeerInTotalMessages:
       oid: .1.3.6.1.2.1.15.3.1.12
       name: bgp.peer.msgs.in
       syntax: Counter32
+      metric: counter
     bgpPeerOutTotalMessages:
       oid: .1.3.6.1.2.1.15.3.1.13
       name: bgp.peer.msgs.out
       syntax: Counter32
+      metric: counter
     bgpPeerLastError:
       oid: .1.3.6.1.2.1.15.3.1.14
       name: bgp.peer.last_error
@@ -82,39 +86,49 @@ BGP4-MIB::bgpPeerEntry:
       oid: .1.3.6.1.2.1.15.3.1.15
       name: bgp.peer.fsm.established.transitions
       syntax: Counter32
+      metric: counter
     bgpPeerFsmEstablishedTime:
       oid: .1.3.6.1.2.1.15.3.1.16
       name: bgp.peer.fsm.established.duration
       syntax: Gauge32
+      metric: gauge
     bgpPeerConnectRetryInterval:
       oid: .1.3.6.1.2.1.15.3.1.17
       name: bgp.peer.connect_retry.config.interval
       syntax: Unsigned32
+      metric: gauge
     bgpPeerHoldTime:
       oid: .1.3.6.1.2.1.15.3.1.18
       name: bgp.peer.hold_time.interval
       syntax: Unsigned32
+      metric: gauge
     bgpPeerKeepAlive:
       oid: .1.3.6.1.2.1.15.3.1.19
       name: bgp.peer.keep_alive.interval
       syntax: Unsigned32
+      metric: gauge
     bgpPeerHoldTimeConfigured:
       oid: .1.3.6.1.2.1.15.3.1.20
       name: bgp.peer.hold_time.config.interval
       syntax: Unsigned32
+      metric: gauge
     bgpPeerKeepAliveConfigured:
       oid: .1.3.6.1.2.1.15.3.1.21
       name: bgp.peer.keep_alive.config.interval
       syntax: Unsigned32
+      metric: gauge
     bgpPeerMinASOriginationInterval:
       oid: .1.3.6.1.2.1.15.3.1.22
       name: bgp.peer.min_as_origin.config.interval
       syntax: Unsigned32
+      metric: gauge
     bgpPeerMinRouteAdvertisementInterval:
       oid: .1.3.6.1.2.1.15.3.1.23
       name: bgp.peer.min_route_advert.config.interval
       syntax: Unsigned32
+      metric: gauge
     bgpPeerInUpdateElapsedTime:
       oid: .1.3.6.1.2.1.15.3.1.24
       name: bgp.peer.last_update.elapsed
       syntax: Gauge32
+      metric: gauge

--- a/objects/ietf/BRIDGE-MIB.yml
+++ b/objects/ietf/BRIDGE-MIB.yml
@@ -11,6 +11,7 @@ BRIDGE-MIB::dot1dBase:
       oid: .1.3.6.1.2.1.17.1.2
       name: bridge.ports
       syntax: Integer32
+      metric: gauge
     dot1dBaseType:
       oid: .1.3.6.1.2.1.17.1.3
       name: bridge.type
@@ -40,10 +41,12 @@ BRIDGE-MIB::dot1dBasePortEntry:
       oid: .1.3.6.1.2.1.17.1.4.1.4
       name: bridge.port.frames.discard.delay
       syntax: Counter32
+      metric: counter
     dot1dBasePortMtuExceededDiscards:
       oid: .1.3.6.1.2.1.17.1.4.1.5
       name: bridge.port.frames.discard.mtu
       syntax: Counter32
+      metric: counter
 
 BRIDGE-MIB::dot1dStp:
   mib: BRIDGE-MIB
@@ -58,14 +61,17 @@ BRIDGE-MIB::dot1dStp:
       oid: .1.3.6.1.2.1.17.2.2
       name: stp.priority
       syntax: Integer32
+      metric: gauge
     dot1dStpTimeSinceTopologyChange:
       oid: .1.3.6.1.2.1.17.2.3
       name: stp.topo_chg.duration
       syntax: TimeTicks
+      metric: gauge
     dot1dStpTopChanges:
       oid: .1.3.6.1.2.1.17.2.4
       name: stp.topo_chgs
       syntax: Counter32
+      metric: counter
     dot1dStpDesignatedRoot:
       oid: .1.3.6.1.2.1.17.2.5
       name: stp.designated.root
@@ -74,6 +80,7 @@ BRIDGE-MIB::dot1dStp:
       oid: .1.3.6.1.2.1.17.2.6
       name: stp.root.cost
       syntax: Integer32
+      metric: gauge
     dot1dStpRootPort:
       oid: .1.3.6.1.2.1.17.2.7
       name: stp.root.port
@@ -81,31 +88,38 @@ BRIDGE-MIB::dot1dStp:
     dot1dStpMaxAge:
       oid: .1.3.6.1.2.1.17.2.8
       name: stp.max_age
-      syntax: Integer32
+      syntax: TicksCentiSec
+      metric: gauge
     dot1dStpHelloTime:
       oid: .1.3.6.1.2.1.17.2.9
       name: stp.hello_time
-      syntax: Integer32
+      syntax: TicksCentiSec
+      metric: gauge
     dot1dStpHoldTime:
       oid: .1.3.6.1.2.1.17.2.10
       name: stp.hold_time
-      syntax: Integer32
+      syntax: TicksCentiSec
+      metric: gauge
     dot1dStpForwardDelay:
       oid: .1.3.6.1.2.1.17.2.11
       name: stp.fwd_delay
-      syntax: Integer32
+      syntax: TicksCentiSec
+      metric: gauge
     dot1dStpBridgeMaxAge:
       oid: .1.3.6.1.2.1.17.2.12
       name: stp.as_root.max_age
-      syntax: Integer32
+      syntax: TicksCentiSec
+      metric: gauge
     dot1dStpBridgeHelloTime:
       oid: .1.3.6.1.2.1.17.2.13
       name: stp.as_root.hello_time
-      syntax: Integer32
+      syntax: TicksCentiSec
+      metric: gauge
     dot1dStpBridgeForwardDelay:
       oid: .1.3.6.1.2.1.17.2.14
       name: stp.as_root.fwd_delay
-      syntax: Integer32
+      syntax: TicksCentiSec
+      metric: gauge
 
 BRIDGE-MIB::dot1dStpPortEntry:
   mib: BRIDGE-MIB
@@ -117,6 +131,7 @@ BRIDGE-MIB::dot1dStpPortEntry:
       oid: .1.3.6.1.2.1.17.2.15.1.2
       name: bridge.port.stp.priority
       syntax: Integer32
+      metric: gauge
     dot1dStpPortState:
       oid: .1.3.6.1.2.1.17.2.15.1.3
       name: bridge.port.stp.state
@@ -129,6 +144,7 @@ BRIDGE-MIB::dot1dStpPortEntry:
       oid: .1.3.6.1.2.1.17.2.15.1.5
       name: bridge.port.stp.path_cost.oper
       syntax: Integer32
+      metric: gauge
     dot1dStpPortDesignatedRoot:
       oid: .1.3.6.1.2.1.17.2.15.1.6
       name: bridge.port.stp.designated.root
@@ -137,6 +153,7 @@ BRIDGE-MIB::dot1dStpPortEntry:
       oid: .1.3.6.1.2.1.17.2.15.1.7
       name: bridge.port.stp.designated.cost
       syntax: Integer32
+      metric: gauge
     dot1dStpPortDesignatedBridge:
       oid: .1.3.6.1.2.1.17.2.15.1.8
       name: bridge.port.stp.designated.bridge
@@ -149,10 +166,12 @@ BRIDGE-MIB::dot1dStpPortEntry:
       oid: .1.3.6.1.2.1.17.2.15.1.10
       name: bridge.port.stp.fwd_transitions
       syntax: Counter32
+      metric: counter
     dot1dStpPortPathCost32:
       oid: .1.3.6.1.2.1.17.2.15.1.11
       name: bridge.port.stp.path_cost.oper
       syntax: Integer32
+      metric: gauge
       overrides:
         object: BRIDGE-MIB::dot1dStpPortEntry
         attribute: dot1dStpPortPathCost
@@ -167,29 +186,12 @@ BRIDGE-MIB::dot1dTp:
       oid: .1.3.6.1.2.1.17.4.1
       name: bridge.transparent.fwd_db.discard.no_space
       syntax: Counter32
+      metric: counter
     dot1dTpAgingTime:
       oid: .1.3.6.1.2.1.17.4.2
       name: bridge.transparent.fwd_db.ttl
       syntax: TicksSec # Integer32
-
-# BRIDGE-MIB::dot1dTpFdbEntry:
-#   mib: BRIDGE-MIB
-#   object: dot1dTpFdbEntry
-#   index:
-#     - type: MacAddress
-#       oid: .1.3.6.1.2.1.17.4.3.1.1
-#       name: dot1dTpFdbAddress
-#       syntax: MacAddress
-#   discovery_attribute: dot1dTpFdbPort
-#   attributes:
-#     dot1dTpFdbPort:
-#       oid: .1.3.6.1.2.1.17.4.3.1.2
-#       name: dot1dTpFdbPort
-#       syntax: IntegerAsID
-#     dot1dTpFdbStatus:
-#       oid: .1.3.6.1.2.1.17.4.3.1.3
-#       name: dot1dTpFdbStatus
-#       syntax: EnumInteger
+      metric: gauge
 
 BRIDGE-MIB::dot1dTpPortEntry:
   mib: BRIDGE-MIB
@@ -201,38 +203,19 @@ BRIDGE-MIB::dot1dTpPortEntry:
       oid: .1.3.6.1.2.1.17.4.4.1.2
       name: bridge.port.transparent.info_max
       syntax: Integer32
+      metric: gauge
     dot1dTpPortInFrames:
       oid: .1.3.6.1.2.1.17.4.4.1.3
       name: bridge.port.transparent.frames.in
       syntax: Counter32
+      metric: counter
     dot1dTpPortOutFrames:
       oid: .1.3.6.1.2.1.17.4.4.1.4
       name: bridge.port.transparent.frames.out
       syntax: Counter32
+      metric: counter
     dot1dTpPortInDiscards:
       oid: .1.3.6.1.2.1.17.4.4.1.5
       name: bridge.port.transparent.frames.discard.in
       syntax: Counter32
-
-# BRIDGE-MIB::dot1dStaticEntry:
-#   mib: BRIDGE-MIB
-#   object: dot1dStaticEntry
-#   index:
-#     - type: MacAddress
-#       oid: .1.3.6.1.2.1.17.5.1.1.1
-#       name: dot1dStaticAddress
-#       syntax: MacAddress
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.5.1.1.2
-#       name: dot1dStaticReceivePort
-#       syntax: IntegerAsID
-#   discovery_attribute: dot1dStaticAllowedToGoTo
-#   attributes:
-#     dot1dStaticAllowedToGoTo:
-#       oid: .1.3.6.1.2.1.17.5.1.1.3
-#       name: dot1dStaticAllowedToGoTo
-#       syntax: OctetString
-#     dot1dStaticStatus:
-#       oid: .1.3.6.1.2.1.17.5.1.1.4
-#       name: dot1dStaticStatus
-#       syntax: EnumInteger
+      metric: counter

--- a/objects/ietf/DIAL-CONTROL-MIB.yml
+++ b/objects/ietf/DIAL-CONTROL-MIB.yml
@@ -54,6 +54,7 @@ DIAL-CONTROL-MIB::dialCtlPeerCfgEntry:
       oid: .1.3.6.1.2.1.10.21.1.2.1.1.8
       name: ietf.dialCtlPeerCfgSpeed
       syntax: BandwidthBits
+      metric: gauge
     dialCtlPeerCfgInfoType:
       oid: .1.3.6.1.2.1.10.21.1.2.1.1.9
       name: ietf.dialCtlPeerCfgInfoType
@@ -66,34 +67,37 @@ DIAL-CONTROL-MIB::dialCtlPeerCfgEntry:
       oid: .1.3.6.1.2.1.10.21.1.2.1.1.11
       name: ietf.dialCtlPeerCfgInactivityTimer
       syntax: TicksSec
+      metric: gauge
     dialCtlPeerCfgMinDuration:
       oid: .1.3.6.1.2.1.10.21.1.2.1.1.12
       name: ietf.dialCtlPeerCfgMinDuration
       syntax: TicksSec
+      metric: gauge
     dialCtlPeerCfgMaxDuration:
       oid: .1.3.6.1.2.1.10.21.1.2.1.1.13
       name: ietf.dialCtlPeerCfgMaxDuration
       syntax: TicksSec
+      metric: gauge
     dialCtlPeerCfgCarrierDelay:
       oid: .1.3.6.1.2.1.10.21.1.2.1.1.14
       name: ietf.dialCtlPeerCfgCarrierDelay
       syntax: TicksSec
+      metric: gauge
     dialCtlPeerCfgCallRetries:
       oid: .1.3.6.1.2.1.10.21.1.2.1.1.15
       name: ietf.dialCtlPeerCfgCallRetries
       syntax: Integer32
+      metric: gauge
     dialCtlPeerCfgRetryDelay:
       oid: .1.3.6.1.2.1.10.21.1.2.1.1.16
       name: ietf.dialCtlPeerCfgRetryDelay
       syntax: TicksSec
+      metric: gauge
     dialCtlPeerCfgFailureDelay:
       oid: .1.3.6.1.2.1.10.21.1.2.1.1.17
       name: ietf.dialCtlPeerCfgFailureDelay
       syntax: TicksSec
-    # dialCtlPeerCfgTrapEnable:
-    #   oid: .1.3.6.1.2.1.10.21.1.2.1.1.18
-    #   name: ietf.dialCtlPeerCfgTrapEnable
-    #   syntax: EnumInteger
+      metric: gauge
 
 DIAL-CONTROL-MIB::dialCtlPeerStatsEntry:
   mib: DIAL-CONTROL-MIB
@@ -105,26 +109,32 @@ DIAL-CONTROL-MIB::dialCtlPeerStatsEntry:
       oid: .1.3.6.1.2.1.10.21.1.2.2.1.1
       name: ietf.dialCtlPeerStatsConnectTime
       syntax: TicksSec
+      metric: counter
     dialCtlPeerStatsChargedUnits:
       oid: .1.3.6.1.2.1.10.21.1.2.2.1.2
       name: ietf.dialCtlPeerStatsChargedUnits
       syntax: Unsigned32
+      metric: counter
     dialCtlPeerStatsSuccessCalls:
       oid: .1.3.6.1.2.1.10.21.1.2.2.1.3
       name: ietf.dialCtlPeerStatsSuccessCalls
       syntax: Unsigned32
+      metric: counter
     dialCtlPeerStatsFailCalls:
       oid: .1.3.6.1.2.1.10.21.1.2.2.1.4
       name: ietf.dialCtlPeerStatsFailCalls
       syntax: Unsigned32
+      metric: counter
     dialCtlPeerStatsAcceptCalls:
       oid: .1.3.6.1.2.1.10.21.1.2.2.1.5
       name: ietf.dialCtlPeerStatsAcceptCalls
       syntax: Unsigned32
+      metric: counter
     dialCtlPeerStatsRefuseCalls:
       oid: .1.3.6.1.2.1.10.21.1.2.2.1.6
       name: ietf.dialCtlPeerStatsRefuseCalls
       syntax: Unsigned32
+      metric: counter
     dialCtlPeerStatsLastDisconnectCause:
       oid: .1.3.6.1.2.1.10.21.1.2.2.1.7
       name: ietf.dialCtlPeerStatsLastDisconnectCause
@@ -188,6 +198,7 @@ DIAL-CONTROL-MIB::callActiveEntry:
       oid: .1.3.6.1.2.1.10.21.1.3.1.1.11
       name: ietf.callActiveChargedUnits
       syntax: Unsigned32
+      metric: counter
     callActiveInfoType:
       oid: .1.3.6.1.2.1.10.21.1.3.1.1.12
       name: ietf.callActiveInfoType
@@ -196,18 +207,22 @@ DIAL-CONTROL-MIB::callActiveEntry:
       oid: .1.3.6.1.2.1.10.21.1.3.1.1.13
       name: ietf.callActiveTransmitPackets
       syntax: Unsigned32
+      metric: counter
     callActiveTransmitBytes:
       oid: .1.3.6.1.2.1.10.21.1.3.1.1.14
       name: ietf.callActiveTransmitBytes
       syntax: BytesB
+      metric: counter
     callActiveReceivePackets:
       oid: .1.3.6.1.2.1.10.21.1.3.1.1.15
       name: ietf.callActiveReceivePackets
       syntax: Unsigned32
+      metric: counter
     callActiveReceiveBytes:
       oid: .1.3.6.1.2.1.10.21.1.3.1.1.16
       name: ietf.callActiveReceiveBytes
       syntax: BytesB
+      metric: counter
 
 DIAL-CONTROL-MIB::callHistory:
   mib: DIAL-CONTROL-MIB
@@ -218,10 +233,12 @@ DIAL-CONTROL-MIB::callHistory:
       oid: .1.3.6.1.2.1.10.21.1.4.1
       name: ietf.callHistoryTableMaxLength
       syntax: Integer32
+      metric: gauge
     callHistoryRetainTimer:
       oid: .1.3.6.1.2.1.10.21.1.4.2
       name: ietf.callHistoryRetainTimer
       syntax: TicksMin
+      metric: gauge
 
 DIAL-CONTROL-MIB::callHistoryEntry:
   mib: DIAL-CONTROL-MIB
@@ -281,6 +298,7 @@ DIAL-CONTROL-MIB::callHistoryEntry:
       oid: .1.3.6.1.2.1.10.21.1.4.3.1.11
       name: ietf.callHistoryChargedUnits
       syntax: Unsigned32
+      metric: counter
     callHistoryInfoType:
       oid: .1.3.6.1.2.1.10.21.1.4.3.1.12
       name: ietf.callHistoryInfoType
@@ -289,15 +307,19 @@ DIAL-CONTROL-MIB::callHistoryEntry:
       oid: .1.3.6.1.2.1.10.21.1.4.3.1.13
       name: ietf.callHistoryTransmitPackets
       syntax: Unsigned32
+      metric: counter
     callHistoryTransmitBytes:
       oid: .1.3.6.1.2.1.10.21.1.4.3.1.14
       name: ietf.callHistoryTransmitBytes
       syntax: BytesB
+      metric: counter
     callHistoryReceivePackets:
       oid: .1.3.6.1.2.1.10.21.1.4.3.1.15
       name: ietf.callHistoryReceivePackets
       syntax: Unsigned32
+      metric: counter
     callHistoryReceiveBytes:
       oid: .1.3.6.1.2.1.10.21.1.4.3.1.16
       name: ietf.callHistoryReceiveBytes
       syntax: BytesB
+      metric: counter

--- a/objects/ietf/ENTITY-SENSOR-MIB.yml
+++ b/objects/ietf/ENTITY-SENSOR-MIB.yml
@@ -20,6 +20,7 @@ ENTITY-SENSOR-MIB::entPhySensorEntry:
       oid: .1.3.6.1.2.1.99.1.1.1.4
       name: entity.phys.sensor.value
       syntax: Integer32
+      metric: gauge
     entPhySensorOperStatus:
       oid: .1.3.6.1.2.1.99.1.1.1.5
       name: entity.phys.sensor.state.oper
@@ -36,3 +37,4 @@ ENTITY-SENSOR-MIB::entPhySensorEntry:
       oid: .1.3.6.1.2.1.99.1.1.1.8
       name: entity.phys.sensor.value_update_rate
       syntax: TicksMilliSec
+      metric: gauge

--- a/objects/ietf/ETHER-WIS.yml
+++ b/objects/ietf/ETHER-WIS.yml
@@ -20,6 +20,7 @@ ETHER-WIS::etherWisDeviceEntry:
       oid: .1.3.6.1.2.1.10.134.1.1.1.1.3
       name: ietf.etherWisDeviceRxTestPatternErrors
       syntax: Gauge32
+      metric: gauge
     # Additional Attributes as Tags
     ifDescr:
       oid: .1.3.6.1.2.1.2.2.1.2
@@ -42,21 +43,6 @@ ETHER-WIS::etherWisDeviceEntry:
       name: netif.alias
       syntax: DisplayString
 
-# ETHER-WIS::etherWisSectionCurrentEntry:
-#   mib: ETHER-WIS
-#   object: etherWisSectionCurrentEntry
-#   augments: ETHER-WIS::etherWisDeviceEntry
-#   discovery_attribute: etherWisSectionCurrentJ0Received
-#   attributes:
-#     etherWisSectionCurrentJ0Transmitted:
-#       oid: .1.3.6.1.2.1.10.134.1.2.1.1.1
-#       name: ietf.etherWisSectionCurrentJ0Transmitted
-#       syntax: OctetString
-#     etherWisSectionCurrentJ0Received:
-#       oid: .1.3.6.1.2.1.10.134.1.2.1.1.2
-#       name: ietf.etherWisSectionCurrentJ0Received
-#       syntax: OctetString
-
 ETHER-WIS::etherWisPathCurrentEntry:
   mib: ETHER-WIS
   object: etherWisPathCurrentEntry
@@ -67,14 +53,6 @@ ETHER-WIS::etherWisPathCurrentEntry:
       oid: .1.3.6.1.2.1.10.134.2.1.1.1.1
       name: ietf.etherWisPathCurrentStatus
       syntax: EnumBitmap
-#     etherWisPathCurrentJ1Transmitted:
-#       oid: .1.3.6.1.2.1.10.134.2.1.1.1.2
-#       name: ietf.etherWisPathCurrentJ1Transmitted
-#       syntax: OctetString
-#     etherWisPathCurrentJ1Received:
-#       oid: .1.3.6.1.2.1.10.134.2.1.1.1.3
-#       name: ietf.etherWisPathCurrentJ1Received
-#       syntax: OctetString
 
 ETHER-WIS::etherWisFarEndPathCurrentEntry:
   mib: ETHER-WIS

--- a/objects/ietf/EtherLike-MIB.yml
+++ b/objects/ietf/EtherLike-MIB.yml
@@ -8,50 +8,62 @@ EtherLike-MIB::dot3StatsEntry:
       oid: .1.3.6.1.2.1.10.7.2.1.2
       name: netif.ethernet.errors.alignment
       syntax: Counter32
+      metric: counter
     dot3StatsFCSErrors:
       oid: .1.3.6.1.2.1.10.7.2.1.3
       name: netif.ethernet.errors.fcs
       syntax: Counter32
+      metric: counter
     dot3StatsSingleCollisionFrames:
       oid: .1.3.6.1.2.1.10.7.2.1.4
       name: netif.ethernet.frames.single_collision
       syntax: Counter32
+      metric: counter
     dot3StatsMultipleCollisionFrames:
       oid: .1.3.6.1.2.1.10.7.2.1.5
       name: netif.ethernet.frames.multi_collision
       syntax: Counter32
+      metric: counter
     dot3StatsSQETestErrors:
       oid: .1.3.6.1.2.1.10.7.2.1.6
       name: netif.ethernet.errors.sqe_test
       syntax: Counter32
+      metric: counter
     dot3StatsDeferredTransmissions:
       oid: .1.3.6.1.2.1.10.7.2.1.7
       name: netif.ethernet.deferred_xmit
       syntax: Counter32
+      metric: counter
     dot3StatsLateCollisions:
       oid: .1.3.6.1.2.1.10.7.2.1.8
       name: netif.ethernet.collisions.late
       syntax: Counter32
+      metric: counter
     dot3StatsExcessiveCollisions:
       oid: .1.3.6.1.2.1.10.7.2.1.9
       name: netif.ethernet.collisions.excess
       syntax: Counter32
+      metric: counter
     dot3StatsInternalMacTransmitErrors:
       oid: .1.3.6.1.2.1.10.7.2.1.10
       name: netif.ethernet.errors.mac.xmit
       syntax: Counter32
+      metric: counter
     dot3StatsCarrierSenseErrors:
       oid: .1.3.6.1.2.1.10.7.2.1.11
       name: netif.ethernet.errors.carrier_sense
       syntax: Counter32
+      metric: counter
     dot3StatsFrameTooLongs:
       oid: .1.3.6.1.2.1.10.7.2.1.13
       name: netif.ethernet.frames.too_long
       syntax: Counter32
+      metric: counter
     dot3StatsInternalMacReceiveErrors:
       oid: .1.3.6.1.2.1.10.7.2.1.16
       name: netif.ethernet.errors.mac.rcv
       syntax: Counter32
+      metric: counter
     dot3StatsEtherChipSet:
       oid: .1.3.6.1.2.1.10.7.2.1.17
       name: netif.ethernet.chipset
@@ -60,6 +72,7 @@ EtherLike-MIB::dot3StatsEntry:
       oid: .1.3.6.1.2.1.10.7.2.1.18
       name: netif.ethernet.errors.symbol
       syntax: Counter32
+      metric: counter
     dot3StatsDuplexStatus:
       oid: .1.3.6.1.2.1.10.7.2.1.19
       name: netif.ethernet.duplex
@@ -87,10 +100,12 @@ EtherLike-MIB::dot3ControlEntry:
       oid: .1.3.6.1.2.1.10.7.9.1.2
       name: netif.ethernet.frames.mac_cntrl.opcode_unknown.in
       syntax: Counter32
+      metric: counter
     dot3HCControlInUnknownOpcodes:
       oid: .1.3.6.1.2.1.10.7.9.1.3
       name: netif.ethernet.frames.mac_cntrl.opcode_unknown.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: EtherLike-MIB::dot3ControlEntry
         attribute: dot3ControlInUnknownOpcodes
@@ -113,14 +128,17 @@ EtherLike-MIB::dot3PauseEntry:
       oid: .1.3.6.1.2.1.10.7.10.1.3
       name: netif.ethernet.frames.pause.in
       syntax: Counter32
+      metric: counter
     dot3OutPauseFrames:
       oid: .1.3.6.1.2.1.10.7.10.1.4
       name: netif.ethernet.frames.pause.out
       syntax: Counter32
+      metric: counter
     dot3HCInPauseFrames:
       oid: .1.3.6.1.2.1.10.7.10.1.5
       name: netif.ethernet.frames.pause.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: EtherLike-MIB::dot3PauseEntry
         attribute: dot3InPauseFrames
@@ -128,6 +146,7 @@ EtherLike-MIB::dot3PauseEntry:
       oid: .1.3.6.1.2.1.10.7.10.1.6
       name: netif.ethernet.frames.pause.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: EtherLike-MIB::dot3PauseEntry
         attribute: dot3OutPauseFrames
@@ -142,6 +161,7 @@ EtherLike-MIB::dot3HCStatsEntry:
       oid: .1.3.6.1.2.1.10.7.11.1.1
       name: netif.ethernet.errors.alignment
       syntax: Counter64
+      metric: counter
       overrides:
         object: EtherLike-MIB::dot3StatsEntry
         attribute: dot3StatsAlignmentErrors
@@ -149,6 +169,7 @@ EtherLike-MIB::dot3HCStatsEntry:
       oid: .1.3.6.1.2.1.10.7.11.1.2
       name: netif.ethernet.errors.fcs
       syntax: Counter64
+      metric: counter
       overrides:
         object: EtherLike-MIB::dot3StatsEntry
         attribute: dot3StatsFCSErrors
@@ -156,6 +177,7 @@ EtherLike-MIB::dot3HCStatsEntry:
       oid: .1.3.6.1.2.1.10.7.11.1.3
       name: netif.ethernet.errors.mac.xmit
       syntax: Counter64
+      metric: counter
       overrides:
         object: EtherLike-MIB::dot3StatsEntry
         attribute: dot3StatsInternalMacTransmitErrors
@@ -163,6 +185,7 @@ EtherLike-MIB::dot3HCStatsEntry:
       oid: .1.3.6.1.2.1.10.7.11.1.4
       name: netif.ethernet.frames.too_long
       syntax: Counter64
+      metric: counter
       overrides:
         object: EtherLike-MIB::dot3StatsEntry
         attribute: dot3StatsFrameTooLongs
@@ -170,6 +193,7 @@ EtherLike-MIB::dot3HCStatsEntry:
       oid: .1.3.6.1.2.1.10.7.11.1.5
       name: netif.ethernet.errors.mac.rcv
       syntax: Counter64
+      metric: counter
       overrides:
         object: EtherLike-MIB::dot3StatsEntry
         attribute: dot3StatsInternalMacReceiveErrors
@@ -177,6 +201,7 @@ EtherLike-MIB::dot3HCStatsEntry:
       oid: .1.3.6.1.2.1.10.7.11.1.6
       name: netif.ethernet.errors.symbol
       syntax: Counter64
+      metric: counter
       overrides:
         object: EtherLike-MIB::dot3StatsEntry
         attribute: dot3StatsSymbolErrors

--- a/objects/ietf/GMPLS-LSR-STD-MIB.yml
+++ b/objects/ietf/GMPLS-LSR-STD-MIB.yml
@@ -12,6 +12,7 @@ GMPLS-LSR-STD-MIB::gmplsInterfaceEntry:
       oid: .1.3.6.1.2.1.10.166.15.1.1.1.2
       name: gmpls.netif.rsvp.hello_interval
       syntax: TicksMilliSec
+      metric: gauge
 
 GMPLS-LSR-STD-MIB::gmplsInSegmentEntry:
   mib: GMPLS-LSR-STD-MIB

--- a/objects/ietf/GMPLS-TE-STD-MIB.yml
+++ b/objects/ietf/GMPLS-TE-STD-MIB.yml
@@ -8,10 +8,12 @@ GMPLS-TE-STD-MIB::gmplsTeScalars:
       oid: .1.3.6.1.2.1.10.166.13.1.1
       name: gmpls.tunnels.config
       syntax: Gauge32
+      metric: gauge
     gmplsTunnelsActive:
       oid: .1.3.6.1.2.1.10.166.13.1.2
       name: gmpls.tunnels.active
       syntax: Gauge32
+      metric: gauge
 
 GMPLS-TE-STD-MIB::gmplsTunnelEntry:
   mib: GMPLS-TE-STD-MIB
@@ -171,10 +173,12 @@ GMPLS-TE-STD-MIB::gmplsTunnelReversePerfEntry:
       oid: .1.3.6.1.2.1.10.166.13.2.5.1.1
       name: gmpls.tunnel.rev.packets
       syntax: Counter32
+      metric: counter
     gmplsTunnelReversePerfHCPackets:
       oid: .1.3.6.1.2.1.10.166.13.2.5.1.2
       name: gmpls.tunnel.rev.packets
       syntax: Counter64
+      metric: counter
       overrides:
         object: GMPLS-TE-STD-MIB::gmplsTunnelReversePerfEntry
         attribute: gmplsTunnelReversePerfPackets
@@ -182,14 +186,17 @@ GMPLS-TE-STD-MIB::gmplsTunnelReversePerfEntry:
       oid: .1.3.6.1.2.1.10.166.13.2.5.1.3
       name: gmpls.tunnel.rev.errors
       syntax: Counter32
+      metric: counter
     gmplsTunnelReversePerfBytes:
       oid: .1.3.6.1.2.1.10.166.13.2.5.1.4
       name: gmpls.tunnel.rev.bytes
       syntax: Counter32
+      metric: counter
     gmplsTunnelReversePerfHCBytes:
       oid: .1.3.6.1.2.1.10.166.13.2.5.1.5
       name: gmpls.tunnel.rev.bytes
       syntax: Counter64
+      metric: counter
       overrides:
         object: GMPLS-TE-STD-MIB::gmplsTunnelReversePerfEntry
         attribute: gmplsTunnelReversePerfBytes
@@ -208,6 +215,7 @@ GMPLS-TE-STD-MIB::gmplsTunnelErrorEntry:
       oid: .1.3.6.1.2.1.10.166.13.2.6.1.2
       name: gmpls.tunnel.error.sysuptime
       syntax: TimeStamp
+      metric: counter
     gmplsTunnelErrorReporter:
       oid: .1.3.6.1.2.1.10.166.13.2.6.1.4
       name: gmpls.tunnel.error.reporter

--- a/objects/ietf/HOST-RESOURCES-MIB.yml
+++ b/objects/ietf/HOST-RESOURCES-MIB.yml
@@ -7,6 +7,7 @@ HOST-RESOURCES-MIB::hrSystem:
       oid: .1.3.6.1.2.1.25.1.1
       name: system.uptime
       syntax: TimeTicks
+      metric: counter
     # hrSystemDate:
     #   oid: .1.3.6.1.2.1.25.1.2
     #   name: hrSystemDate
@@ -23,18 +24,22 @@ HOST-RESOURCES-MIB::hrSystem:
       oid: .1.3.6.1.2.1.25.1.5
       name: system.users
       syntax: Gauge32
+      metric: gauge
     hrSystemProcesses:
       oid: .1.3.6.1.2.1.25.1.6
       name: system.procs
       syntax: Gauge32
+      metric: gauge
     hrSystemMaxProcesses:
       oid: .1.3.6.1.2.1.25.1.7
       name: system.procs_max
       syntax: Integer32
+      metric: gauge
     hrMemorySize:
       oid: .1.3.6.1.2.1.25.2.2
       name: mem.total.bytes
       syntax: BytesKB
+      metric: gauge
 
 HOST-RESOURCES-MIB::hrStorageEntry:
   mib: HOST-RESOURCES-MIB
@@ -60,18 +65,22 @@ HOST-RESOURCES-MIB::hrStorageEntry:
       oid: .1.3.6.1.2.1.25.2.3.1.4
       name: disk.alloc_unit.size
       syntax: Integer32
+      metric: gauge
     hrStorageSize:
       oid: .1.3.6.1.2.1.25.2.3.1.5
       name: disk.alloc_unit.total
       syntax: Integer32
+      metric: gauge
     hrStorageUsed:
       oid: .1.3.6.1.2.1.25.2.3.1.6
       name: disk.alloc_unit.used
       syntax: Integer32
+      metric: gauge
     hrStorageAllocationFailures:
       oid: .1.3.6.1.2.1.25.2.3.1.7
       name: disk.alloc.fails
       syntax: Counter32
+      metric: counter
 
 HOST-RESOURCES-MIB::hrDeviceEntry:
   mib: HOST-RESOURCES-MIB
@@ -106,6 +115,7 @@ HOST-RESOURCES-MIB::hrDeviceEntry:
       oid: .1.3.6.1.2.1.25.3.2.1.6
       name: device.errors
       syntax: Counter32
+      metric: counter
 
 HOST-RESOURCES-MIB::hrProcessorEntry:
   mib: HOST-RESOURCES-MIB
@@ -122,6 +132,7 @@ HOST-RESOURCES-MIB::hrProcessorEntry:
       oid: .1.3.6.1.2.1.25.3.3.1.2
       name: cpu.util.pct
       syntax: Percent100
+      metric: gauge
 
 HOST-RESOURCES-MIB::hrPrinterEntry:
   mib: HOST-RESOURCES-MIB

--- a/objects/ietf/IF-MIB.yml
+++ b/objects/ietf/IF-MIB.yml
@@ -8,16 +8,19 @@ IF-MIB::system:
       oid: .1.3.6.1.2.1.2.1
       name: system.netifs
       syntax: Integer32
+      metric: gauge
       #rediscover: OnChange
     ifTableLastChange:
       oid: .1.3.6.1.2.1.31.1.5
       name: netif.count.last_chg
-      syntax: Integer32
+      syntax: TimeTicks
+      metric: counter
       #rediscover: OnChange
     ifStackLastChange:
       oid: .1.3.6.1.2.1.31.1.6
       name: netif.stack.last_chg
-      syntax: Integer32
+      syntax: TimeTicks
+      metric: counter
       #rediscover: OnChange
 
 IF-MIB::ifEntry:
@@ -44,10 +47,12 @@ IF-MIB::ifEntry:
       oid: .1.3.6.1.2.1.2.2.1.4
       name: netif.mtu
       syntax: Integer32
+      metric: gauge
     ifSpeed:
       oid: .1.3.6.1.2.1.2.2.1.5
       name: netif.bandwidth.bw
       syntax: Gauge32
+      metric: gauge
     ifPhysAddress:
       oid: .1.3.6.1.2.1.2.2.1.6
       tag: true
@@ -65,54 +70,67 @@ IF-MIB::ifEntry:
       oid: .1.3.6.1.2.1.2.2.1.9
       name: netif.last_change
       syntax: TimeTicks
+      metric: counter
     ifInOctets:
       oid: .1.3.6.1.2.1.2.2.1.10
       name: netif.bytes.in
-      syntax: Counter32
+      syntax: BytesB
+      metric: counter
     ifInUcastPkts:
       oid: .1.3.6.1.2.1.2.2.1.11
       name: netif.packets.ucast.in
       syntax: Counter32
+      metric: counter
     ifInNUcastPkts:
       oid: .1.3.6.1.2.1.2.2.1.12
       name: netif.packets.nucast.in
       syntax: Counter32
+      metric: counter
     ifInDiscards:
       oid: .1.3.6.1.2.1.2.2.1.13
       name: netif.packets.discard.in
       syntax: Counter32
+      metric: counter
     ifInErrors:
       oid: .1.3.6.1.2.1.2.2.1.14
       name: netif.packets.error.in
       syntax: Counter32
+      metric: counter
     ifInUnknownProtos:
       oid: .1.3.6.1.2.1.2.2.1.15
       name: netif.packets.unkproto.in
       syntax: Counter32
+      metric: counter
     ifOutOctets:
       oid: .1.3.6.1.2.1.2.2.1.16
       name: netif.bytes.out
-      syntax: Counter32
+      syntax: BytesB
+      metric: counter
     ifOutUcastPkts:
       oid: .1.3.6.1.2.1.2.2.1.17
       name: netif.packets.ucast.out
       syntax: Counter32
+      metric: counter
     ifOutNUcastPkts:
       oid: .1.3.6.1.2.1.2.2.1.18
       name: netif.packets.nucast.out
       syntax: Counter32
+      metric: counter
     ifOutDiscards:
       oid: .1.3.6.1.2.1.2.2.1.19
       name: netif.packets.discard.out
       syntax: Counter32
+      metric: counter
     ifOutErrors:
       oid: .1.3.6.1.2.1.2.2.1.20
       name: netif.packets.error.out
       syntax: Counter32
+      metric: counter
     ifOutQLen:
       oid: .1.3.6.1.2.1.2.2.1.21
       name: netif.queue.out
       syntax: Gauge32
+      metric: gauge
 
 IF-MIB::ifXEntry:
   mib: IF-MIB
@@ -129,22 +147,27 @@ IF-MIB::ifXEntry:
       oid: .1.3.6.1.2.1.31.1.1.1.2
       name: netif.packets.mcast.in
       syntax: Counter32
+      metric: counter
     ifInBroadcastPkts:
       oid: .1.3.6.1.2.1.31.1.1.1.3
       name: netif.packets.bcast.in
       syntax: Counter32
+      metric: counter
     ifOutMulticastPkts:
       oid: .1.3.6.1.2.1.31.1.1.1.4
       name: netif.packets.mcast.out
       syntax: Counter32
+      metric: counter
     ifOutBroadcastPkts:
       oid: .1.3.6.1.2.1.31.1.1.1.5
       name: netif.packets.bcast.out
       syntax: Counter32
+      metric: counter
     ifHCInOctets:
       oid: .1.3.6.1.2.1.31.1.1.1.6
       name: netif.bytes.in
-      syntax: Counter64
+      syntax: BytesB
+      metric: counter
       overrides:
         object: IF-MIB::ifEntry
         attribute: ifInOctets
@@ -152,6 +175,7 @@ IF-MIB::ifXEntry:
       oid: .1.3.6.1.2.1.31.1.1.1.7
       name: netif.packets.ucast.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IF-MIB::ifEntry
         attribute: ifInUcastPkts
@@ -159,6 +183,7 @@ IF-MIB::ifXEntry:
       oid: .1.3.6.1.2.1.31.1.1.1.8
       name: netif.packets.mcast.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IF-MIB::ifXEntry
         attribute: ifInMulticastPkts
@@ -166,13 +191,15 @@ IF-MIB::ifXEntry:
       oid: .1.3.6.1.2.1.31.1.1.1.9
       name: netif.packets.bcast.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IF-MIB::ifXEntry
         attribute: ifInBroadcastPkts
     ifHCOutOctets:
       oid: .1.3.6.1.2.1.31.1.1.1.10
       name: netif.bytes.out
-      syntax: Counter64
+      syntax: BytesB
+      metric: counter
       overrides:
         object: IF-MIB::ifEntry
         attribute: ifOutOctets
@@ -180,6 +207,7 @@ IF-MIB::ifXEntry:
       oid: .1.3.6.1.2.1.31.1.1.1.11
       name: netif.packets.ucast.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IF-MIB::ifEntry
         attribute: ifOutUcastPkts
@@ -187,6 +215,7 @@ IF-MIB::ifXEntry:
       oid: .1.3.6.1.2.1.31.1.1.1.12
       name: netif.packets.mcast.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IF-MIB::ifXEntry
         attribute: ifOutMulticastPkts
@@ -194,6 +223,7 @@ IF-MIB::ifXEntry:
       oid: .1.3.6.1.2.1.31.1.1.1.13
       name: netif.packets.bcast.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IF-MIB::ifXEntry
         attribute: ifOutBroadcastPkts
@@ -205,6 +235,7 @@ IF-MIB::ifXEntry:
       oid: .1.3.6.1.2.1.31.1.1.1.15
       name: netif.bandwidth.bw
       syntax: BandwidthMBits
+      metric: gauge
       overrides:
         object: IF-MIB::ifEntry
         attribute: ifSpeed
@@ -225,3 +256,4 @@ IF-MIB::ifXEntry:
       oid: .1.3.6.1.2.1.31.1.1.1.19
       name: netif.stats.discontinuity_time
       syntax: TimeTicks
+      metric: counter

--- a/objects/ietf/IGMP-MIB.yml
+++ b/objects/ietf/IGMP-MIB.yml
@@ -12,6 +12,7 @@ IGMP-MIB::igmpInterfaceEntry:
       oid: .1.3.6.1.3.59.1.1.1.1.2
       name: igmp.query.interval
       syntax: TicksSec
+      metric: gauge
     igmpInterfaceVersion:
       oid: .1.3.6.1.3.59.1.1.1.1.4
       name: igmp.version.ver
@@ -24,10 +25,12 @@ IGMP-MIB::igmpInterfaceEntry:
       oid: .1.3.6.1.3.59.1.1.1.1.6
       name: igmp.query.max_resp_time
       syntax: TicksSec
+      metric: gauge
     igmpInterfaceQuerierPresentTimeout:
       oid: .1.3.6.1.3.59.1.1.1.1.7
       name: igmp.querier.timeout_interval
       syntax: TicksSec
+      metric: gauge
     igmpInterfaceLeaveEnabled:
       oid: .1.3.6.1.3.59.1.1.1.1.8
       name: igmp.leave.enable
@@ -36,26 +39,32 @@ IGMP-MIB::igmpInterfaceEntry:
       oid: .1.3.6.1.3.59.1.1.1.1.9
       name: igmp.v1_querier_remain
       syntax: TicksSec
+      metric: gauge
     igmpInterfaceWrongVersionQueries:
       oid: .1.3.6.1.3.59.1.1.1.1.10
       name: igmp.netif.queries.wrong_version
       syntax: Counter32
+      metric: counter
     igmpInterfaceJoins:
       oid: .1.3.6.1.3.59.1.1.1.1.11
       name: igmp.netif.joins
       syntax: Counter32
+      metric: counter
     igmpInterfaceLeaves:
       oid: .1.3.6.1.3.59.1.1.1.1.12
       name: igmp.netif.leaves
       syntax: Counter32
+      metric: counter
     igmpInterfaceGroups:
       oid: .1.3.6.1.3.59.1.1.1.1.13
       name: igmp.groups
       syntax: Gauge32
+      metric: gauge
     igmpInterfaceRobustness:
       oid: .1.3.6.1.3.59.1.1.1.1.14
       name: igmp.robustness
       syntax: Integer32
+      metric: gauge
     # Additional Attributes as Tags
     ifDescr:
       oid: .1.3.6.1.2.1.2.2.1.2

--- a/objects/ietf/IGMP-STD-MIB.yml
+++ b/objects/ietf/IGMP-STD-MIB.yml
@@ -12,6 +12,7 @@ IGMP-STD-MIB::igmpInterfaceEntry:
       oid: .1.3.6.1.2.1.85.1.1.1.2
       name: igmp.query.interval
       syntax: TicksSec
+      metric: gauge
     igmpInterfaceVersion:
       oid: .1.3.6.1.2.1.85.1.1.1.4
       name: igmp.version.ver
@@ -24,26 +25,32 @@ IGMP-STD-MIB::igmpInterfaceEntry:
       oid: .1.3.6.1.2.1.85.1.1.1.6
       name: igmp.query.max_resp_time
       syntax: TicksDeciSec
+      metric: gauge
     igmpInterfaceQuerierUpTime:
       oid: .1.3.6.1.2.1.85.1.1.1.7
       name: igmp.querier.uptime
       syntax: TimeTicks
+      metric: gauge
     igmpInterfaceQuerierExpiryTime:
       oid: .1.3.6.1.2.1.85.1.1.1.8
       name: igmp.querier.expiry_time
       syntax: TimeTicks
+      metric: gauge
     igmpInterfaceVersion1QuerierTimer:
       oid: .1.3.6.1.2.1.85.1.1.1.9
       name: igmp.v1_querier_remain
       syntax: TimeTicks
+      metric: gauge
     igmpInterfaceWrongVersionQueries:
       oid: .1.3.6.1.2.1.85.1.1.1.10
       name: igmp.netif.queries.wrong_version
       syntax: Counter32
+      metric: counter
     igmpInterfaceJoins:
       oid: .1.3.6.1.2.1.85.1.1.1.11
       name: igmp.netif.joins
       syntax: Counter32
+      metric: counter
     igmpInterfaceProxyIfIndex:
       oid: .1.3.6.1.2.1.85.1.1.1.12
       name: igmp.proxy.netif
@@ -52,14 +59,17 @@ IGMP-STD-MIB::igmpInterfaceEntry:
       oid: .1.3.6.1.2.1.85.1.1.1.13
       name: igmp.groups
       syntax: Gauge32
+      metric: gauge
     igmpInterfaceRobustness:
       oid: .1.3.6.1.2.1.85.1.1.1.14
       name: igmp.robustness
       syntax: Unsigned32
+      metric: gauge
     igmpInterfaceLastMembQueryIntvl:
       oid: .1.3.6.1.2.1.85.1.1.1.15
       name: igmp.last_member_query_interval
       syntax: Unsigned32
+      metric: gauge
     # Additional Attributes as Tags
     ifDescr:
       oid: .1.3.6.1.2.1.2.2.1.2

--- a/objects/ietf/IP-FORWARD-MIB.yml
+++ b/objects/ietf/IP-FORWARD-MIB.yml
@@ -7,14 +7,17 @@ IP-FORWARD-MIB::ipForward:
       oid: .1.3.6.1.2.1.4.24.3
       name: ip.routes.valid
       syntax: Gauge32
+      metric: gauge
     inetCidrRouteNumber:
       oid: .1.3.6.1.2.1.4.24.6
       name: ip.routes.valid
       syntax: Gauge32
+      metric: gauge
       overrides:
         object: IP-FORWARD-MIB::ipForward
         attribute: ipCidrRouteNumber
     inetCidrRouteDiscards:
       oid: .1.3.6.1.2.1.4.24.8
       name: ip.routes.discard
-      syntax: Gauge32
+      syntax: Counter32
+      metric: counter

--- a/objects/ietf/IP-MIB.yml
+++ b/objects/ietf/IP-MIB.yml
@@ -11,74 +11,92 @@ IP-MIB::ip:
       oid: .1.3.6.1.2.1.4.2
       name: ip.ttl_default
       syntax: Integer32
+      metric: gauge
     ipInReceives:
       oid: .1.3.6.1.2.1.4.3
       name: ip.dgrms.in
       syntax: Counter32
+      metric: counter
     ipInHdrErrors:
       oid: .1.3.6.1.2.1.4.4
       name: ip.dgrms.discard.header_error.in
       syntax: Counter32
+      metric: counter
     ipInAddrErrors:
       oid: .1.3.6.1.2.1.4.5
       name: ip.dgrms.discard.addr_error.in
       syntax: Counter32
+      metric: counter
     ipForwDatagrams:
       oid: .1.3.6.1.2.1.4.6
       name: ip.dgrms.fwd.in
       syntax: Counter32
+      metric: counter
     ipInUnknownProtos:
       oid: .1.3.6.1.2.1.4.7
       name: ip.dgrms.discard.unkproto.in
       syntax: Counter32
+      metric: counter
     ipInDiscards:
       oid: .1.3.6.1.2.1.4.8
       name: ip.dgrms.discard.no_error.in
       syntax: Counter32
+      metric: counter
     ipInDelivers:
       oid: .1.3.6.1.2.1.4.9
       name: ip.dgrms.deliver.in
       syntax: Counter32
+      metric: counter
     ipOutRequests:
       oid: .1.3.6.1.2.1.4.10
       name: ip.dgrms.req.out
       syntax: Counter32
+      metric: counter
     ipOutDiscards:
       oid: .1.3.6.1.2.1.4.11
       name: ip.dgrms.discard.no_error.out
       syntax: Counter32
+      metric: counter
     ipOutNoRoutes:
       oid: .1.3.6.1.2.1.4.12
       name: ip.dgrms.discard.no_route.out
       syntax: Counter32
+      metric: counter
     ipReasmTimeout:
       oid: .1.3.6.1.2.1.4.13
       name: ip.frags.reassem.timeout
       syntax: Integer32
+      metric: counter
     ipReasmReqds:
       oid: .1.3.6.1.2.1.4.14
       name: ip.frags.reassem.req
       syntax: Counter32
+      metric: counter
     ipReasmOKs:
       oid: .1.3.6.1.2.1.4.15
       name: ip.dgrms.reassem.ok
       syntax: Counter32
+      metric: counter
     ipReasmFails:
       oid: .1.3.6.1.2.1.4.16
       name: ip.dgrms.reassem.fail
       syntax: Counter32
+      metric: counter
     ipFragOKs:
       oid: .1.3.6.1.2.1.4.17
       name: ip.dgrms.frag.ok.out
       syntax: Counter32
+      metric: counter
     ipFragFails:
       oid: .1.3.6.1.2.1.4.18
       name: ip.dgrms.frag.fail.out
       syntax: Counter32
+      metric: counter
     ipFragCreates:
       oid: .1.3.6.1.2.1.4.19
       name: ip.frags.created.out
       syntax: Counter32
+      metric: counter
     ipv6IpForwarding:
       oid: .1.3.6.1.2.1.4.25
       name: ip.v6.forward
@@ -87,18 +105,22 @@ IP-MIB::ip:
       oid: .1.3.6.1.2.1.4.26
       name: ip.v6.hop_limit_default
       syntax: Integer32
+      metric: gauge
     ipv4InterfaceTableLastChange:
       oid: .1.3.6.1.2.1.4.27
       name: ip.v4.netif.last_change
       syntax: TimeStamp
+      metric: counter
     ipv6InterfaceTableLastChange:
       oid: .1.3.6.1.2.1.4.29
       name: ip.v6.netif.last_change
       syntax: TimeStamp
+      metric: counter
     ipIfStatsTableLastChange:
       oid: .1.3.6.1.2.1.4.31.2
       name: ip.stats.netif.last_change
       syntax: TimeStamp
+      metric: counter
 
 IP-MIB::ipSystemStatsEntry:
   mib: IP-MIB
@@ -114,10 +136,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.3
       name: ip.dgrms.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCInReceives:
       oid: .1.3.6.1.2.1.4.31.1.1.4
       name: ip.dgrms.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsInReceives
@@ -125,10 +149,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.5
       name: ip.bytes.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCInOctets:
       oid: .1.3.6.1.2.1.4.31.1.1.6
       name: ip.bytes.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsInOctets
@@ -136,30 +162,37 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.7
       name: ip.dgrms.discard.header_error.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsInNoRoutes:
       oid: .1.3.6.1.2.1.4.31.1.1.8
       name: ip.dgrms.discard.no_route.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsInAddrErrors:
       oid: .1.3.6.1.2.1.4.31.1.1.9
       name: ip.dgrms.discard.addr_error.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsInUnknownProtos:
       oid: .1.3.6.1.2.1.4.31.1.1.10
       name: ip.dgrms.discard.unkproto.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsInTruncatedPkts:
       oid: .1.3.6.1.2.1.4.31.1.1.11
       name: ip.dgrms.discard.trunc.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsInForwDatagrams:
       oid: .1.3.6.1.2.1.4.31.1.1.12
       name: ip.dgrms.fwd.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCInForwDatagrams:
       oid: .1.3.6.1.2.1.4.31.1.1.13
       name: ip.dgrms.fwd.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsInForwDatagrams
@@ -167,26 +200,32 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.14
       name: ip.frags.reassem.req
       syntax: Counter32
+      metric: counter
     ipSystemStatsReasmOKs:
       oid: .1.3.6.1.2.1.4.31.1.1.15
       name: ip.dgrms.reassem.ok
       syntax: Counter32
+      metric: counter
     ipSystemStatsReasmFails:
       oid: .1.3.6.1.2.1.4.31.1.1.16
       name: ip.dgrms.reassem.fail
       syntax: Counter32
+      metric: counter
     ipSystemStatsInDiscards:
       oid: .1.3.6.1.2.1.4.31.1.1.17
       name: ip.dgrms.discard.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsInDelivers:
       oid: .1.3.6.1.2.1.4.31.1.1.18
       name: ip.dgrms.deliver.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCInDelivers:
       oid: .1.3.6.1.2.1.4.31.1.1.19
       name: ip.dgrms.deliver.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsInDelivers
@@ -194,10 +233,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.20
       name: ip.dgrms.req.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCOutRequests:
       oid: .1.3.6.1.2.1.4.31.1.1.21
       name: ip.dgrms.req.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsOutRequests
@@ -205,14 +246,17 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.22
       name: ip.dgrms.discard.no_route.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsOutForwDatagrams:
       oid: .1.3.6.1.2.1.4.31.1.1.23
       name: ip.dgrms.fwd.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCOutForwDatagrams:
       oid: .1.3.6.1.2.1.4.31.1.1.24
       name: ip.dgrms.fwd.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsOutForwDatagrams
@@ -220,30 +264,37 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.25
       name: ip.dgrms.discard.no_error.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsOutFragReqds:
       oid: .1.3.6.1.2.1.4.31.1.1.26
       name: ip.dgrms.frag.req.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsOutFragOKs:
       oid: .1.3.6.1.2.1.4.31.1.1.27
       name: ip.dgrms.frag.ok.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsOutFragFails:
       oid: .1.3.6.1.2.1.4.31.1.1.28
       name: ip.dgrms.frag.fail.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsOutFragCreates:
       oid: .1.3.6.1.2.1.4.31.1.1.29
       name: ip.frags.created.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsOutTransmits:
       oid: .1.3.6.1.2.1.4.31.1.1.30
       name: ip.dgrms.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCOutTransmits:
       oid: .1.3.6.1.2.1.4.31.1.1.31
       name: ip.dgrms.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsOutTransmits
@@ -251,10 +302,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.32
       name: ip.bytes.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCOutOctets:
       oid: .1.3.6.1.2.1.4.31.1.1.33
       name: ip.bytes.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsOutOctets
@@ -262,10 +315,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.34
       name: ip.dgrms.mcast.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCInMcastPkts:
       oid: .1.3.6.1.2.1.4.31.1.1.35
       name: ip.dgrms.mcast.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsInMcastPkts
@@ -273,10 +328,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.36
       name: ip.bytes.mcast.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCInMcastOctets:
       oid: .1.3.6.1.2.1.4.31.1.1.37
       name: ip.bytes.mcast.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsInMcastOctets
@@ -284,10 +341,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.38
       name: ip.dgrms.mcast.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCOutMcastPkts:
       oid: .1.3.6.1.2.1.4.31.1.1.39
       name: ip.dgrms.mcast.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsOutMcastPkts
@@ -295,10 +354,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.40
       name: ip.bytes.mcast.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCOutMcastOctets:
       oid: .1.3.6.1.2.1.4.31.1.1.41
       name: ip.bytes.mcast.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsOutMcastOctets
@@ -306,10 +367,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.42
       name: ip.dgrms.bcast.in
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCInBcastPkts:
       oid: .1.3.6.1.2.1.4.31.1.1.43
       name: ip.dgrms.bcast.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsInBcastPkts
@@ -317,10 +380,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.44
       name: ip.dgrms.bcast.out
       syntax: Counter32
+      metric: counter
     ipSystemStatsHCOutBcastPkts:
       oid: .1.3.6.1.2.1.4.31.1.1.45
       name: ip.dgrms.bcast.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipSystemStatsEntry
         attribute: ipSystemStatsOutBcastPkts
@@ -328,10 +393,12 @@ IP-MIB::ipSystemStatsEntry:
       oid: .1.3.6.1.2.1.4.31.1.1.46
       name: ip.stats.system.discontinuity_time
       syntax: TimeStamp
+      metric: counter
     ipSystemStatsRefreshRate:
       oid: .1.3.6.1.2.1.4.31.1.1.47
       name: ip.stats.system.refresh_rate
       syntax: Unsigned32
+      metric: gauge
 
 IP-MIB::ipIfStatsEntry:
   mib: IP-MIB
@@ -351,10 +418,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.3
       name: ip.dgrms.in
       syntax: Counter32
+      metric: counter
     ipIfStatsHCInReceives:
       oid: .1.3.6.1.2.1.4.31.3.1.4
       name: ip.dgrms.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsInReceives
@@ -362,10 +431,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.5
       name: ip.bytes.in
       syntax: Counter32
+      metric: counter
     ipIfStatsHCInOctets:
       oid: .1.3.6.1.2.1.4.31.3.1.6
       name: ip.bytes.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsInOctets
@@ -373,30 +444,37 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.7
       name: ip.dgrms.discard.header_error.in
       syntax: Counter32
+      metric: counter
     ipIfStatsInNoRoutes:
       oid: .1.3.6.1.2.1.4.31.3.1.8
       name: ip.dgrms.discard.no_route.in
       syntax: Counter32
+      metric: counter
     ipIfStatsInAddrErrors:
       oid: .1.3.6.1.2.1.4.31.3.1.9
       name: ip.dgrms.discard.addr_error.in
       syntax: Counter32
+      metric: counter
     ipIfStatsInUnknownProtos:
       oid: .1.3.6.1.2.1.4.31.3.1.10
       name: ip.dgrms.discard.unkproto.in
       syntax: Counter32
+      metric: counter
     ipIfStatsInTruncatedPkts:
       oid: .1.3.6.1.2.1.4.31.3.1.11
       name: ip.dgrms.discard.trunc.in
       syntax: Counter32
+      metric: counter
     ipIfStatsInForwDatagrams:
       oid: .1.3.6.1.2.1.4.31.3.1.12
       name: ip.dgrms.fwd.in
       syntax: Counter32
+      metric: counter
     ipIfStatsHCInForwDatagrams:
       oid: .1.3.6.1.2.1.4.31.3.1.13
       name: ip.dgrms.fwd.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsInForwDatagrams
@@ -404,26 +482,32 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.14
       name: ip.frags.reassem.req
       syntax: Counter32
+      metric: counter
     ipIfStatsReasmOKs:
       oid: .1.3.6.1.2.1.4.31.3.1.15
       name: ip.dgrms.reassem.ok
       syntax: Counter32
+      metric: counter
     ipIfStatsReasmFails:
       oid: .1.3.6.1.2.1.4.31.3.1.16
       name: ip.dgrms.reassem.fail
       syntax: Counter32
+      metric: counter
     ipIfStatsInDiscards:
       oid: .1.3.6.1.2.1.4.31.3.1.17
       name: ip.dgrms.discard.in
       syntax: Counter32
+      metric: counter
     ipIfStatsInDelivers:
       oid: .1.3.6.1.2.1.4.31.3.1.18
       name: ip.dgrms.deliver.in
       syntax: Counter32
+      metric: counter
     ipIfStatsHCInDelivers:
       oid: .1.3.6.1.2.1.4.31.3.1.19
       name: ip.dgrms.deliver.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsInDelivers
@@ -431,10 +515,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.20
       name: ip.dgrms.req.out
       syntax: Counter32
+      metric: counter
     ipIfStatsHCOutRequests:
       oid: .1.3.6.1.2.1.4.31.3.1.21
       name: ip.dgrms.req.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsOutRequests
@@ -442,10 +528,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.23
       name: ip.dgrms.fwd.out
       syntax: Counter32
+      metric: counter
     ipIfStatsHCOutForwDatagrams:
       oid: .1.3.6.1.2.1.4.31.3.1.24
       name: ip.dgrms.fwd.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsOutForwDatagrams
@@ -453,30 +541,37 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.25
       name: ip.dgrms.discard.no_error.out
       syntax: Counter32
+      metric: counter
     ipIfStatsOutFragReqds:
       oid: .1.3.6.1.2.1.4.31.3.1.26
       name: ip.dgrms.frag.req.out
       syntax: Counter32
+      metric: counter
     ipIfStatsOutFragOKs:
       oid: .1.3.6.1.2.1.4.31.3.1.27
       name: ip.dgrms.frag.ok.out
       syntax: Counter32
+      metric: counter
     ipIfStatsOutFragFails:
       oid: .1.3.6.1.2.1.4.31.3.1.28
       name: ip.dgrms.frag.fail.out
       syntax: Counter32
+      metric: counter
     ipIfStatsOutFragCreates:
       oid: .1.3.6.1.2.1.4.31.3.1.29
       name: ip.frags.created.out
       syntax: Counter32
+      metric: counter
     ipIfStatsOutTransmits:
       oid: .1.3.6.1.2.1.4.31.3.1.30
       name: ip.dgrms.out
       syntax: Counter32
+      metric: counter
     ipIfStatsHCOutTransmits:
       oid: .1.3.6.1.2.1.4.31.3.1.31
       name: ip.dgrms.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsOutTransmits
@@ -484,10 +579,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.32
       name: ip.bytes.out
       syntax: Counter32
+      metric: counter
     ipIfStatsHCOutOctets:
       oid: .1.3.6.1.2.1.4.31.3.1.33
       name: ip.bytes.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsOutOctets
@@ -495,10 +592,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.34
       name: ip.dgrms.mcast.in
       syntax: Counter32
+      metric: counter
     ipIfStatsHCInMcastPkts:
       oid: .1.3.6.1.2.1.4.31.3.1.35
       name: ip.dgrms.mcast.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsInMcastPkts
@@ -506,10 +605,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.36
       name: ip.bytes.mcast.in
       syntax: Counter32
+      metric: counter
     ipIfStatsHCInMcastOctets:
       oid: .1.3.6.1.2.1.4.31.3.1.37
       name: ip.bytes.mcast.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsInMcastOctets
@@ -517,10 +618,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.38
       name: ip.dgrms.mcast.out
       syntax: Counter32
+      metric: counter
     ipIfStatsHCOutMcastPkts:
       oid: .1.3.6.1.2.1.4.31.3.1.39
       name: ip.dgrms.mcast.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsOutMcastPkts
@@ -528,10 +631,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.40
       name: ip.bytes.mcast.out
       syntax: Counter32
+      metric: counter
     ipIfStatsHCOutMcastOctets:
       oid: .1.3.6.1.2.1.4.31.3.1.41
       name: ip.bytes.mcast.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsOutMcastOctets
@@ -539,10 +644,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.42
       name: ip.dgrms.bcast.in
       syntax: Counter32
+      metric: counter
     ipIfStatsHCInBcastPkts:
       oid: .1.3.6.1.2.1.4.31.3.1.43
       name: ip.dgrms.bcast.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsInBcastPkts
@@ -550,10 +657,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.44
       name: ip.dgrms.bcast.out
       syntax: Counter32
+      metric: counter
     ipIfStatsHCOutBcastPkts:
       oid: .1.3.6.1.2.1.4.31.3.1.45
       name: ip.dgrms.bcast.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: IP-MIB::ipIfStatsEntry
         attribute: ipIfStatsOutBcastPkts
@@ -561,10 +670,12 @@ IP-MIB::ipIfStatsEntry:
       oid: .1.3.6.1.2.1.4.31.3.1.46
       name: ip.stats.netif.discontinuity_time
       syntax: TimeStamp
+      metric: counter
     ipIfStatsRefreshRate:
       oid: .1.3.6.1.2.1.4.31.3.1.47
       name: ip.stats.netif.refresh_rate
       syntax: Unsigned32
+      metric: gauge
 
 IP-MIB::ipAddressEntry:
   mib: IP-MIB
@@ -600,10 +711,12 @@ IP-MIB::ipAddressEntry:
       oid: .1.3.6.1.2.1.4.34.1.8
       name: ip.address.created
       syntax: TimeStamp
+      metric: counter
     ipAddressLastChanged:
       oid: .1.3.6.1.2.1.4.34.1.9
       name: ip.address.last_chg
       syntax: TimeStamp
+      metric: counter
 
 IP-MIB::icmp:
   mib: IP-MIB
@@ -614,106 +727,132 @@ IP-MIB::icmp:
       oid: .1.3.6.1.2.1.5.1
       name: icmp.msgs.in
       syntax: Counter32
+      metric: counter
     icmpInErrors:
       oid: .1.3.6.1.2.1.5.2
       name: icmp.msgs.error.in
       syntax: Counter32
+      metric: counter
     icmpInDestUnreachs:
       oid: .1.3.6.1.2.1.5.3
       name: icmp.msgs.dst_unreach.in
       syntax: Counter32
+      metric: counter
     icmpInTimeExcds:
       oid: .1.3.6.1.2.1.5.4
       name: icmp.msgs.time_exceed.in
       syntax: Counter32
+      metric: counter
     icmpInParmProbs:
       oid: .1.3.6.1.2.1.5.5
       name: icmp.msgs.param_prob.in
       syntax: Counter32
+      metric: counter
     icmpInSrcQuenchs:
       oid: .1.3.6.1.2.1.5.6
       name: icmp.msgs.src_quench.in
       syntax: Counter32
+      metric: counter
     icmpInRedirects:
       oid: .1.3.6.1.2.1.5.7
       name: icmp.msgs.redirect.in
       syntax: Counter32
+      metric: counter
     icmpInEchos:
       oid: .1.3.6.1.2.1.5.8
       name: icmp.msgs.echo_req.in
       syntax: Counter32
+      metric: counter
     icmpInEchoReps:
       oid: .1.3.6.1.2.1.5.9
       name: icmp.msgs.echo_reply.in
       syntax: Counter32
+      metric: counter
     icmpInTimestamps:
       oid: .1.3.6.1.2.1.5.10
       name: icmp.msgs.timestamp_req.in
       syntax: Counter32
+      metric: counter
     icmpInTimestampReps:
       oid: .1.3.6.1.2.1.5.11
       name: icmp.msgs.timestamp_reply.in
       syntax: Counter32
+      metric: counter
     icmpInAddrMasks:
       oid: .1.3.6.1.2.1.5.12
       name: icmp.msgs.addr_mask_req.in
       syntax: Counter32
+      metric: counter
     icmpInAddrMaskReps:
       oid: .1.3.6.1.2.1.5.13
       name: icmp.msgs.addr_mask_reply.in
       syntax: Counter32
+      metric: counter
     icmpOutMsgs:
       oid: .1.3.6.1.2.1.5.14
       name: icmp.msgs.out
       syntax: Counter32
+      metric: counter
     icmpOutErrors:
       oid: .1.3.6.1.2.1.5.15
       name: icmp.msgs.error.out
       syntax: Counter32
+      metric: counter
     icmpOutDestUnreachs:
       oid: .1.3.6.1.2.1.5.16
       name: icmp.msgs.dst_unreach.out
       syntax: Counter32
+      metric: counter
     icmpOutTimeExcds:
       oid: .1.3.6.1.2.1.5.17
       name: icmp.msgs.time_exceed.out
       syntax: Counter32
+      metric: counter
     icmpOutParmProbs:
       oid: .1.3.6.1.2.1.5.18
       name: icmp.msgs.param_prob.out
       syntax: Counter32
+      metric: counter
     icmpOutSrcQuenchs:
       oid: .1.3.6.1.2.1.5.19
       name: icmp.msgs.src_quench.out
       syntax: Counter32
+      metric: counter
     icmpOutRedirects:
       oid: .1.3.6.1.2.1.5.20
       name: icmp.msgs.redirect.out
       syntax: Counter32
+      metric: counter
     icmpOutEchos:
       oid: .1.3.6.1.2.1.5.21
       name: icmp.msgs.echo_req.out
       syntax: Counter32
+      metric: counter
     icmpOutEchoReps:
       oid: .1.3.6.1.2.1.5.22
       name: icmp.msgs.echo_reply.out
       syntax: Counter32
+      metric: counter
     icmpOutTimestamps:
       oid: .1.3.6.1.2.1.5.23
       name: icmp.msgs.timestamp_req.out
       syntax: Counter32
+      metric: counter
     icmpOutTimestampReps:
       oid: .1.3.6.1.2.1.5.24
       name: icmp.msgs.timestamp_reply.out
       syntax: Counter32
+      metric: counter
     icmpOutAddrMasks:
       oid: .1.3.6.1.2.1.5.25
       name: icmp.msgs.addr_mask_req.out
       syntax: Counter32
+      metric: counter
     icmpOutAddrMaskReps:
       oid: .1.3.6.1.2.1.5.26
       name: icmp.msgs.addr_mask_reply.out
       syntax: Counter32
+      metric: counter
 
 IP-MIB::icmpStatsEntry:
   mib: IP-MIB
@@ -729,18 +868,22 @@ IP-MIB::icmpStatsEntry:
       oid: .1.3.6.1.2.1.5.29.1.2
       name: icmp.msgs.in
       syntax: Counter32
+      metric: counter
     icmpStatsInErrors:
       oid: .1.3.6.1.2.1.5.29.1.3
       name: icmp.errors.in
       syntax: Counter32
+      metric: counter
     icmpStatsOutMsgs:
       oid: .1.3.6.1.2.1.5.29.1.4
       name: icmp.msgs.out
       syntax: Counter32
+      metric: counter
     icmpStatsOutErrors:
       oid: .1.3.6.1.2.1.5.29.1.5
       name: icmp.errors.out
       syntax: Counter32
+      metric: counter
 
 IP-MIB::icmpMsgStatsEntry:
   mib: IP-MIB
@@ -760,7 +903,9 @@ IP-MIB::icmpMsgStatsEntry:
       oid: .1.3.6.1.2.1.5.30.1.3
       name: icmp.msgs.in
       syntax: Counter32
+      metric: counter
     icmpMsgStatsOutPkts:
       oid: .1.3.6.1.2.1.5.30.1.4
       name: icmp.msgs.out
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/IPV6-ICMP-MIB.yml
+++ b/objects/ietf/IPV6-ICMP-MIB.yml
@@ -12,135 +12,169 @@ IPV6-ICMP-MIB::ipv6IfIcmpEntry:
       oid: .1.3.6.1.2.1.56.1.1.1.1
       name: icmp.msgs.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInErrors:
       oid: .1.3.6.1.2.1.56.1.1.1.2
       name: icmp.msgs.error.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInDestUnreachs:
       oid: .1.3.6.1.2.1.56.1.1.1.3
       name: icmp.msgs.dst_unreach.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInAdminProhibs:
       oid: .1.3.6.1.2.1.56.1.1.1.4
       name: icmp.msgs.admin_prohibit.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInTimeExcds:
       oid: .1.3.6.1.2.1.56.1.1.1.5
       name: icmp.msgs.time_exceed.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInParmProblems:
       oid: .1.3.6.1.2.1.56.1.1.1.6
       name: icmp.msgs.param_prob.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInPktTooBigs:
       oid: .1.3.6.1.2.1.56.1.1.1.7
       name: icmp.msgs.packet_too_big.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInEchos:
       oid: .1.3.6.1.2.1.56.1.1.1.8
       name: icmp.msgs.echo_req.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInEchoReplies:
       oid: .1.3.6.1.2.1.56.1.1.1.9
       name: icmp.msgs.echo_reply.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInRouterSolicits:
       oid: .1.3.6.1.2.1.56.1.1.1.10
       name: icmp.msgs.router_solicit.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInRouterAdvertisements:
       oid: .1.3.6.1.2.1.56.1.1.1.11
       name: icmp.msgs.router_advert.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInNeighborSolicits:
       oid: .1.3.6.1.2.1.56.1.1.1.12
       name: icmp.msgs.neighbor_solicit.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInNeighborAdvertisements:
       oid: .1.3.6.1.2.1.56.1.1.1.13
       name: icmp.msgs.neighbor_advert.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInRedirects:
       oid: .1.3.6.1.2.1.56.1.1.1.14
       name: icmp.msgs.redirect.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInGroupMembQueries:
       oid: .1.3.6.1.2.1.56.1.1.1.15
       name: icmp.msgs.group_member_query.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInGroupMembResponses:
       oid: .1.3.6.1.2.1.56.1.1.1.16
       name: icmp.msgs.group_member_reply.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpInGroupMembReductions:
       oid: .1.3.6.1.2.1.56.1.1.1.17
       name: icmp.msgs.group_member_reduct.in
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutMsgs:
       oid: .1.3.6.1.2.1.56.1.1.1.18
       name: icmp.msgs.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutErrors:
       oid: .1.3.6.1.2.1.56.1.1.1.19
       name: icmp.msgs.errors.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutDestUnreachs:
       oid: .1.3.6.1.2.1.56.1.1.1.20
       name: icmp.msgs.dst_unreach.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutAdminProhibs:
       oid: .1.3.6.1.2.1.56.1.1.1.21
       name: icmp.msgs.admin_prohibit.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutTimeExcds:
       oid: .1.3.6.1.2.1.56.1.1.1.22
       name: icmp.msgs.time_exceed.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutParmProblems:
       oid: .1.3.6.1.2.1.56.1.1.1.23
       name: icmp.msgs.param_prob.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutPktTooBigs:
       oid: .1.3.6.1.2.1.56.1.1.1.24
       name: icmp.msgs.packet_too_big.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutEchos:
       oid: .1.3.6.1.2.1.56.1.1.1.25
       name: icmp.msgs.echo_req.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutEchoReplies:
       oid: .1.3.6.1.2.1.56.1.1.1.26
       name: icmp.msgs.echo_reply.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutRouterSolicits:
       oid: .1.3.6.1.2.1.56.1.1.1.27
       name: icmp.msgs.router_solicit.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutRouterAdvertisements:
       oid: .1.3.6.1.2.1.56.1.1.1.28
       name: icmp.msgs.router_advert.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutNeighborSolicits:
       oid: .1.3.6.1.2.1.56.1.1.1.29
       name: icmp.msgs.neighbor_solicit.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutNeighborAdvertisements:
       oid: .1.3.6.1.2.1.56.1.1.1.30
       name: icmp.msgs.neighbor_advert.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutRedirects:
       oid: .1.3.6.1.2.1.56.1.1.1.31
       name: icmp.msgs.redirect.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutGroupMembQueries:
       oid: .1.3.6.1.2.1.56.1.1.1.32
       name: icmp.msgs.group_member_query.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutGroupMembResponses:
       oid: .1.3.6.1.2.1.56.1.1.1.33
       name: icmp.msgs.group_member_reply.out
       syntax: Counter32
+      metric: counter
     ipv6IfIcmpOutGroupMembReductions:
       oid: .1.3.6.1.2.1.56.1.1.1.34
       name: icmp.msgs.group_member_reduct.out
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/IPV6-MIB.yml
+++ b/objects/ietf/IPV6-MIB.yml
@@ -11,22 +11,27 @@ IPV6-MIB::ipv6MIBObjects:
       oid: .1.3.6.1.2.1.55.1.2
       name: ip.ttl_default
       syntax: Integer
+      metric: gauge
     ipv6Interfaces:
       oid: .1.3.6.1.2.1.55.1.3
       name: ip.v6.netifs
       syntax: Unsigned32
+      metric: gauge
     ipv6IfTableLastChange:
       oid: .1.3.6.1.2.1.55.1.4
       name: ip.v6.netif.last_change
       syntax: TimeStamp
+      metric: counter
     ipv6RouteNumber:
       oid: .1.3.6.1.2.1.55.1.9
       name: ip.v6.routes.current
       syntax: Gauge32
+      metric: gauge
     ipv6DiscardedRoutes:
       oid: .1.3.6.1.2.1.55.1.10
       name: ip.v6.routes.discard
       syntax: Counter32
+      metric: counter
 
 IPV6-MIB::ipv6IfEntry:
   mib: IPV6-MIB
@@ -50,10 +55,12 @@ IPV6-MIB::ipv6IfEntry:
       oid: .1.3.6.1.2.1.55.1.5.1.4
       name: ip.v6.effective_mtu
       syntax: Unsigned32
+      metric: gauge
     ipv6IfReasmMaxSize:
       oid: .1.3.6.1.2.1.55.1.5.1.5
       name: ip.v6.reassem.max_size
       syntax: Unsigned32
+      metric: gauge
     ipv6IfIdentifier:
       oid: .1.3.6.1.2.1.55.1.5.1.6
       name: ip.v6.netif.id
@@ -78,6 +85,7 @@ IPV6-MIB::ipv6IfEntry:
       oid: .1.3.6.1.2.1.55.1.5.1.11
       name: ip.v6.last_chg
       syntax: TimeStamp
+      metric: counter
 
 IPV6-MIB::ipv6IfStatsEntry:
   mib: IPV6-MIB
@@ -89,79 +97,99 @@ IPV6-MIB::ipv6IfStatsEntry:
       oid: .1.3.6.1.2.1.55.1.6.1.1
       name: ip.dgrms.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsInHdrErrors:
       oid: .1.3.6.1.2.1.55.1.6.1.2
       name: ip.dgrms.discard.header_error.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsInTooBigErrors:
       oid: .1.3.6.1.2.1.55.1.6.1.3
       name: ip.dgrms.discard.too_big.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsInNoRoutes:
       oid: .1.3.6.1.2.1.55.1.6.1.4
       name: ip.dgrms.discard.no_route.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsInAddrErrors:
       oid: .1.3.6.1.2.1.55.1.6.1.5
       name: ip.dgrms.discard.addr_error.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsInUnknownProtos:
       oid: .1.3.6.1.2.1.55.1.6.1.6
       name: ip.dgrms.discard.unkproto.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsInTruncatedPkts:
       oid: .1.3.6.1.2.1.55.1.6.1.7
       name: ip.dgrms.discard.trunc.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsInDiscards:
       oid: .1.3.6.1.2.1.55.1.6.1.8
       name: ip.dgrms.discard.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsInDelivers:
       oid: .1.3.6.1.2.1.55.1.6.1.9
       name: ip.dgrms.deliver.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsOutForwDatagrams:
       oid: .1.3.6.1.2.1.55.1.6.1.10
       name: ip.dgrms.fwd.out
       syntax: Counter32
+      metric: counter
     ipv6IfStatsOutRequests:
       oid: .1.3.6.1.2.1.55.1.6.1.11
       name: ip.dgrms.req.out
       syntax: Counter32
+      metric: counter
     ipv6IfStatsOutDiscards:
       oid: .1.3.6.1.2.1.55.1.6.1.12
       name: ip.dgrms.discard.no_error.out
       syntax: Counter32
+      metric: counter
     ipv6IfStatsOutFragOKs:
       oid: .1.3.6.1.2.1.55.1.6.1.13
       name: ip.dgrms.frag.ok.out
       syntax: Counter32
+      metric: counter
     ipv6IfStatsOutFragFails:
       oid: .1.3.6.1.2.1.55.1.6.1.14
       name: ip.dgrms.frag.fail.out
       syntax: Counter32
+      metric: counter
     ipv6IfStatsOutFragCreates:
       oid: .1.3.6.1.2.1.55.1.6.1.15
       name: ip.frags.created.out
       syntax: Counter32
+      metric: counter
     ipv6IfStatsReasmReqds:
       oid: .1.3.6.1.2.1.55.1.6.1.16
       name: ip.frags.reassem.req
       syntax: Counter32
+      metric: counter
     ipv6IfStatsReasmOKs:
       oid: .1.3.6.1.2.1.55.1.6.1.17
       name: ip.dgrms.reassem.ok
       syntax: Counter32
+      metric: counter
     ipv6IfStatsReasmFails:
       oid: .1.3.6.1.2.1.55.1.6.1.18
       name: ip.dgrms.reassem.fail
       syntax: Counter32
+      metric: counter
     ipv6IfStatsInMcastPkts:
       oid: .1.3.6.1.2.1.55.1.6.1.19
       name: ip.dgrms.mcast.in
       syntax: Counter32
+      metric: counter
     ipv6IfStatsOutMcastPkts:
       oid: .1.3.6.1.2.1.55.1.6.1.20
       name: ip.dgrms.mcast.out
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/ISIS-MIB.yml
+++ b/objects/ietf/ISIS-MIB.yml
@@ -19,18 +19,22 @@ ISIS-MIB::isisSysObject:
       oid: .1.3.6.1.2.1.138.1.1.1.4
       name: isis.system.max_path_splits
       syntax: Unsigned32
+      metric: gauge
     isisSysMaxLSPGenInt:
       oid: .1.3.6.1.2.1.138.1.1.1.5
       name: isis.system.max_lsp_interval
       syntax: TicksSec
+      metric: gauge
     isisSysPollESHelloRate:
       oid: .1.3.6.1.2.1.138.1.1.1.6
       name: isis.system.es.hello_interval
       syntax: TicksSec
+      metric: gauge
     isisSysWaitTime:
       oid: .1.3.6.1.2.1.138.1.1.1.7
       name: isis.system.wait_time
       syntax: TicksSec
+      metric: gauge
     isisSysAdminState:
       oid: .1.3.6.1.2.1.138.1.1.1.8
       name: isis.system.state.admin
@@ -43,10 +47,12 @@ ISIS-MIB::isisSysObject:
       oid: .1.3.6.1.2.1.138.1.1.1.10
       name: isis.system.max_age
       syntax: TicksSec
+      metric: gauge
     isisSysReceiveLSPBufferSize:
       oid: .1.3.6.1.2.1.138.1.1.1.11
       name: isis.system.lsp.rcv_buffer_size
       syntax: BytesB
+      metric: gauge
     isisSysProtSupported:
       oid: .1.3.6.1.2.1.138.1.1.1.12
       name: isis.system.proto.support
@@ -66,10 +72,12 @@ ISIS-MIB::isisSysLevelEntry:
       oid: .1.3.6.1.2.1.138.1.2.1.1.2
       name: isis.system.level.lsp.size.out
       syntax: BytesB
+      metric: gauge
     isisSysLevelMinLSPGenInt:
       oid: .1.3.6.1.2.1.138.1.2.1.1.3
       name: isis.system.level.min_lsp_interval
       syntax: TicksSec
+      metric: gauge
     isisSysLevelState:
       oid: .1.3.6.1.2.1.138.1.2.1.1.4
       name: isis.system.level.state
@@ -82,6 +90,7 @@ ISIS-MIB::isisSysLevelEntry:
       oid: .1.3.6.1.2.1.138.1.2.1.1.6
       name: isis.system.level.overload.set.duration
       syntax: TicksSec
+      metric: gauge
     isisSysLevelMetricStyle:
       oid: .1.3.6.1.2.1.138.1.2.1.1.7
       name: isis.system.level.lsp.metric.style
@@ -146,6 +155,7 @@ ISIS-MIB::isisCircEntry:
       oid: .1.3.6.1.2.1.138.1.3.2.1.12
       name: isis.circuit.last_uptime
       syntax: TimeStamp
+      metric: counter
     isisCirc3WayEnabled:
       oid: .1.3.6.1.2.1.138.1.3.2.1.13
       name: isis.circuit.3_way.enable
@@ -201,26 +211,32 @@ ISIS-MIB::isisCircLevelEntry:
       oid: .1.3.6.1.2.1.138.1.4.1.1.9
       name: isis.circuit.level.hello_interval
       syntax: OpTicksMilliSec
+      metric: gauge
     isisCircLevelDRHelloTimer:
       oid: .1.3.6.1.2.1.138.1.4.1.1.10
       name: isis.circuit.level.dr_hello_interval
       syntax: OpTicksMilliSec
+      metric: gauge
     isisCircLevelLSPThrottle:
       oid: .1.3.6.1.2.1.138.1.4.1.1.11
       name: isis.circuit.level.min_lsp_interval
       syntax: OpTicksMilliSec
+      metric: gauge
     isisCircLevelMinLSPRetransInt:
       oid: .1.3.6.1.2.1.138.1.4.1.1.12
       name: isis.circuit.level.min_lsp_retrans
       syntax: TicksSec
+      metric: gauge
     isisCircLevelCSNPInterval:
       oid: .1.3.6.1.2.1.138.1.4.1.1.13
       name: isis.circuit.level.csnp_interval
       syntax: TicksSec
+      metric: gauge
     isisCircLevelPartSNPInterval:
       oid: .1.3.6.1.2.1.138.1.4.1.1.14
       name: isis.circuit.level.psnp_interval
       syntax: TicksSec
+      metric: gauge
 
 ISIS-MIB::isisSystemCounterEntry:
   mib: ISIS-MIB
@@ -232,50 +248,62 @@ ISIS-MIB::isisSystemCounterEntry:
       oid: .1.3.6.1.2.1.138.1.5.1.1.2
       name: isis.system.lsps.corrupt
       syntax: Counter32
+      metric: counter
     isisSysStatAuthTypeFails:
       oid: .1.3.6.1.2.1.138.1.5.1.1.3
       name: isis.system.auth.type_fails
       syntax: Counter32
+      metric: counter
     isisSysStatAuthFails:
       oid: .1.3.6.1.2.1.138.1.5.1.1.4
       name: isis.system.auth.fails
       syntax: Counter32
+      metric: counter
     isisSysStatLSPDbaseOloads:
       oid: .1.3.6.1.2.1.138.1.5.1.1.5
       name: isis.system.lsp.db_overloads
       syntax: Counter32
+      metric: counter
     isisSysStatManAddrDropFromAreas:
       oid: .1.3.6.1.2.1.138.1.5.1.1.6
       name: isis.system.manual_addr_drops
       syntax: Counter32
+      metric: counter
     isisSysStatAttmptToExMaxSeqNums:
       oid: .1.3.6.1.2.1.138.1.5.1.1.7
       name: isis.system.seq_num.exceeds
       syntax: Counter32
+      metric: counter
     isisSysStatSeqNumSkips:
       oid: .1.3.6.1.2.1.138.1.5.1.1.8
       name: isis.system.seq_num.skips
       syntax: Counter32
+      metric: counter
     isisSysStatOwnLSPPurges:
       oid: .1.3.6.1.2.1.138.1.5.1.1.9
       name: isis.system.lsp.own_purges
       syntax: Counter32
+      metric: counter
     isisSysStatIDFieldLenMismatches:
       oid: .1.3.6.1.2.1.138.1.5.1.1.10
       name: isis.system.id_size_mismatches
       syntax: Counter32
+      metric: counter
     isisSysStatPartChanges:
       oid: .1.3.6.1.2.1.138.1.5.1.1.11
       name: isis.system.partition_changes
       syntax: Counter32
+      metric: counter
     isisSysStatSPFRuns:
       oid: .1.3.6.1.2.1.138.1.5.1.1.12
       name: isis.system.spf_runs
       syntax: Counter32
+      metric: counter
     isisSysStatLSPErrors:
       oid: .1.3.6.1.2.1.138.1.5.1.1.13
       name: isis.system.lsp.errors
       syntax: Counter32
+      metric: counter
 
 ISIS-MIB::isisCircuitCounterEntry:
   mib: ISIS-MIB
@@ -295,38 +323,47 @@ ISIS-MIB::isisCircuitCounterEntry:
       oid: .1.3.6.1.2.1.138.1.5.2.1.2
       name: isis.circuit.adjacency.chgs
       syntax: Counter32
+      metric: counter
     isisCircNumAdj:
       oid: .1.3.6.1.2.1.138.1.5.2.1.3
       name: isis.circuit.adjacencies
       syntax: Unsigned32
+      metric: gauge
     isisCircInitFails:
       oid: .1.3.6.1.2.1.138.1.5.2.1.4
       name: isis.circuit.init_fails
       syntax: Counter32
+      metric: counter
     isisCircRejAdjs:
       oid: .1.3.6.1.2.1.138.1.5.2.1.5
       name: isis.circuit.adjacency.rejects
       syntax: Counter32
+      metric: counter
     isisCircIDFieldLenMismatches:
       oid: .1.3.6.1.2.1.138.1.5.2.1.6
       name: isis.circuit.id_size_mismatches
       syntax: Counter32
+      metric: counter
     isisCircMaxAreaAddrMismatches:
       oid: .1.3.6.1.2.1.138.1.5.2.1.7
       name: isis.circuit.max_area_addr_mismatches
       syntax: Counter32
+      metric: counter
     isisCircAuthTypeFails:
       oid: .1.3.6.1.2.1.138.1.5.2.1.8
       name: isis.circuit.auth.type_fails
       syntax: Counter32
+      metric: counter
     isisCircAuthFails:
       oid: .1.3.6.1.2.1.138.1.5.2.1.9
       name: isis.circuit.auth.fails
       syntax: Counter32
+      metric: counter
     isisCircLANDesISChanges:
       oid: .1.3.6.1.2.1.138.1.5.2.1.10
       name: isis.circuit.lan_is_chgs
       syntax: Counter32
+      metric: counter
 
 ISIS-MIB::isisPacketCounterEntry:
   mib: ISIS-MIB
@@ -350,30 +387,37 @@ ISIS-MIB::isisPacketCounterEntry:
       oid: .1.3.6.1.2.1.138.1.5.3.1.3
       name: isis.packets.ii_hello
       syntax: Counter32
+      metric: counter
     isisPacketCountISHello:
       oid: .1.3.6.1.2.1.138.1.5.3.1.4
       name: isis.packets.is_hello
       syntax: Counter32
+      metric: counter
     isisPacketCountESHello:
       oid: .1.3.6.1.2.1.138.1.5.3.1.5
       name: isis.packets.es_hello
       syntax: Counter32
+      metric: counter
     isisPacketCountLSP:
       oid: .1.3.6.1.2.1.138.1.5.3.1.6
       name: isis.packets.lsp
       syntax: Counter32
+      metric: counter
     isisPacketCountCSNP:
       oid: .1.3.6.1.2.1.138.1.5.3.1.7
       name: isis.packets.csnp
       syntax: Counter32
+      metric: counter
     isisPacketCountPSNP:
       oid: .1.3.6.1.2.1.138.1.5.3.1.8
       name: isis.packets.psnp
       syntax: Counter32
+      metric: counter
     isisPacketCountUnknown:
       oid: .1.3.6.1.2.1.138.1.5.3.1.9
       name: isis.packets.unknown
       syntax: Counter32
+      metric: counter
 
 ISIS-MIB::isisISAdjEntry:
   mib: ISIS-MIB
@@ -421,6 +465,7 @@ ISIS-MIB::isisISAdjEntry:
       oid: .1.3.6.1.2.1.138.1.6.1.1.9
       name: isis.adjacency.hold_time
       syntax: TicksSec
+      metric: gauge
     isisISAdjNeighPriority:
       oid: .1.3.6.1.2.1.138.1.6.1.1.10
       name: isis.adjacency.neighbor.priority
@@ -429,6 +474,7 @@ ISIS-MIB::isisISAdjEntry:
       oid: .1.3.6.1.2.1.138.1.6.1.1.11
       name: isis.adjacency.last_uptime
       syntax: TimeStamp
+      metric: counter
 
 ISIS-MIB::isisRAEntry:
   mib: ISIS-MIB
@@ -570,10 +616,12 @@ ISIS-MIB::isisLSPSummaryEntry:
       oid: .1.3.6.1.2.1.138.1.9.1.1.6
       name: isis.lsp.life_remain
       syntax: TicksSec
+      metric: gauge
     isisLSPPDULength:
       oid: .1.3.6.1.2.1.138.1.9.1.1.7
       name: isis.lsp.pdu.size
       syntax: BytesB
+      metric: gauge
     isisLSPAttributes:
       oid: .1.3.6.1.2.1.138.1.9.1.1.8
       name: isis.lsp.flags.bits
@@ -613,6 +661,7 @@ ISIS-MIB::isisLSPTLVEntry:
       oid: .1.3.6.1.2.1.138.1.9.2.1.5
       name: isis.lsp.tlv.size
       syntax: BytesB
+      metric: gauge
     isisLSPTLVValue:
       oid: .1.3.6.1.2.1.138.1.9.2.1.6
       name: isis.lsp.tlv.value

--- a/objects/ietf/MPLS-L3VPN-STD-MIB.yml
+++ b/objects/ietf/MPLS-L3VPN-STD-MIB.yml
@@ -7,26 +7,32 @@ MPLS-L3VPN-STD-MIB::mplsL3VpnScalars:
       oid: .1.3.6.1.2.1.10.166.11.1.1.1
       name: mpls.l3vpn.vrfs.config
       syntax: Unsigned32
+      metric: gauge
     mplsL3VpnActiveVrfs:
       oid: .1.3.6.1.2.1.10.166.11.1.1.2
       name: mpls.l3vpn.vrfs.active
       syntax: Gauge32
+      metric: gauge
     mplsL3VpnConnectedInterfaces:
       oid: .1.3.6.1.2.1.10.166.11.1.1.3
       name: mpls.l3vpn.netifs.connected
       syntax: Gauge32
+      metric: gauge
     mplsL3VpnVrfConfMaxPossRts:
       oid: .1.3.6.1.2.1.10.166.11.1.1.5
       name: mpls.l3vpn.vrf.max_routes_thresh
       syntax: Unsigned32
+      metric: gauge
     mplsL3VpnVrfConfRteMxThrshTime:
       oid: .1.3.6.1.2.1.10.166.11.1.1.6
       name: mpls.l3vpn.vrf.max_routes_thresh_interval
       syntax: Unsigned32
+      metric: gauge
     mplsL3VpnIllLblRcvThrsh:
       oid: .1.3.6.1.2.1.10.166.11.1.1.7
       name: mpls.l3vpn.illegal_label_thresh
       syntax: Unsigned32
+      metric: gauge
 
 MPLS-L3VPN-STD-MIB::mplsL3VpnIfConfEntry:
   mib: MPLS-L3VPN-STD-MIB
@@ -77,6 +83,7 @@ MPLS-L3VPN-STD-MIB::mplsL3VpnVrfEntry:
       oid: .1.3.6.1.2.1.10.166.11.1.2.2.1.5
       name: mpls.l3vpn.vrf.create.sysuptime
       syntax: TimeStamp
+      metric: counter
     mplsL3VpnVrfOperStatus:
       oid: .1.3.6.1.2.1.10.166.11.1.2.2.1.6
       name: mpls.l3vpn.vrf.state.oper
@@ -85,26 +92,32 @@ MPLS-L3VPN-STD-MIB::mplsL3VpnVrfEntry:
       oid: .1.3.6.1.2.1.10.166.11.1.2.2.1.7
       name: mpls.l3vpn.vrf.netifs.active
       syntax: Gauge32
+      metric: gauge
     mplsL3VpnVrfAssociatedInterfaces:
       oid: .1.3.6.1.2.1.10.166.11.1.2.2.1.8
       name: mpls.l3vpn.vrf.netifs.assoc
       syntax: Unsigned32
+      metric: gauge
     mplsL3VpnVrfConfMidRteThresh:
       oid: .1.3.6.1.2.1.10.166.11.1.2.2.1.9
       name: mpls.l3vpn.vrf.mid_routes_thresh
       syntax: Unsigned32
+      metric: gauge
     mplsL3VpnVrfConfHighRteThresh:
       oid: .1.3.6.1.2.1.10.166.11.1.2.2.1.10
       name: mpls.l3vpn.vrf.high_routes_thresh
       syntax: Unsigned32
+      metric: gauge
     mplsL3VpnVrfConfMaxRoutes:
       oid: .1.3.6.1.2.1.10.166.11.1.2.2.1.11
       name: mpls.l3vpn.vrf.max_routes_thresh
       syntax: Unsigned32
+      metric: gauge
     mplsL3VpnVrfConfLastChanged:
       oid: .1.3.6.1.2.1.10.166.11.1.2.2.1.12
       name: mpls.l3vpn.vrf.last_chg
       syntax: TimeStamp
+      metric: counter
     mplsL3VpnVrfConfAdminStatus:
       oid: .1.3.6.1.2.1.10.166.11.1.2.2.1.14
       name: mpls.l3vpn.vrf.state.admin
@@ -147,10 +160,12 @@ MPLS-L3VPN-STD-MIB::mplsL3VpnVrfSecEntry:
       oid: .1.3.6.1.2.1.10.166.11.1.2.6.1.1
       name: mpls.l3vpn.vrf.sec.labels.illegal
       syntax: Counter32
+      metric: counter
     mplsL3VpnVrfSecDiscontinuityTime:
       oid: .1.3.6.1.2.1.10.166.11.1.2.6.1.2
       name: mpls.l3vpn.vrf.sec.discontinuity_time
       syntax: TimeStamp
+      metric: counter
 
 MPLS-L3VPN-STD-MIB::mplsL3VpnVrfPerfEntry:
   mib: MPLS-L3VPN-STD-MIB
@@ -162,19 +177,24 @@ MPLS-L3VPN-STD-MIB::mplsL3VpnVrfPerfEntry:
       oid: .1.3.6.1.2.1.10.166.11.1.3.1.1.1
       name: mpls.l3vpn.vrf.routes.add
       syntax: Counter32
+      metric: counter
     mplsL3VpnVrfPerfRoutesDeleted:
       oid: .1.3.6.1.2.1.10.166.11.1.3.1.1.2
       name: mpls.l3vpn.vrf.routes.delete
       syntax: Counter32
+      metric: counter
     mplsL3VpnVrfPerfCurrNumRoutes:
       oid: .1.3.6.1.2.1.10.166.11.1.3.1.1.3
       name: mpls.l3vpn.vrf.routes.current
       syntax: Gauge32
+      metric: gauge
     mplsL3VpnVrfPerfRoutesDropped:
       oid: .1.3.6.1.2.1.10.166.11.1.3.1.1.4
       name: mpls.l3vpn.vrf.routes.drop
       syntax: Counter32
+      metric: counter
     mplsL3VpnVrfPerfDiscTime:
       oid: .1.3.6.1.2.1.10.166.11.1.3.1.1.5
       name: mpls.l3vpn.vrf.discontinuity_time
       syntax: TimeStamp
+      metric: counter

--- a/objects/ietf/MPLS-LDP-STD-MIB.yml
+++ b/objects/ietf/MPLS-LDP-STD-MIB.yml
@@ -15,18 +15,22 @@ MPLS-LDP-STD-MIB::mplsLdpObjects:
       oid: .1.3.6.1.2.1.10.166.4.1.2.1
       name: ldp.entity.last_chg
       syntax: TimeStamp
+      metric: counter
     mplsLdpPeerLastChange:
       oid: .1.3.6.1.2.1.10.166.4.1.3.1
       name: ldp.peer.last_chg
       syntax: TimeStamp
+      metric: counter
     mplsFecLastChange:
       oid: .1.3.6.1.2.1.10.166.4.1.3.8.1
       name: ldp.fec.last_chg
       syntax: TimeStamp
+      metric: counter
     mplsLdpLspFecLastChange:
       oid: .1.3.6.1.2.1.10.166.4.1.3.9
       name: ldp.lsp.fec.last_chg
       syntax: TimeStamp
+      metric: counter
 
 MPLS-LDP-STD-MIB::mplsLdpEntityEntry:
   mib: MPLS-LDP-STD-MIB
@@ -66,18 +70,22 @@ MPLS-LDP-STD-MIB::mplsLdpEntityEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.2.3.1.8
       name: ldp.entity.max_pdu_size
       syntax: Unsigned32
+      metric: gauge
     mplsLdpEntityKeepAliveHoldTimer:
       oid: .1.3.6.1.2.1.10.166.4.1.2.3.1.9
       name: ldp.entity.keep_alive_hold_time
       syntax: TicksSec
+      metric: gauge
     mplsLdpEntityHelloHoldTimer:
       oid: .1.3.6.1.2.1.10.166.4.1.2.3.1.10
       name: ldp.entity.hello_hold_time
       syntax: TicksSec
+      metric: gauge
     mplsLdpEntityInitSessionThreshold:
       oid: .1.3.6.1.2.1.10.166.4.1.2.3.1.11
       name: ldp.entity.session_init_thresh
       syntax: Integer32
+      metric: gauge
     mplsLdpEntityLabelDistMethod:
       oid: .1.3.6.1.2.1.10.166.4.1.2.3.1.12
       name: ldp.entity.label_distribution_method
@@ -90,10 +98,12 @@ MPLS-LDP-STD-MIB::mplsLdpEntityEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.2.3.1.14
       name: ldp.entity.path_vector_limit
       syntax: Integer32
+      metric: gauge
     mplsLdpEntityHopCountLimit:
       oid: .1.3.6.1.2.1.10.166.4.1.2.3.1.15
       name: ldp.entity.hop_limit
       syntax: Integer32
+      metric: gauge
     mplsLdpEntityTransportAddrKind:
       oid: .1.3.6.1.2.1.10.166.4.1.2.3.1.16
       name: ldp.entity.transport_addr_kind
@@ -114,6 +124,7 @@ MPLS-LDP-STD-MIB::mplsLdpEntityEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.2.3.1.21
       name: ldp.entity.discontinuity_time
       syntax: TimeStamp
+      metric: counter
 
 MPLS-LDP-STD-MIB::mplsLdpEntityStatsEntry:
   mib: MPLS-LDP-STD-MIB
@@ -125,54 +136,67 @@ MPLS-LDP-STD-MIB::mplsLdpEntityStatsEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.1
       name: ldp.entity.sessions.attempt
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsSessionRejectedNoHelloErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.2
       name: ldp.entity.sessions.reject.no_hello
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsSessionRejectedAdErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.3
       name: ldp.entity.sessions.reject.advert
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsSessionRejectedMaxPduErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.4
       name: ldp.entity.sessions.reject.max_pdu
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsSessionRejectedLRErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.5
       name: ldp.entity.sessions.reject.label_range
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsBadLdpIdentifierErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.6
       name: ldp.entity.errors.ldp_id
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsBadPduLengthErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.7
       name: ldp.entity.errors.pdu_size
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsBadMessageLengthErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.8
       name: ldp.entity.errors.msg_size
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsBadTlvLengthErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.9
       name: ldp.entity.errors.tlv_size
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsMalformedTlvValueErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.10
       name: ldp.entity.errors.malformed_tlv
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsKeepAliveTimerExpErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.11
       name: ldp.entity.errors.keep_alive_expire
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsShutdownReceivedNotifications:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.12
       name: ldp.entity.notifs.shutdown.in
       syntax: Counter32
+      metric: counter
     mplsLdpEntityStatsShutdownSentNotifications:
       oid: .1.3.6.1.2.1.10.166.4.1.2.4.1.13
       name: ldp.entity.notifs.shutdown.out
       syntax: Counter32
+      metric: counter
 
 MPLS-LDP-STD-MIB::mplsLdpPeerEntry:
   mib: MPLS-LDP-STD-MIB
@@ -200,6 +224,7 @@ MPLS-LDP-STD-MIB::mplsLdpPeerEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.3.2.1.3
       name: ldp.peer.path_vector_limit
       syntax: Integer32
+      metric: gauge
     mplsLdpPeerTransportAddr:
       oid: .1.3.6.1.2.1.10.166.4.1.3.2.1.5
       name: ldp.peer.transport
@@ -215,6 +240,7 @@ MPLS-LDP-STD-MIB::mplsLdpSessionEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.3.3.1.1
       name: ldp.session.state.last_chg
       syntax: TimeStamp
+      metric: counter
     mplsLdpSessionState:
       oid: .1.3.6.1.2.1.10.166.4.1.3.3.1.2
       name: ldp.session.state
@@ -231,18 +257,22 @@ MPLS-LDP-STD-MIB::mplsLdpSessionEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.3.3.1.5
       name: ldp.session.keep_alive_remain
       syntax: TicksSec
+      metric: gauge
     mplsLdpSessionKeepAliveTime:
       oid: .1.3.6.1.2.1.10.166.4.1.3.3.1.6
       name: ldp.session.keep_alive_time
       syntax: TicksSec
+      metric: gauge
     mplsLdpSessionMaxPduLength:
       oid: .1.3.6.1.2.1.10.166.4.1.3.3.1.7
       name: ldp.session.max_pdu_size
       syntax: Unsigned32
+      metric: gauge
     mplsLdpSessionDiscontinuityTime:
       oid: .1.3.6.1.2.1.10.166.4.1.3.3.1.8
       name: ldp.session.discontinuity_time
       syntax: TimeStamp
+      metric: counter
 
 MPLS-LDP-STD-MIB::mplsLdpSessionStatsEntry:
   mib: MPLS-LDP-STD-MIB
@@ -254,10 +284,12 @@ MPLS-LDP-STD-MIB::mplsLdpSessionStatsEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.3.4.1.1
       name: ldp.session.errors.msg_type_unk
       syntax: Counter32
+      metric: counter
     mplsLdpSessionStatsUnknownTlvErrors:
       oid: .1.3.6.1.2.1.10.166.4.1.3.4.1.2
       name: ldp.session.errors.tlv_unk
       syntax: Counter32
+      metric: counter
 
 MPLS-LDP-STD-MIB::mplsLdpHelloAdjacencyEntry:
   mib: MPLS-LDP-STD-MIB
@@ -285,10 +317,12 @@ MPLS-LDP-STD-MIB::mplsLdpHelloAdjacencyEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.3.5.1.1.2
       name: ldp.session.hello_adj.hold_remain
       syntax: Integer
+      metric: gauge
     mplsLdpHelloAdjacencyHoldTime:
       oid: .1.3.6.1.2.1.10.166.4.1.3.5.1.1.3
       name: ldp.session.hello_adj.hold_time
       syntax: Unsigned32
+      metric: gauge
     mplsLdpHelloAdjacencyType:
       oid: .1.3.6.1.2.1.10.166.4.1.3.5.1.1.4
       name: ldp.session.hello_adj.type
@@ -312,6 +346,7 @@ MPLS-LDP-STD-MIB::mplsFecEntry:
       oid: .1.3.6.1.2.1.10.166.4.1.3.8.3.1.3
       name: ldp.fec.ip.subnet.mask_size
       syntax: Unsigned32
+      metric: gauge
     mplsFecAddr:
       oid: .1.3.6.1.2.1.10.166.4.1.3.8.3.1.5
       name: ldp.fec

--- a/objects/ietf/MPLS-LSR-STD-MIB.yml
+++ b/objects/ietf/MPLS-LSR-STD-MIB.yml
@@ -12,26 +12,32 @@ MPLS-LSR-STD-MIB::mplsInterfaceEntry:
       oid: .1.3.6.1.2.1.10.166.2.1.1.1.2
       name: mpls.netif.label.min.in
       syntax: Unsigned32
+      metric: gauge
     mplsInterfaceLabelMaxIn:
       oid: .1.3.6.1.2.1.10.166.2.1.1.1.3
       name: mpls.netif.label.max.in
       syntax: Unsigned32
+      metric: gauge
     mplsInterfaceLabelMinOut:
       oid: .1.3.6.1.2.1.10.166.2.1.1.1.4
       name: mpls.netif.label.min.out
       syntax: Unsigned32
+      metric: gauge
     mplsInterfaceLabelMaxOut:
       oid: .1.3.6.1.2.1.10.166.2.1.1.1.5
       name: mpls.netif.label.max.out
       syntax: Unsigned32
+      metric: gauge
     mplsInterfaceTotalBandwidth:
       oid: .1.3.6.1.2.1.10.166.2.1.1.1.6
       name: mpls.netif.bandwidth.bw
       syntax: BandwidthKBits
+      metric: gauge
     mplsInterfaceAvailableBandwidth:
       oid: .1.3.6.1.2.1.10.166.2.1.1.1.7
       name: mpls.netif.bandwidth.avail
       syntax: BandwidthKBits
+      metric: gauge
     mplsInterfaceLabelParticipationType:
       oid: .1.3.6.1.2.1.10.166.2.1.1.1.8
       name: mpls.netif.label.participation_type
@@ -47,18 +53,22 @@ MPLS-LSR-STD-MIB::mplsInterfacePerfEntry:
       oid: .1.3.6.1.2.1.10.166.2.1.2.1.1
       name: mpls.netif.labels.in_use.in
       syntax: Gauge32
+      metric: gauge
     mplsInterfacePerfInLabelLookupFailures:
       oid: .1.3.6.1.2.1.10.166.2.1.2.1.2
       name: mpls.netif.labels.lookup_fail.in
       syntax: Counter32
+      metric: counter
     mplsInterfacePerfOutLabelsInUse:
       oid: .1.3.6.1.2.1.10.166.2.1.2.1.3
       name: mpls.netif.labels.in_use.out
       syntax: Gauge32
+      metric: gauge
     mplsInterfacePerfOutFragmentedPkts:
       oid: .1.3.6.1.2.1.10.166.2.1.2.1.4
       name: mpls.netif.packets.frag.out
       syntax: Counter32
+      metric: counter
 
 MPLS-LSR-STD-MIB::mplsLsrObjects:
   mib: MPLS-LSR-STD-MIB
@@ -69,6 +79,7 @@ MPLS-LSR-STD-MIB::mplsLsrObjects:
       oid: .1.3.6.1.2.1.10.166.2.1.11
       name: mpls.lsr.label_stack.max_depth
       syntax: Unsigned32
+      metric: gauge
 
 MPLS-LSR-STD-MIB::mplsInSegmentEntry:
   mib: MPLS-LSR-STD-MIB
@@ -124,22 +135,27 @@ MPLS-LSR-STD-MIB::mplsInSegmentPerfEntry:
       oid: .1.3.6.1.2.1.10.166.2.1.5.1.1
       name: mpls.segment.ingress.bytes
       syntax: Counter32
+      metric: counter
     mplsInSegmentPerfPackets:
       oid: .1.3.6.1.2.1.10.166.2.1.5.1.2
       name: mpls.segment.ingress.packets
       syntax: Counter32
+      metric: counter
     mplsInSegmentPerfErrors:
       oid: .1.3.6.1.2.1.10.166.2.1.5.1.3
       name: mpls.segment.ingress.errors
       syntax: Counter32
+      metric: counter
     mplsInSegmentPerfDiscards:
       oid: .1.3.6.1.2.1.10.166.2.1.5.1.4
       name: mpls.segment.ingress.discards
       syntax: Counter32
+      metric: counter
     mplsInSegmentPerfHCOctets:
       oid: .1.3.6.1.2.1.10.166.2.1.5.1.5
       name: mpls.segment.ingress.bytes
       syntax: Counter64
+      metric: counter
       overrides:
         object: MPLS-LSR-STD-MIB::mplsInSegmentPerfEntry
         attribute: mplsInSegmentPerfOctets
@@ -147,6 +163,7 @@ MPLS-LSR-STD-MIB::mplsInSegmentPerfEntry:
       oid: .1.3.6.1.2.1.10.166.2.1.5.1.6
       name: mpls.segment.ingress.discontinuity_time
       syntax: TimeStamp
+      metric: counter
 
 MPLS-LSR-STD-MIB::mplsOutSegmentEntry:
   mib: MPLS-LSR-STD-MIB
@@ -202,22 +219,27 @@ MPLS-LSR-STD-MIB::mplsOutSegmentPerfEntry:
       oid: .1.3.6.1.2.1.10.166.2.1.8.1.1
       name: mpls.segment.egress.bytes
       syntax: Counter32
+      metric: counter
     mplsOutSegmentPerfPackets:
       oid: .1.3.6.1.2.1.10.166.2.1.8.1.2
       name: mpls.segment.egress.packets
       syntax: Counter32
+      metric: counter
     mplsOutSegmentPerfErrors:
       oid: .1.3.6.1.2.1.10.166.2.1.8.1.3
       name: mpls.segment.egress.errors
       syntax: Counter32
+      metric: counter
     mplsOutSegmentPerfDiscards:
       oid: .1.3.6.1.2.1.10.166.2.1.8.1.4
       name: mpls.segment.egress.discards
       syntax: Counter32
+      metric: counter
     mplsOutSegmentPerfHCOctets:
       oid: .1.3.6.1.2.1.10.166.2.1.8.1.5
       name: mpls.segment.egress.bytes
       syntax: Counter64
+      metric: counter
       overrides:
         object: MPLS-LSR-STD-MIB::mplsOutSegmentPerfEntry
         attribute: mplsOutSegmentPerfOctets
@@ -225,6 +247,7 @@ MPLS-LSR-STD-MIB::mplsOutSegmentPerfEntry:
       oid: .1.3.6.1.2.1.10.166.2.1.8.1.6
       name: mpls.segment.egress.discontinuity_time
       syntax: TimeStamp
+      metric: counter
 
 MPLS-LSR-STD-MIB::mplsXCEntry:
   mib: MPLS-LSR-STD-MIB

--- a/objects/ietf/MPLS-TE-STD-MIB.yml
+++ b/objects/ietf/MPLS-TE-STD-MIB.yml
@@ -7,10 +7,12 @@ MPLS-TE-STD-MIB::mplsTeScalars:
       oid: .1.3.6.1.2.1.10.166.3.1.1
       name: mpls.tunnels.config
       syntax: Unsigned32
+      metric: gauge
     mplsTunnelActive:
       oid: .1.3.6.1.2.1.10.166.3.1.2
       name: mpls.tunnels.active
       syntax: Unsigned32
+      metric: gauge
     mplsTunnelTEDistProto:
       oid: .1.3.6.1.2.1.10.166.3.1.3
       name: mpls.tunnel.te.distrib_proto
@@ -19,10 +21,12 @@ MPLS-TE-STD-MIB::mplsTeScalars:
       oid: .1.3.6.1.2.1.10.166.3.1.4
       name: mpls.tunnel.max_hops
       syntax: Unsigned32
+      metric: gauge
     mplsTunnelNotificationMaxRate:
       oid: .1.3.6.1.2.1.10.166.3.1.5
       name: mpls.tunnel.notifs.max_rate
       syntax: Unsigned32
+      metric: gauge
 
 MPLS-TE-STD-MIB::mplsTunnelEntry:
   mib: MPLS-TE-STD-MIB
@@ -140,30 +144,37 @@ MPLS-TE-STD-MIB::mplsTunnelEntry:
       oid: .1.3.6.1.2.1.10.166.3.2.2.1.27
       name: mpls.tunnel.total.uptime
       syntax: TimeTicks
+      metric: counter
     mplsTunnelInstanceUpTime:
       oid: .1.3.6.1.2.1.10.166.3.2.2.1.28
       name: mpls.tunnel.instance.uptime
       syntax: TimeTicks
+      metric: counter
     mplsTunnelPrimaryUpTime:
       oid: .1.3.6.1.2.1.10.166.3.2.2.1.29
       name: mpls.tunnel.primary.uptime
       syntax: TimeTicks
+      metric: counter
     mplsTunnelPathChanges:
       oid: .1.3.6.1.2.1.10.166.3.2.2.1.30
       name: mpls.tunnel.path_chgs
       syntax: Counter32
+      metric: counter
     mplsTunnelLastPathChange:
       oid: .1.3.6.1.2.1.10.166.3.2.2.1.31
       name: mpls.tunnel.last_path_chg
       syntax: TimeTicks
+      metric: counter
     mplsTunnelCreationTime:
       oid: .1.3.6.1.2.1.10.166.3.2.2.1.32
       name: mpls.tunnel.create.sysuptime
       syntax: TimeStamp
+      metric: counter
     mplsTunnelStateTransitions:
       oid: .1.3.6.1.2.1.10.166.3.2.2.1.33
       name: mpls.tunnel.state.transitions
       syntax: Counter32
+      metric: counter
     mplsTunnelAdminStatus:
       oid: .1.3.6.1.2.1.10.166.3.2.2.1.34
       name: mpls.tunnel.state.admin
@@ -203,6 +214,7 @@ MPLS-TE-STD-MIB::mplsTunnelHopEntry:
       oid: .1.3.6.1.2.1.10.166.3.2.4.1.6
       name: mpls.tunnel.hop.ip.subnet.mask_size
       syntax: Unsigned32
+      metric: gauge
     mplsTunnelHopAsNumber:
       oid: .1.3.6.1.2.1.10.166.3.2.4.1.7
       name: mpls.tunnel.hop.as.asn
@@ -246,22 +258,27 @@ MPLS-TE-STD-MIB::mplsTunnelResourceEntry:
       oid: .1.3.6.1.2.1.10.166.3.2.6.1.2
       name: mpls.tunnel.resource.rate.max
       syntax: BandwidthKBits
+      metric: gauge
     mplsTunnelResourceMeanRate:
       oid: .1.3.6.1.2.1.10.166.3.2.6.1.3
       name: mpls.tunnel.resource.rate.avg
       syntax: BandwidthKBits
+      metric: gauge
     mplsTunnelResourceMaxBurstSize:
       oid: .1.3.6.1.2.1.10.166.3.2.6.1.4
       name: mpls.tunnel.resource.burst_size.max
       syntax: BytesB
+      metric: gauge
     mplsTunnelResourceMeanBurstSize:
       oid: .1.3.6.1.2.1.10.166.3.2.6.1.5
       name: mpls.tunnel.resource.burst_size.avg
       syntax: BytesB
+      metric: gauge
     mplsTunnelResourceExBurstSize:
       oid: .1.3.6.1.2.1.10.166.3.2.6.1.6
       name: mpls.tunnel.resource.burst_size.excess
       syntax: BytesB
+      metric: gauge
     mplsTunnelResourceFrequency:
       oid: .1.3.6.1.2.1.10.166.3.2.6.1.7
       name: mpls.tunnel.resource.freq
@@ -270,6 +287,7 @@ MPLS-TE-STD-MIB::mplsTunnelResourceEntry:
       oid: .1.3.6.1.2.1.10.166.3.2.6.1.8
       name: mpls.tunnel.resource.weight
       syntax: Unsigned32
+      metric: gauge
 
 MPLS-TE-STD-MIB::mplsTunnelARHopEntry:
   mib: MPLS-TE-STD-MIB
@@ -330,6 +348,7 @@ MPLS-TE-STD-MIB::mplsTunnelCHopEntry:
       oid: .1.3.6.1.2.1.10.166.3.2.8.1.5
       name: mpls.tunnel.cspf.hop.ip.subnet.mask_size
       syntax: Unsigned32
+      metric: gauge
     mplsTunnelCHopAsNumber:
       oid: .1.3.6.1.2.1.10.166.3.2.8.1.6
       name: mpls.tunnel.cspf.hop.as.asn
@@ -357,10 +376,12 @@ MPLS-TE-STD-MIB::mplsTunnelPerfEntry:
       oid: .1.3.6.1.2.1.10.166.3.2.9.1.1
       name: mpls.tunnel.packets
       syntax: Counter32
+      metric: counter
     mplsTunnelPerfHCPackets:
       oid: .1.3.6.1.2.1.10.166.3.2.9.1.2
       name: mpls.tunnel.packets
       syntax: Counter64
+      metric: counter
       overrides:
         object: MPLS-TE-STD-MIB::mplsTunnelPerfEntry
         attribute: mplsTunnelPerfPackets
@@ -368,14 +389,17 @@ MPLS-TE-STD-MIB::mplsTunnelPerfEntry:
       oid: .1.3.6.1.2.1.10.166.3.2.9.1.3
       name: mpls.tunnel.errors
       syntax: Counter32
+      metric: counter
     mplsTunnelPerfBytes:
       oid: .1.3.6.1.2.1.10.166.3.2.9.1.4
       name: mpls.tunnel.bytes
       syntax: Counter32
+      metric: counter
     mplsTunnelPerfHCBytes:
       oid: .1.3.6.1.2.1.10.166.3.2.9.1.5
       name: mpls.tunnel.bytes
       syntax: Counter64
+      metric: counter
       overrides:
         object: MPLS-TE-STD-MIB::mplsTunnelPerfEntry
         attribute: mplsTunnelPerfBytes
@@ -390,10 +414,12 @@ MPLS-TE-STD-MIB::mplsTunnelCRLDPResEntry:
       oid: .1.3.6.1.2.1.10.166.3.2.10.1.1
       name: mpls.tunnel.cr_ldp.resource.burst_size.avg
       syntax: BytesB
+      metric: gauge
     mplsTunnelCRLDPResExBurstSize:
       oid: .1.3.6.1.2.1.10.166.3.2.10.1.2
       name: mpls.tunnel.cr_ldp.resource.burst_size.excess
       syntax: BytesB
+      metric: gauge
     mplsTunnelCRLDPResFrequency:
       oid: .1.3.6.1.2.1.10.166.3.2.10.1.3
       name: mpls.tunnel.cr_ldp.resource.freq
@@ -402,6 +428,7 @@ MPLS-TE-STD-MIB::mplsTunnelCRLDPResEntry:
       oid: .1.3.6.1.2.1.10.166.3.2.10.1.4
       name: mpls.tunnel.cr_ldp.resource.weight
       syntax: Unsigned32
+      metric: gauge
     mplsTunnelCRLDPResFlags:
       oid: .1.3.6.1.2.1.10.166.3.2.10.1.5
       name: mpls.tunnel.cr_ldp.resource.flags

--- a/objects/ietf/MTA-MIB.yml
+++ b/objects/ietf/MTA-MIB.yml
@@ -8,50 +8,62 @@ MTA-MIB::mtaEntry:
       oid: .1.3.6.1.2.1.28.1.1.1
       name: ietf.mtaReceivedMessages
       syntax: Counter32
+      metric: counter
     mtaStoredMessages:
       oid: .1.3.6.1.2.1.28.1.1.2
       name: ietf.mtaStoredMessages
       syntax: Gauge32
+      metric: gauge
     mtaTransmittedMessages:
       oid: .1.3.6.1.2.1.28.1.1.3
       name: ietf.mtaTransmittedMessages
       syntax: Counter32
+      metric: counter
     mtaReceivedVolume:
       oid: .1.3.6.1.2.1.28.1.1.4
       name: ietf.mtaReceivedVolume
       syntax: BytesKB
+      metric: counter
     mtaStoredVolume:
       oid: .1.3.6.1.2.1.28.1.1.5
       name: ietf.mtaStoredVolume
       syntax: BytesKB
+      metric: gauge
     mtaTransmittedVolume:
       oid: .1.3.6.1.2.1.28.1.1.6
       name: ietf.mtaTransmittedVolume
       syntax: BytesKB
+      metric: counter
     mtaReceivedRecipients:
       oid: .1.3.6.1.2.1.28.1.1.7
       name: ietf.mtaReceivedRecipients
       syntax: Counter32
+      metric: counter
     mtaStoredRecipients:
       oid: .1.3.6.1.2.1.28.1.1.8
       name: ietf.mtaStoredRecipients
       syntax: Gauge32
+      metric: gauge
     mtaTransmittedRecipients:
       oid: .1.3.6.1.2.1.28.1.1.9
       name: ietf.mtaTransmittedRecipients
       syntax: Counter32
+      metric: counter
     mtaSuccessfulConvertedMessages:
       oid: .1.3.6.1.2.1.28.1.1.10
       name: ietf.mtaSuccessfulConvertedMessages
       syntax: Counter32
+      metric: counter
     mtaFailedConvertedMessages:
       oid: .1.3.6.1.2.1.28.1.1.11
       name: ietf.mtaFailedConvertedMessages
       syntax: Counter32
+      metric: counter
     mtaLoopsDetected:
       oid: .1.3.6.1.2.1.28.1.1.12
       name: ietf.mtaLoopsDetected
       syntax: Counter32
+      metric: counter
 
 MTA-MIB::mtaGroupEntry:
   mib: MTA-MIB
@@ -71,78 +83,97 @@ MTA-MIB::mtaGroupEntry:
       oid: .1.3.6.1.2.1.28.2.1.2
       name: ietf.mtaGroupReceivedMessages
       syntax: Counter32
+      metric: counter
     mtaGroupRejectedMessages:
       oid: .1.3.6.1.2.1.28.2.1.3
       name: ietf.mtaGroupRejectedMessages
       syntax: Counter32
+      metric: counter
     mtaGroupStoredMessages:
       oid: .1.3.6.1.2.1.28.2.1.4
       name: ietf.mtaGroupStoredMessages
       syntax: Gauge32
+      metric: gauge
     mtaGroupTransmittedMessages:
       oid: .1.3.6.1.2.1.28.2.1.5
       name: ietf.mtaGroupTransmittedMessages
       syntax: Counter32
+      metric: counter
     mtaGroupReceivedVolume:
       oid: .1.3.6.1.2.1.28.2.1.6
       name: ietf.mtaGroupReceivedVolume
       syntax: BytesKB
+      metric: counter
     mtaGroupStoredVolume:
       oid: .1.3.6.1.2.1.28.2.1.7
       name: ietf.mtaGroupStoredVolume
       syntax: BytesKB
+      metric: gauge
     mtaGroupTransmittedVolume:
       oid: .1.3.6.1.2.1.28.2.1.8
       name: ietf.mtaGroupTransmittedVolume
       syntax: BytesKB
+      metric: counter
     mtaGroupReceivedRecipients:
       oid: .1.3.6.1.2.1.28.2.1.9
       name: ietf.mtaGroupReceivedRecipients
       syntax: Counter32
+      metric: counter
     mtaGroupStoredRecipients:
       oid: .1.3.6.1.2.1.28.2.1.10
       name: ietf.mtaGroupStoredRecipients
       syntax: Gauge32
+      metric: gauge
     mtaGroupTransmittedRecipients:
       oid: .1.3.6.1.2.1.28.2.1.11
       name: ietf.mtaGroupTransmittedRecipients
       syntax: Counter32
+      metric: counter
     mtaGroupOldestMessageStored:
       oid: .1.3.6.1.2.1.28.2.1.12
       name: ietf.mtaGroupOldestMessageStored
       syntax: TicksCentiSec
+      metric: gauge
     mtaGroupInboundAssociations:
       oid: .1.3.6.1.2.1.28.2.1.13
       name: ietf.mtaGroupInboundAssociations
       syntax: Gauge32
+      metric: gauge
     mtaGroupOutboundAssociations:
       oid: .1.3.6.1.2.1.28.2.1.14
       name: ietf.mtaGroupOutboundAssociations
       syntax: Gauge32
+      metric: gauge
     mtaGroupAccumulatedInboundAssociations:
       oid: .1.3.6.1.2.1.28.2.1.15
       name: ietf.mtaGroupAccumulatedInboundAssociations
       syntax: Counter32
+      metric: counter
     mtaGroupAccumulatedOutboundAssociations:
       oid: .1.3.6.1.2.1.28.2.1.16
       name: ietf.mtaGroupAccumulatedOutboundAssociations
       syntax: Counter32
+      metric: counter
     mtaGroupLastInboundActivity:
       oid: .1.3.6.1.2.1.28.2.1.17
       name: ietf.mtaGroupLastInboundActivity
       syntax: TicksCentiSec
+      metric: gauge
     mtaGroupLastOutboundActivity:
       oid: .1.3.6.1.2.1.28.2.1.18
       name: ietf.mtaGroupLastOutboundActivity
       syntax: TicksCentiSec
+      metric: gauge
     mtaGroupRejectedInboundAssociations:
       oid: .1.3.6.1.2.1.28.2.1.19
       name: ietf.mtaGroupRejectedInboundAssociations
       syntax: Counter32
+      metric: counter
     mtaGroupFailedOutboundAssociations:
       oid: .1.3.6.1.2.1.28.2.1.20
       name: ietf.mtaGroupFailedOutboundAssociations
       syntax: Counter32
+      metric: counter
     mtaGroupInboundRejectionReason:
       oid: .1.3.6.1.2.1.28.2.1.21
       name: ietf.mtaGroupInboundRejectionReason
@@ -155,6 +186,7 @@ MTA-MIB::mtaGroupEntry:
       oid: .1.3.6.1.2.1.28.2.1.23
       name: ietf.mtaGroupScheduledRetry
       syntax: TicksCentiSec
+      metric: gauge
     mtaGroupMailProtocol:
       oid: .1.3.6.1.2.1.28.2.1.24
       name: ietf.mtaGroupMailProtocol
@@ -167,10 +199,12 @@ MTA-MIB::mtaGroupEntry:
       oid: .1.3.6.1.2.1.28.2.1.26
       name: ietf.mtaGroupSuccessfulConvertedMessages
       syntax: Counter32
+      metric: counter
     mtaGroupFailedConvertedMessages:
       oid: .1.3.6.1.2.1.28.2.1.27
       name: ietf.mtaGroupFailedConvertedMessages
       syntax: Counter32
+      metric: counter
     mtaGroupDescription:
       oid: .1.3.6.1.2.1.28.2.1.28
       name: ietf.mtaGroupDescription
@@ -183,6 +217,7 @@ MTA-MIB::mtaGroupEntry:
       oid: .1.3.6.1.2.1.28.2.1.30
       name: ietf.mtaGroupCreationTime
       syntax: TicksCentiSec
+      metric: counter
     mtaGroupHierarchy:
       oid: .1.3.6.1.2.1.28.2.1.31
       name: ietf.mtaGroupHierarchy
@@ -195,10 +230,12 @@ MTA-MIB::mtaGroupEntry:
       oid: .1.3.6.1.2.1.28.2.1.33
       name: ietf.mtaGroupLoopsDetected
       syntax: Counter32
+      metric: counter
     mtaGroupLastOutboundAssociationAttempt:
       oid: .1.3.6.1.2.1.28.2.1.34
       name: ietf.mtaGroupLastOutboundAssociationAttempt
       syntax: TicksCentiSec
+      metric: gauge
 
 MTA-MIB::mtaGroupErrorEntry:
   mib: MTA-MIB
@@ -222,11 +259,14 @@ MTA-MIB::mtaGroupErrorEntry:
       oid: .1.3.6.1.2.1.28.5.1.1
       name: ietf.mtaGroupInboundErrorCount
       syntax: Counter32
+      metric: counter
     mtaGroupInternalErrorCount:
       oid: .1.3.6.1.2.1.28.5.1.2
       name: ietf.mtaGroupInternalErrorCount
       syntax: Counter32
+      metric: counter
     mtaGroupOutboundErrorCount:
       oid: .1.3.6.1.2.1.28.5.1.3
       name: ietf.mtaGroupOutboundErrorCount
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/NAT-MIB.yml
+++ b/objects/ietf/NAT-MIB.yml
@@ -7,50 +7,12 @@ NAT-MIB::natMIBObjects:
       oid: .1.3.6.1.2.1.123.1.5
       name: ietf.natAddrBindNumberOfEntries
       syntax: Gauge32
+      metric: gauge
     natAddrPortBindNumberOfEntries:
       oid: .1.3.6.1.2.1.123.1.7
       name: ietf.natAddrPortBindNumberOfEntries
       syntax: Gauge32
-
-# NAT-MIB::natDefTimeouts:
-#   mib: NAT-MIB
-#   object: natDefTimeouts
-#   discovery_attribute: natBindDefIdleTimeout
-#   attributes:
-#     natBindDefIdleTimeout:
-#       oid: .1.3.6.1.2.1.123.1.1.1
-#       name: ietf.natBindDefIdleTimeout
-#       syntax: TicksSec
-#     natUdpDefIdleTimeout:
-#       oid: .1.3.6.1.2.1.123.1.1.2
-#       name: ietf.natUdpDefIdleTimeout
-#       syntax: TicksSec
-#     natIcmpDefIdleTimeout:
-#       oid: .1.3.6.1.2.1.123.1.1.3
-#       name: ietf.natIcmpDefIdleTimeout
-#       syntax: TicksSec
-#     natOtherDefIdleTimeout:
-#       oid: .1.3.6.1.2.1.123.1.1.4
-#       name: ietf.natOtherDefIdleTimeout
-#       syntax: TicksSec
-#     natTcpDefIdleTimeout:
-#       oid: .1.3.6.1.2.1.123.1.1.5
-#       name: ietf.natTcpDefIdleTimeout
-#       syntax: TicksSec
-#     natTcpDefNegTimeout:
-#       oid: .1.3.6.1.2.1.123.1.1.6
-#       name: ietf.natTcpDefNegTimeout
-#       syntax: TicksSec
-
-# NAT-MIB::natNotifCtrl:
-#   mib: NAT-MIB
-#   object: natNotifCtrl
-#   discovery_attribute: natNotifThrottlingInterval
-#   attributes:
-#     natNotifThrottlingInterval:
-#       oid: .1.3.6.1.2.1.123.1.2.1
-#       name: ietf.natNotifThrottlingInterval
-#       syntax: TicksSec
+      metric: gauge
 
 NAT-MIB::natInterfaceEntry:
   mib: NAT-MIB
@@ -74,14 +36,17 @@ NAT-MIB::natInterfaceEntry:
       oid: .1.3.6.1.2.1.123.1.3.1.3
       name: ietf.natInterfaceInTranslates
       syntax: Counter64
+      metric: counter
     natInterfaceOutTranslates:
       oid: .1.3.6.1.2.1.123.1.3.1.4
       name: ietf.natInterfaceOutTranslates
       syntax: Counter64
+      metric: counter
     natInterfaceDiscards:
       oid: .1.3.6.1.2.1.123.1.3.1.5
       name: ietf.natInterfaceDiscards
       syntax: Counter64
+      metric: counter
 
 NAT-MIB::natAddrMapEntry:
   mib: NAT-MIB
@@ -149,18 +114,22 @@ NAT-MIB::natAddrMapEntry:
       oid: .1.3.6.1.2.1.123.1.4.1.16
       name: ietf.natAddrMapInTranslates
       syntax: Counter64
+      metric: counter
     natAddrMapOutTranslates:
       oid: .1.3.6.1.2.1.123.1.4.1.17
       name: ietf.natAddrMapOutTranslates
       syntax: Counter64
+      metric: counter
     natAddrMapDiscards:
       oid: .1.3.6.1.2.1.123.1.4.1.18
       name: ietf.natAddrMapDiscards
       syntax: Counter64
+      metric: counter
     natAddrMapAddrUsed:
       oid: .1.3.6.1.2.1.123.1.4.1.19
       name: ietf.natAddrMapAddrUsed
       syntax: Gauge32
+      metric: gauge
 
 NAT-MIB::natAddrBindEntry:
   mib: NAT-MIB
@@ -204,22 +173,27 @@ NAT-MIB::natAddrBindEntry:
       oid: .1.3.6.1.2.1.123.1.6.1.9
       name: ietf.natAddrBindSessions
       syntax: Gauge32
+      metric: gauge
     natAddrBindMaxIdleTime:
       oid: .1.3.6.1.2.1.123.1.6.1.10
       name: ietf.natAddrBindMaxIdleTime
       syntax: TimeTicks
+      metric: gauge
     natAddrBindCurrentIdleTime:
       oid: .1.3.6.1.2.1.123.1.6.1.11
       name: ietf.natAddrBindCurrentIdleTime
       syntax: TimeTicks
+      metric: gauge
     natAddrBindInTranslates:
       oid: .1.3.6.1.2.1.123.1.6.1.12
       name: ietf.natAddrBindInTranslates
       syntax: Counter64
+      metric: counter
     natAddrBindOutTranslates:
       oid: .1.3.6.1.2.1.123.1.6.1.13
       name: ietf.natAddrBindOutTranslates
       syntax: Counter64
+      metric: counter
 
 NAT-MIB::natAddrPortBindEntry:
   mib: NAT-MIB
@@ -275,22 +249,27 @@ NAT-MIB::natAddrPortBindEntry:
       oid: .1.3.6.1.2.1.123.1.8.1.12
       name: ietf.natAddrPortBindSessions
       syntax: Gauge32
+      metric: gauge
     natAddrPortBindMaxIdleTime:
       oid: .1.3.6.1.2.1.123.1.8.1.13
       name: ietf.natAddrPortBindMaxIdleTime
       syntax: TimeTicks
+      metric: gauge
     natAddrPortBindCurrentIdleTime:
       oid: .1.3.6.1.2.1.123.1.8.1.14
       name: ietf.natAddrPortBindCurrentIdleTime
       syntax: TimeTicks
+      metric: gauge
     natAddrPortBindInTranslates:
       oid: .1.3.6.1.2.1.123.1.8.1.15
       name: ietf.natAddrPortBindInTranslates
       syntax: Counter64
+      metric: counter
     natAddrPortBindOutTranslates:
       oid: .1.3.6.1.2.1.123.1.8.1.16
       name: ietf.natAddrPortBindOutTranslates
       syntax: Counter64
+      metric: counter
 
 NAT-MIB::natSessionEntry:
   mib: NAT-MIB
@@ -330,6 +309,7 @@ NAT-MIB::natSessionEntry:
       oid: .1.3.6.1.2.1.123.1.9.1.7
       name: ietf.natSessionUpTime
       syntax: TimeTicks
+      metric: counter
     natSessionAddrMapIndex:
       oid: .1.3.6.1.2.1.123.1.9.1.8
       name: ietf.natSessionAddrMapIndex
@@ -374,18 +354,22 @@ NAT-MIB::natSessionEntry:
       oid: .1.3.6.1.2.1.123.1.9.1.20
       name: ietf.natSessionMaxIdleTime
       syntax: TimeTicks
+      metric: gauge
     natSessionCurrentIdleTime:
       oid: .1.3.6.1.2.1.123.1.9.1.21
       name: ietf.natSessionCurrentIdleTime
       syntax: TimeTicks
+      metric: gauge
     natSessionInTranslates:
       oid: .1.3.6.1.2.1.123.1.9.1.22
       name: ietf.natSessionInTranslates
       syntax: Counter64
+      metric: counter
     natSessionOutTranslates:
       oid: .1.3.6.1.2.1.123.1.9.1.23
       name: ietf.natSessionOutTranslates
       syntax: Counter64
+      metric: counter
 
 NAT-MIB::natProtocolEntry:
   mib: NAT-MIB
@@ -401,11 +385,14 @@ NAT-MIB::natProtocolEntry:
       oid: .1.3.6.1.2.1.123.1.10.1.2
       name: ietf.natProtocolInTranslates
       syntax: Counter64
+      metric: counter
     natProtocolOutTranslates:
       oid: .1.3.6.1.2.1.123.1.10.1.3
       name: ietf.natProtocolOutTranslates
       syntax: Counter64
+      metric: counter
     natProtocolDiscards:
       oid: .1.3.6.1.2.1.123.1.10.1.4
       name: ietf.natProtocolDiscards
       syntax: Counter64
+      metric: counter

--- a/objects/ietf/NETWORK-SERVICES-MIB.yml
+++ b/objects/ietf/NETWORK-SERVICES-MIB.yml
@@ -24,6 +24,7 @@ NETWORK-SERVICES-MIB::applEntry:
       oid: .1.3.6.1.2.1.27.1.1.5
       name: ietf.applUptime
       syntax: TimeStamp
+      metric: counter
     applOperStatus:
       oid: .1.3.6.1.2.1.27.1.1.6
       name: ietf.applOperStatus
@@ -32,38 +33,47 @@ NETWORK-SERVICES-MIB::applEntry:
       oid: .1.3.6.1.2.1.27.1.1.7
       name: ietf.applLastChange
       syntax: TimeStamp
+      metric: counter
     applInboundAssociations:
       oid: .1.3.6.1.2.1.27.1.1.8
       name: ietf.applInboundAssociations
       syntax: Gauge32
+      metric: gauge
     applOutboundAssociations:
       oid: .1.3.6.1.2.1.27.1.1.9
       name: ietf.applOutboundAssociations
       syntax: Gauge32
+      metric: gauge
     applAccumulatedInboundAssociations:
       oid: .1.3.6.1.2.1.27.1.1.10
       name: ietf.applAccumulatedInboundAssociations
       syntax: Counter32
+      metric: counter
     applAccumulatedOutboundAssociations:
       oid: .1.3.6.1.2.1.27.1.1.11
       name: ietf.applAccumulatedOutboundAssociations
       syntax: Counter32
+      metric: counter
     applLastInboundActivity:
       oid: .1.3.6.1.2.1.27.1.1.12
       name: ietf.applLastInboundActivity
       syntax: TimeStamp
+      metric: counter
     applLastOutboundActivity:
       oid: .1.3.6.1.2.1.27.1.1.13
       name: ietf.applLastOutboundActivity
       syntax: TimeStamp
+      metric: counter
     applRejectedInboundAssociations:
       oid: .1.3.6.1.2.1.27.1.1.14
       name: ietf.applRejectedInboundAssociations
       syntax: Counter32
+      metric: counter
     applFailedOutboundAssociations:
       oid: .1.3.6.1.2.1.27.1.1.15
       name: ietf.applFailedOutboundAssociations
       syntax: Counter32
+      metric: counter
     applDescription:
       oid: .1.3.6.1.2.1.27.1.1.16
       name: ietf.applDescription
@@ -103,3 +113,4 @@ NETWORK-SERVICES-MIB::assocEntry:
       oid: .1.3.6.1.2.1.27.2.1.5
       name: ietf.assocDuration
       syntax: TimeStamp
+      metric: counter

--- a/objects/ietf/NHRP-MIB.yml
+++ b/objects/ietf/NHRP-MIB.yml
@@ -1,107 +1,3 @@
-# NHRP-MIB::nhrpGeneralObjects:
-#   mib: NHRP-MIB
-#   object: nhrpGeneralObjects
-#   discovery_attribute: nhrpNextIndex
-#   attributes:
-#     nhrpNextIndex:
-#       oid: .1.3.6.1.2.1.71.1.1.1
-#       name: ietf.nhrpNextIndex
-#       syntax: Unsigned32
-
-# NHRP-MIB::nhrpCacheEntry:
-#   mib: NHRP-MIB
-#   object: nhrpCacheEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.1
-#       name: ietf.nhrpCacheInternetworkAddrType
-#       syntax: EnumInteger
-#     - type: OctetString
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.2
-#       name: ietf.nhrpCacheInternetworkAddr
-#       syntax: OctetString
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.3
-#       name: ietf.nhrpCacheIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: nhrpCachePrefixLength
-#   attributes:
-#     nhrpCachePrefixLength:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.4
-#       name: ietf.nhrpCachePrefixLength
-#       syntax: Integer32
-#     nhrpCacheNextHopInternetworkAddr:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.5
-#       name: ietf.nhrpCacheNextHopInternetworkAddr
-#       syntax: OctetString
-#     nhrpCacheNbmaAddrType:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.6
-#       name: ietf.nhrpCacheNbmaAddrType
-#       syntax: EnumInteger
-#     nhrpCacheNbmaAddr:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.7
-#       name: ietf.nhrpCacheNbmaAddr
-#       syntax: OctetString
-#     nhrpCacheNbmaSubaddr:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.8
-#       name: ietf.nhrpCacheNbmaSubaddr
-#       syntax: OctetString
-#     nhrpCacheType:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.9
-#       name: ietf.nhrpCacheType
-#       syntax: EnumInteger
-#     nhrpCacheState:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.10
-#       name: ietf.nhrpCacheState
-#       syntax: EnumInteger
-#     nhrpCacheHoldingTimeValid:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.11
-#       name: ietf.nhrpCacheHoldingTimeValid
-#       syntax: TruthValue
-#     nhrpCacheHoldingTime:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.12
-#       name: ietf.nhrpCacheHoldingTime
-#       syntax: TicksSec
-#     nhrpCacheNegotiatedMtu:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.13
-#       name: ietf.nhrpCacheNegotiatedMtu
-#       syntax: BytesB
-#     nhrpCachePreference:
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.14
-#       name: ietf.nhrpCachePreference
-#       syntax: Integer32
-
-# NHRP-MIB::nhrpPurgeReqEntry:
-#   mib: NHRP-MIB
-#   object: nhrpPurgeReqEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.71.1.1.3.1.1
-#       name: ietf.nhrpPurgeIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: nhrpPurgeCacheIdentifier
-#   attributes:
-#     nhrpPurgeCacheIdentifier:
-#       oid: .1.3.6.1.2.1.71.1.1.3.1.2
-#       name: ietf.nhrpPurgeCacheIdentifier
-#       syntax: Unsigned32
-#     nhrpPurgePrefixLength:
-#       oid: .1.3.6.1.2.1.71.1.1.3.1.3
-#       name: ietf.nhrpPurgePrefixLength
-#       syntax: Integer32
-#     nhrpPurgeRequestID:
-#       oid: .1.3.6.1.2.1.71.1.1.3.1.4
-#       name: ietf.nhrpPurgeRequestID
-#       syntax: Unsigned32
-#     nhrpPurgeReplyExpected:
-#       oid: .1.3.6.1.2.1.71.1.1.3.1.5
-#       name: ietf.nhrpPurgeReplyExpected
-#       syntax: TruthValue
-
 NHRP-MIB::nhrpClientEntry:
   mib: NHRP-MIB
   object: nhrpClientEntry
@@ -136,92 +32,36 @@ NHRP-MIB::nhrpClientEntry:
       oid: .1.3.6.1.2.1.71.1.2.1.1.7
       name: ietf.nhrpClientInitialRequestTimeout
       syntax: TicksSec
+      metric: gauge
     nhrpClientRegistrationRequestRetries:
       oid: .1.3.6.1.2.1.71.1.2.1.1.8
       name: ietf.nhrpClientRegistrationRequestRetries
       syntax: Integer32
+      metric: gauge
     nhrpClientResolutionRequestRetries:
       oid: .1.3.6.1.2.1.71.1.2.1.1.9
       name: ietf.nhrpClientResolutionRequestRetries
       syntax: Integer32
+      metric: gauge
     nhrpClientPurgeRequestRetries:
       oid: .1.3.6.1.2.1.71.1.2.1.1.10
       name: ietf.nhrpClientPurgeRequestRetries
       syntax: Integer32
+      metric: gauge
     nhrpClientDefaultMtu:
       oid: .1.3.6.1.2.1.71.1.2.1.1.11
       name: ietf.nhrpClientDefaultMtu
       syntax: BytesB
+      metric: gauge
     nhrpClientHoldTime:
       oid: .1.3.6.1.2.1.71.1.2.1.1.12
       name: ietf.nhrpClientHoldTime
       syntax: TicksSec
+      metric: gauge
     nhrpClientRequestID:
       oid: .1.3.6.1.2.1.71.1.2.1.1.13
       name: ietf.nhrpClientRequestID
       syntax: UnsignedAsID
-
-# NHRP-MIB::nhrpClientRegistrationEntry:
-#   mib: NHRP-MIB
-#   object: nhrpClientRegistrationEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.71.1.2.1.1.1
-#       name: ietf.nhrpClientIndex
-#       syntax: UnsignedAsID
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.71.1.2.2.1.1
-#       name: ietf.nhrpClientRegIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: nhrpClientRegUniqueness
-#   attributes:
-#     nhrpClientRegUniqueness:
-#       oid: .1.3.6.1.2.1.71.1.2.2.1.2
-#       name: ietf.nhrpClientRegUniqueness
-#       syntax: EnumInteger
-#     nhrpClientRegState:
-#       oid: .1.3.6.1.2.1.71.1.2.2.1.3
-#       name: ietf.nhrpClientRegState
-#       syntax: EnumInteger
-
-# NHRP-MIB::nhrpClientNhsEntry:
-#   mib: NHRP-MIB
-#   object: nhrpClientNhsEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.71.1.2.1.1.1
-#       name: ietf.nhrpClientIndex
-#       syntax: UnsignedAsID
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.71.1.2.3.1.1
-#       name: ietf.nhrpClientNhsIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: nhrpClientNhsInternetworkAddrType
-#   attributes:
-#     nhrpClientNhsInternetworkAddrType:
-#       oid: .1.3.6.1.2.1.71.1.2.3.1.2
-#       name: ietf.nhrpClientNhsInternetworkAddrType
-#       syntax: EnumInteger
-#     nhrpClientNhsInternetworkAddr:
-#       oid: .1.3.6.1.2.1.71.1.2.3.1.3
-#       name: ietf.nhrpClientNhsInternetworkAddr
-#       syntax: OctetString
-#     nhrpClientNhsNbmaAddrType:
-#       oid: .1.3.6.1.2.1.71.1.2.3.1.4
-#       name: ietf.nhrpClientNhsNbmaAddrType
-#       syntax: EnumInteger
-#     nhrpClientNhsNbmaAddr:
-#       oid: .1.3.6.1.2.1.71.1.2.3.1.5
-#       name: ietf.nhrpClientNhsNbmaAddr
-#       syntax: OctetString
-#     nhrpClientNhsNbmaSubaddr:
-#       oid: .1.3.6.1.2.1.71.1.2.3.1.6
-#       name: ietf.nhrpClientNhsNbmaSubaddr
-#       syntax: OctetString
-#     nhrpClientNhsInUse:
-#       oid: .1.3.6.1.2.1.71.1.2.3.1.7
-#       name: ietf.nhrpClientNhsInUse
-#       syntax: TruthValue
 
 NHRP-MIB::nhrpClientStatEntry:
   mib: NHRP-MIB
@@ -233,102 +73,127 @@ NHRP-MIB::nhrpClientStatEntry:
       oid: .1.3.6.1.2.1.71.1.2.4.1.1
       name: ietf.nhrpClientStatTxResolveReq
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxResolveReplyAck:
       oid: .1.3.6.1.2.1.71.1.2.4.1.2
       name: ietf.nhrpClientStatRxResolveReplyAck
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxResolveReplyNakProhibited:
       oid: .1.3.6.1.2.1.71.1.2.4.1.3
       name: ietf.nhrpClientStatRxResolveReplyNakProhibited
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxResolveReplyNakInsufResources:
       oid: .1.3.6.1.2.1.71.1.2.4.1.4
       name: ietf.nhrpClientStatRxResolveReplyNakInsufResources
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxResolveReplyNakNoBinding:
       oid: .1.3.6.1.2.1.71.1.2.4.1.5
       name: ietf.nhrpClientStatRxResolveReplyNakNoBinding
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxResolveReplyNakNotUnique:
       oid: .1.3.6.1.2.1.71.1.2.4.1.6
       name: ietf.nhrpClientStatRxResolveReplyNakNotUnique
       syntax: Counter32
+      metric: counter
     nhrpClientStatTxRegisterReq:
       oid: .1.3.6.1.2.1.71.1.2.4.1.7
       name: ietf.nhrpClientStatTxRegisterReq
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxRegisterAck:
       oid: .1.3.6.1.2.1.71.1.2.4.1.8
       name: ietf.nhrpClientStatRxRegisterAck
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxRegisterNakProhibited:
       oid: .1.3.6.1.2.1.71.1.2.4.1.9
       name: ietf.nhrpClientStatRxRegisterNakProhibited
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxRegisterNakInsufResources:
       oid: .1.3.6.1.2.1.71.1.2.4.1.10
       name: ietf.nhrpClientStatRxRegisterNakInsufResources
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxRegisterNakAlreadyReg:
       oid: .1.3.6.1.2.1.71.1.2.4.1.11
       name: ietf.nhrpClientStatRxRegisterNakAlreadyReg
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxPurgeReq:
       oid: .1.3.6.1.2.1.71.1.2.4.1.12
       name: ietf.nhrpClientStatRxPurgeReq
       syntax: Counter32
+      metric: counter
     nhrpClientStatTxPurgeReq:
       oid: .1.3.6.1.2.1.71.1.2.4.1.13
       name: ietf.nhrpClientStatTxPurgeReq
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxPurgeReply:
       oid: .1.3.6.1.2.1.71.1.2.4.1.14
       name: ietf.nhrpClientStatRxPurgeReply
       syntax: Counter32
+      metric: counter
     nhrpClientStatTxPurgeReply:
       oid: .1.3.6.1.2.1.71.1.2.4.1.15
       name: ietf.nhrpClientStatTxPurgeReply
       syntax: Counter32
+      metric: counter
     nhrpClientStatTxErrorIndication:
       oid: .1.3.6.1.2.1.71.1.2.4.1.16
       name: ietf.nhrpClientStatTxErrorIndication
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxErrUnrecognizedExtension:
       oid: .1.3.6.1.2.1.71.1.2.4.1.17
       name: ietf.nhrpClientStatRxErrUnrecognizedExtension
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxErrLoopDetected:
       oid: .1.3.6.1.2.1.71.1.2.4.1.18
       name: ietf.nhrpClientStatRxErrLoopDetected
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxErrProtoAddrUnreachable:
       oid: .1.3.6.1.2.1.71.1.2.4.1.19
       name: ietf.nhrpClientStatRxErrProtoAddrUnreachable
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxErrProtoError:
       oid: .1.3.6.1.2.1.71.1.2.4.1.20
       name: ietf.nhrpClientStatRxErrProtoError
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxErrSduSizeExceeded:
       oid: .1.3.6.1.2.1.71.1.2.4.1.21
       name: ietf.nhrpClientStatRxErrSduSizeExceeded
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxErrInvalidExtension:
       oid: .1.3.6.1.2.1.71.1.2.4.1.22
       name: ietf.nhrpClientStatRxErrInvalidExtension
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxErrAuthenticationFailure:
       oid: .1.3.6.1.2.1.71.1.2.4.1.23
       name: ietf.nhrpClientStatRxErrAuthenticationFailure
       syntax: Counter32
+      metric: counter
     nhrpClientStatRxErrHopCountExceeded:
       oid: .1.3.6.1.2.1.71.1.2.4.1.24
       name: ietf.nhrpClientStatRxErrHopCountExceeded
       syntax: Counter32
+      metric: counter
     nhrpClientStatDiscontinuityTime:
       oid: .1.3.6.1.2.1.71.1.2.4.1.25
       name: ietf.nhrpClientStatDiscontinuityTime
       syntax: TimeStamp
+      metric: counter
 
 NHRP-MIB::nhrpServerEntry:
   mib: NHRP-MIB
@@ -361,76 +226,6 @@ NHRP-MIB::nhrpServerEntry:
       name: ietf.nhrpServerNbmaSubaddr
       syntax: OctetString
 
-# NHRP-MIB::nhrpServerCacheEntry:
-#   mib: NHRP-MIB
-#   object: nhrpServerCacheEntry
-#   index:
-#     - type: AddressFamilyNumbers
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.1
-#       name: ietf.nhrpCacheInternetworkAddrType
-#       syntax: EnumInteger
-#     - type: OctetString
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.2
-#       name: ietf.nhrpCacheInternetworkAddr
-#       syntax: OctetString
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.71.1.1.2.1.3
-#       name: ietf.nhrpCacheIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: nhrpServerCacheUniqueness
-#   attributes:
-#     nhrpServerCacheAuthoritative:
-#       oid: .1.3.6.1.2.1.71.1.3.2.1.1
-#       name: ietf.nhrpServerCacheAuthoritative
-#       syntax: TruthValue
-#     nhrpServerCacheUniqueness:
-#       oid: .1.3.6.1.2.1.71.1.3.2.1.2
-#       name: ietf.nhrpServerCacheUniqueness
-#       syntax: TruthValue
-
-# NHRP-MIB::nhrpServerNhcEntry:
-#   mib: NHRP-MIB
-#   object: nhrpServerNhcEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.71.1.3.1.1.1
-#       name: ietf.nhrpServerIndex
-#       syntax: UnsignedAsID
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.71.1.3.3.1.1
-#       name: ietf.nhrpServerNhcIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: nhrpServerNhcPrefixLength
-#   attributes:
-#     nhrpServerNhcPrefixLength:
-#       oid: .1.3.6.1.2.1.71.1.3.3.1.2
-#       name: ietf.nhrpServerNhcPrefixLength
-#       syntax: Integer32
-#     nhrpServerNhcInternetworkAddrType:
-#       oid: .1.3.6.1.2.1.71.1.3.3.1.3
-#       name: ietf.nhrpServerNhcInternetworkAddrType
-#       syntax: EnumInteger
-#     nhrpServerNhcInternetworkAddr:
-#       oid: .1.3.6.1.2.1.71.1.3.3.1.4
-#       name: ietf.nhrpServerNhcInternetworkAddr
-#       syntax: OctetString
-#     nhrpServerNhcNbmaAddrType:
-#       oid: .1.3.6.1.2.1.71.1.3.3.1.5
-#       name: ietf.nhrpServerNhcNbmaAddrType
-#       syntax: EnumInteger
-#     nhrpServerNhcNbmaAddr:
-#       oid: .1.3.6.1.2.1.71.1.3.3.1.6
-#       name: ietf.nhrpServerNhcNbmaAddr
-#       syntax: OctetString
-#     nhrpServerNhcNbmaSubaddr:
-#       oid: .1.3.6.1.2.1.71.1.3.3.1.7
-#       name: ietf.nhrpServerNhcNbmaSubaddr
-#       syntax: OctetString
-#     nhrpServerNhcInUse:
-#       oid: .1.3.6.1.2.1.71.1.3.3.1.8
-#       name: ietf.nhrpServerNhcInUse
-#       syntax: TruthValue
-
 NHRP-MIB::nhrpServerStatEntry:
   mib: NHRP-MIB
   object: nhrpServerStatEntry
@@ -441,159 +236,199 @@ NHRP-MIB::nhrpServerStatEntry:
       oid: .1.3.6.1.2.1.71.1.3.4.1.1
       name: ietf.nhrpServerStatRxResolveReq
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxResolveReplyAck:
       oid: .1.3.6.1.2.1.71.1.3.4.1.2
       name: ietf.nhrpServerStatTxResolveReplyAck
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxResolveReplyNakProhibited:
       oid: .1.3.6.1.2.1.71.1.3.4.1.3
       name: ietf.nhrpServerStatTxResolveReplyNakProhibited
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxResolveReplyNakInsufResources:
       oid: .1.3.6.1.2.1.71.1.3.4.1.4
       name: ietf.nhrpServerStatTxResolveReplyNakInsufResources
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxResolveReplyNakNoBinding:
       oid: .1.3.6.1.2.1.71.1.3.4.1.5
       name: ietf.nhrpServerStatTxResolveReplyNakNoBinding
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxResolveReplyNakNotUnique:
       oid: .1.3.6.1.2.1.71.1.3.4.1.6
       name: ietf.nhrpServerStatTxResolveReplyNakNotUnique
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxRegisterReq:
       oid: .1.3.6.1.2.1.71.1.3.4.1.7
       name: ietf.nhrpServerStatRxRegisterReq
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxRegisterAck:
       oid: .1.3.6.1.2.1.71.1.3.4.1.8
       name: ietf.nhrpServerStatTxRegisterAck
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxRegisterNakProhibited:
       oid: .1.3.6.1.2.1.71.1.3.4.1.9
       name: ietf.nhrpServerStatTxRegisterNakProhibited
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxRegisterNakInsufResources:
       oid: .1.3.6.1.2.1.71.1.3.4.1.10
       name: ietf.nhrpServerStatTxRegisterNakInsufResources
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxRegisterNakAlreadyReg:
       oid: .1.3.6.1.2.1.71.1.3.4.1.11
       name: ietf.nhrpServerStatTxRegisterNakAlreadyReg
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxPurgeReq:
       oid: .1.3.6.1.2.1.71.1.3.4.1.12
       name: ietf.nhrpServerStatRxPurgeReq
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxPurgeReq:
       oid: .1.3.6.1.2.1.71.1.3.4.1.13
       name: ietf.nhrpServerStatTxPurgeReq
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxPurgeReply:
       oid: .1.3.6.1.2.1.71.1.3.4.1.14
       name: ietf.nhrpServerStatRxPurgeReply
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxPurgeReply:
       oid: .1.3.6.1.2.1.71.1.3.4.1.15
       name: ietf.nhrpServerStatTxPurgeReply
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxErrUnrecognizedExtension:
       oid: .1.3.6.1.2.1.71.1.3.4.1.16
       name: ietf.nhrpServerStatRxErrUnrecognizedExtension
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxErrLoopDetected:
       oid: .1.3.6.1.2.1.71.1.3.4.1.17
       name: ietf.nhrpServerStatRxErrLoopDetected
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxErrProtoAddrUnreachable:
       oid: .1.3.6.1.2.1.71.1.3.4.1.18
       name: ietf.nhrpServerStatRxErrProtoAddrUnreachable
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxErrProtoError:
       oid: .1.3.6.1.2.1.71.1.3.4.1.19
       name: ietf.nhrpServerStatRxErrProtoError
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxErrSduSizeExceeded:
       oid: .1.3.6.1.2.1.71.1.3.4.1.20
       name: ietf.nhrpServerStatRxErrSduSizeExceeded
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxErrInvalidExtension:
       oid: .1.3.6.1.2.1.71.1.3.4.1.21
       name: ietf.nhrpServerStatRxErrInvalidExtension
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxErrInvalidResReplyReceived:
       oid: .1.3.6.1.2.1.71.1.3.4.1.22
       name: ietf.nhrpServerStatRxErrInvalidResReplyReceived
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxErrAuthenticationFailure:
       oid: .1.3.6.1.2.1.71.1.3.4.1.23
       name: ietf.nhrpServerStatRxErrAuthenticationFailure
       syntax: Counter32
+      metric: counter
     nhrpServerStatRxErrHopCountExceeded:
       oid: .1.3.6.1.2.1.71.1.3.4.1.24
       name: ietf.nhrpServerStatRxErrHopCountExceeded
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxErrUnrecognizedExtension:
       oid: .1.3.6.1.2.1.71.1.3.4.1.25
       name: ietf.nhrpServerStatTxErrUnrecognizedExtension
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxErrLoopDetected:
       oid: .1.3.6.1.2.1.71.1.3.4.1.26
       name: ietf.nhrpServerStatTxErrLoopDetected
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxErrProtoAddrUnreachable:
       oid: .1.3.6.1.2.1.71.1.3.4.1.27
       name: ietf.nhrpServerStatTxErrProtoAddrUnreachable
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxErrProtoError:
       oid: .1.3.6.1.2.1.71.1.3.4.1.28
       name: ietf.nhrpServerStatTxErrProtoError
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxErrSduSizeExceeded:
       oid: .1.3.6.1.2.1.71.1.3.4.1.29
       name: ietf.nhrpServerStatTxErrSduSizeExceeded
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxErrInvalidExtension:
       oid: .1.3.6.1.2.1.71.1.3.4.1.30
       name: ietf.nhrpServerStatTxErrInvalidExtension
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxErrAuthenticationFailure:
       oid: .1.3.6.1.2.1.71.1.3.4.1.31
       name: ietf.nhrpServerStatTxErrAuthenticationFailure
       syntax: Counter32
+      metric: counter
     nhrpServerStatTxErrHopCountExceeded:
       oid: .1.3.6.1.2.1.71.1.3.4.1.32
       name: ietf.nhrpServerStatTxErrHopCountExceeded
       syntax: Counter32
+      metric: counter
     nhrpServerStatFwResolveReq:
       oid: .1.3.6.1.2.1.71.1.3.4.1.33
       name: ietf.nhrpServerStatFwResolveReq
       syntax: Counter32
+      metric: counter
     nhrpServerStatFwResolveReply:
       oid: .1.3.6.1.2.1.71.1.3.4.1.34
       name: ietf.nhrpServerStatFwResolveReply
       syntax: Counter32
+      metric: counter
     nhrpServerStatFwRegisterReq:
       oid: .1.3.6.1.2.1.71.1.3.4.1.35
       name: ietf.nhrpServerStatFwRegisterReq
       syntax: Counter32
+      metric: counter
     nhrpServerStatFwRegisterReply:
       oid: .1.3.6.1.2.1.71.1.3.4.1.36
       name: ietf.nhrpServerStatFwRegisterReply
       syntax: Counter32
+      metric: counter
     nhrpServerStatFwPurgeReq:
       oid: .1.3.6.1.2.1.71.1.3.4.1.37
       name: ietf.nhrpServerStatFwPurgeReq
       syntax: Counter32
+      metric: counter
     nhrpServerStatFwPurgeReply:
       oid: .1.3.6.1.2.1.71.1.3.4.1.38
       name: ietf.nhrpServerStatFwPurgeReply
       syntax: Counter32
+      metric: counter
     nhrpServerStatFwErrorIndication:
       oid: .1.3.6.1.2.1.71.1.3.4.1.39
       name: ietf.nhrpServerStatFwErrorIndication
       syntax: Counter32
+      metric: counter
     nhrpServerStatDiscontinuityTime:
       oid: .1.3.6.1.2.1.71.1.3.4.1.40
       name: ietf.nhrpServerStatDiscontinuityTime
       syntax: TimeStamp
+      metric: counter

--- a/objects/ietf/NTPv4-MIB.yml
+++ b/objects/ietf/NTPv4-MIB.yml
@@ -62,6 +62,7 @@ NTPv4-MIB::ntpEntStatus:
       oid: .1.3.6.1.2.1.197.1.2.6
       name: ntp.references
       syntax: Unsigned32
+      metric: gauge
     ntpEntStatusDispersion:
       oid: .1.3.6.1.2.1.197.1.2.7
       name: ntp.dispersion
@@ -70,6 +71,7 @@ NTPv4-MIB::ntpEntStatus:
       oid: .1.3.6.1.2.1.197.1.2.8
       name: ntp.uptime
       syntax: TimeTicks
+      metric: gauge
     ntpEntStatusDateTime:
       oid: .1.3.6.1.2.1.197.1.2.9
       name: ntp.date_time
@@ -86,22 +88,27 @@ NTPv4-MIB::ntpEntStatus:
       oid: .1.3.6.1.2.1.197.1.2.12
       name: ntp.packets.in
       syntax: Counter32
+      metric: counter
     ntpEntStatusOutPkts:
       oid: .1.3.6.1.2.1.197.1.2.13
       name: ntp.packets.out
       syntax: Counter32
+      metric: counter
     ntpEntStatusBadVersion:
       oid: .1.3.6.1.2.1.197.1.2.14
       name: ntp.msgs.bad_version
       syntax: Counter32
+      metric: counter
     ntpEntStatusProtocolError:
       oid: .1.3.6.1.2.1.197.1.2.15
       name: ntp.msgs.proto_error
       syntax: Counter32
+      metric: counter
     ntpEntStatusNotifications:
       oid: .1.3.6.1.2.1.197.1.2.16
       name: ntp.notifs.out
       syntax: Counter32
+      metric: counter
 
 NTPv4-MIB::ntpEntStatPktModeEntry:
   mib: NTPv4-MIB
@@ -117,10 +124,12 @@ NTPv4-MIB::ntpEntStatPktModeEntry:
       oid: .1.3.6.1.2.1.197.1.2.17.1.2
       name: ntp.packets.out
       syntax: Counter32
+      metric: counter
     ntpEntStatPktReceived:
       oid: .1.3.6.1.2.1.197.1.2.17.1.3
       name: ntp.packets.in
       syntax: Counter32
+      metric: counter
 
 NTPv4-MIB::ntpAssociationEntry:
   mib: NTPv4-MIB
@@ -175,14 +184,17 @@ NTPv4-MIB::ntpAssociationStatisticsEntry:
       oid: .1.3.6.1.2.1.197.1.3.2.1.1
       name: ntp.assoc.packets.in
       syntax: Counter32
+      metric: counter
     ntpAssocStatOutPkts:
       oid: .1.3.6.1.2.1.197.1.3.2.1.2
       name: ntp.assoc.packets.out
       syntax: Counter32
+      metric: counter
     ntpAssocStatProtocolError:
       oid: .1.3.6.1.2.1.197.1.3.2.1.3
       name: ntp.assoc.msgs.proto_error
       syntax: Counter32
+      metric: counter
 
 NTPv4-MIB::ntpEntControl:
   mib: NTPv4-MIB
@@ -194,6 +206,7 @@ NTPv4-MIB::ntpEntControl:
       oid: .1.3.6.1.2.1.197.1.4.1
       name: ntp.heartbeat_interval
       syntax: Unsigned32
+      metric: gauge
     ntpEntNotifBits:
       oid: .1.3.6.1.2.1.197.1.4.2
       name: ntp.NotifBits

--- a/objects/ietf/OSPF-MIB.yml
+++ b/objects/ietf/OSPF-MIB.yml
@@ -29,6 +29,7 @@ OSPF-MIB::ospfGeneralGroup:
       oid: .1.3.6.1.2.1.14.1.6
       name: ospf.lsdb.as_extern.lsas
       syntax: Gauge32
+      metric: gauge
     ospfExternLsaCksumSum:
       oid: .1.3.6.1.2.1.14.1.7
       name: ospf.lsdb.as_extern.checksum
@@ -41,14 +42,17 @@ OSPF-MIB::ospfGeneralGroup:
       oid: .1.3.6.1.2.1.14.1.9
       name: ospf.lsas.new.out
       syntax: Counter32
+      metric: counter
     ospfRxNewLsas:
       oid: .1.3.6.1.2.1.14.1.10
       name: ospf.lsas.new.in
       syntax: Counter32
+      metric: counter
     ospfExtLsdbLimit:
       oid: .1.3.6.1.2.1.14.1.11
       name: ospf.lsdb.as_extern.limit
       syntax: Integer32
+      metric: gauge
     ospfMulticastExtensions:
       oid: .1.3.6.1.2.1.14.1.12
       name: ospf.mcast.flags.bits
@@ -57,6 +61,7 @@ OSPF-MIB::ospfGeneralGroup:
       oid: .1.3.6.1.2.1.14.1.13
       name: ospf.lsdb.as_extern.overflow_interval
       syntax: Unsigned32 # PositiveInteger
+      metric: gauge
     ospfDemandExtensions:
       oid: .1.3.6.1.2.1.14.1.14
       name: ospf.demand.support
@@ -73,6 +78,7 @@ OSPF-MIB::ospfGeneralGroup:
       oid: .1.3.6.1.2.1.14.1.17
       name: ospf.reference_bandwidth
       syntax: BandwidthKBits
+      metric: gauge
     ospfRestartSupport:
       oid: .1.3.6.1.2.1.14.1.18
       name: ospf.graceful_restart.support
@@ -81,6 +87,7 @@ OSPF-MIB::ospfGeneralGroup:
       oid: .1.3.6.1.2.1.14.1.19
       name: ospf.graceful_restart.interval
       syntax: Unsigned32
+      metric: gauge
     ospfRestartStrictLsaChecking:
       oid: .1.3.6.1.2.1.14.1.20
       name: ospf.graceful_restart.strict_check
@@ -93,6 +100,7 @@ OSPF-MIB::ospfGeneralGroup:
       oid: .1.3.6.1.2.1.14.1.22
       name: ospf.graceful_restart.age
       syntax: Unsigned32
+      metric: gauge
     ospfRestartExitReason:
       oid: .1.3.6.1.2.1.14.1.23
       name: ospf.graceful_restart.exit_reason
@@ -101,6 +109,7 @@ OSPF-MIB::ospfGeneralGroup:
       oid: .1.3.6.1.2.1.14.1.24
       name: ospf.lsdb.as_scope.lsas
       syntax: Gauge32
+      metric: gauge
     ospfAsLsaCksumSum:
       oid: .1.3.6.1.2.1.14.1.25
       name: ospf.lsdb.as_scope.checksum
@@ -117,6 +126,7 @@ OSPF-MIB::ospfGeneralGroup:
       oid: .1.3.6.1.2.1.14.1.28
       name: ospf.discontinuity_time
       syntax: TimeStamp
+      metric: counter
 
 OSPF-MIB::ospfAreaEntry:
   mib: OSPF-MIB
@@ -140,18 +150,22 @@ OSPF-MIB::ospfAreaEntry:
       oid: .1.3.6.1.2.1.14.2.1.4
       name: ospf.area.spf.runs
       syntax: Counter32
+      metric: counter
     ospfAreaBdrRtrCount:
       oid: .1.3.6.1.2.1.14.2.1.5
       name: ospf.area.area_border_routers
       syntax: Gauge32
+      metric: gauge
     ospfAsBdrRtrCount:
       oid: .1.3.6.1.2.1.14.2.1.6
       name: ospf.area.as_border_routers
       syntax: Gauge32
+      metric: gauge
     ospfAreaLsaCount:
       oid: .1.3.6.1.2.1.14.2.1.7
       name: ospf.area.lsdb.area_scope.lsas
       syntax: Gauge32
+      metric: gauge
     ospfAreaLsaCksumSum:
       oid: .1.3.6.1.2.1.14.2.1.8
       name: ospf.area.lsdb.area_scope.checksum
@@ -172,10 +186,12 @@ OSPF-MIB::ospfAreaEntry:
       oid: .1.3.6.1.2.1.14.2.1.13
       name: ospf.area.nssa_translator.stability_interval
       syntax: Unsigned32 # PositiveInteger
+      metric: gauge
     ospfAreaNssaTranslatorEvents:
       oid: .1.3.6.1.2.1.14.2.1.14
       name: ospf.area.nssa_translator.events
       syntax: Counter32
+      metric: counter
 
 OSPF-MIB::ospfStubAreaEntry:
   mib: OSPF-MIB
@@ -195,49 +211,11 @@ OSPF-MIB::ospfStubAreaEntry:
       oid: .1.3.6.1.2.1.14.3.1.3
       name: ospf.stub.metric.value
       syntax: Unsigned32 # BigMetric
+      metric: gauge
     ospfStubMetricType:
       oid: .1.3.6.1.2.1.14.3.1.5
       name: ospf.stub.metric.type
       syntax: EnumInteger
-
-# OSPF-MIB::ospfLsdbEntry:
-#   mib: OSPF-MIB
-#   object: ospfLsdbEntry
-#   index:
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.4.1.1
-#       name: ospf.lsdb.lsa.area.id # ospfLsdbAreaId
-#       syntax: IpAddressAsID # AreaID
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.14.4.1.2
-#       name: ospf.lsdb.lsa.type # ospfLsdbType
-#       syntax: EnumInteger
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.4.1.3
-#       name: ospf.lsdb.lsa.lsid # ospfLsdbLsid
-#       syntax: IpAddressAsID
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.4.1.4
-#       name: ospf.lsdb.lsa.router.id # ospfLsdbRouterId
-#       syntax: IpAddressAsID # RouterID
-#   discovery_attribute: ospfLsdbSequence
-#   attributes:
-#     ospfLsdbSequence:
-#       oid: .1.3.6.1.2.1.14.4.1.5
-#       name: ospf.lsdb.lsa.seq
-#       syntax: Integer32
-#     ospfLsdbAge:
-#       oid: .1.3.6.1.2.1.14.4.1.6
-#       name: ospf.lsdb.lsa.age
-#       syntax: Unsigned32
-#     ospfLsdbChecksum:
-#       oid: .1.3.6.1.2.1.14.4.1.7
-#       name: ospf.lsdb.lsa.checksum
-#       syntax: Unsigned32
-#     ospfLsdbAdvertisement:
-#       oid: .1.3.6.1.2.1.14.4.1.8
-#       name: ospf.lsdb.lsa.advert
-#       syntax: OctetString
 
 OSPF-MIB::ospfIfEntry:
   mib: OSPF-MIB
@@ -271,26 +249,32 @@ OSPF-MIB::ospfIfEntry:
       oid: .1.3.6.1.2.1.14.7.1.6
       name: ospf.netif.designated_router.priority
       syntax: Integer32 # DesignatedRouterPriority
+      metric: gauge
     ospfIfTransitDelay:
       oid: .1.3.6.1.2.1.14.7.1.7
       name: ospf.netif.lsa.transit_delay
       syntax: Unsigned32 # UpToMaxAge
+      metric: gauge
     ospfIfRetransInterval:
       oid: .1.3.6.1.2.1.14.7.1.8
       name: ospf.netif.lsa.retrans_interval
       syntax: Unsigned32 # UpToMaxAge
+      metric: gauge
     ospfIfHelloInterval:
       oid: .1.3.6.1.2.1.14.7.1.9
       name: ospf.netif.hello_interval
       syntax: Unsigned32 # HelloRange
+      metric: gauge
     ospfIfRtrDeadInterval:
       oid: .1.3.6.1.2.1.14.7.1.10
       name: ospf.netif.router_dead_interval
       syntax: Unsigned32 # PositiveInteger
+      metric: gauge
     ospfIfPollInterval:
       oid: .1.3.6.1.2.1.14.7.1.11
       name: ospf.netif.poll_interval
       syntax: Unsigned32 # PositiveInteger
+      metric: gauge
     ospfIfState:
       oid: .1.3.6.1.2.1.14.7.1.12
       name: ospf.netif.state
@@ -307,6 +291,7 @@ OSPF-MIB::ospfIfEntry:
       oid: .1.3.6.1.2.1.14.7.1.15
       name: ospf.netif.state.changes
       syntax: Counter32
+      metric: counter
     ospfIfAuthKey:
       oid: .1.3.6.1.2.1.14.7.1.16
       name: ospf.netif.auth.key
@@ -327,6 +312,7 @@ OSPF-MIB::ospfIfEntry:
       oid: .1.3.6.1.2.1.14.7.1.21
       name: ospf.netif.lsdb.link_local.lsas
       syntax: Gauge32
+      metric: gauge
     ospfIfLsaCksumSum:
       oid: .1.3.6.1.2.1.14.7.1.22
       name: ospf.netif.lsdb.link_local.checksum
@@ -358,18 +344,22 @@ OSPF-MIB::ospfVirtIfEntry:
       oid: .1.3.6.1.2.1.14.9.1.3
       name: ospf.virt_netif.lsa.transit_delay
       syntax: TicksSec # UpToMaxAge
+      metric: gauge
     ospfVirtIfRetransInterval:
       oid: .1.3.6.1.2.1.14.9.1.4
       name: ospf.virt_netif.lsa.retrans_interval
       syntax: TicksSec # UpToMaxAge
+      metric: gauge
     ospfVirtIfHelloInterval:
       oid: .1.3.6.1.2.1.14.9.1.5
       name: ospf.virt_netif.hello_interval
       syntax: TicksSec # HelloRange
+      metric: gauge
     ospfVirtIfRtrDeadInterval:
       oid: .1.3.6.1.2.1.14.9.1.6
       name: ospf.virt_netif.router_dead_interval
       syntax: TicksSec # PositiveInteger
+      metric: gauge
     ospfVirtIfState:
       oid: .1.3.6.1.2.1.14.9.1.7
       name: ospf.virt_netif.state
@@ -378,6 +368,7 @@ OSPF-MIB::ospfVirtIfEntry:
       oid: .1.3.6.1.2.1.14.9.1.8
       name: ospf.virt_netif.state.changes
       syntax: Counter32
+      metric: counter
     ospfVirtIfAuthKey:
       oid: .1.3.6.1.2.1.14.9.1.9
       name: ospf.virt_netif.auth.key
@@ -390,6 +381,7 @@ OSPF-MIB::ospfVirtIfEntry:
       oid: .1.3.6.1.2.1.14.9.1.12
       name: ospf.virt_netif.lsdb.link_local.lsas
       syntax: Gauge32
+      metric: gauge
     ospfVirtIfLsaCksumSum:
       oid: .1.3.6.1.2.1.14.9.1.13
       name: ospf.virt_netif.lsdb.link_local.checksum
@@ -422,6 +414,7 @@ OSPF-MIB::ospfNbrEntry:
       oid: .1.3.6.1.2.1.14.10.1.5
       name: ospf.neighbor.designated_router.priority
       syntax: Integer32 # DesignatedRouterPriority
+      metric: gauge
     ospfNbrState:
       oid: .1.3.6.1.2.1.14.10.1.6
       name: ospf.neighbor.state
@@ -430,10 +423,12 @@ OSPF-MIB::ospfNbrEntry:
       oid: .1.3.6.1.2.1.14.10.1.7
       name: ospf.neighbor.state.changes
       syntax: Counter32
+      metric: counter
     ospfNbrLsRetransQLen:
       oid: .1.3.6.1.2.1.14.10.1.8
       name: ospf.neighbor.link_state_retrans_queue
       syntax: Gauge32
+      metric: gauge
     ospfNbmaNbrPermanence:
       oid: .1.3.6.1.2.1.14.10.1.10
       name: ospf.neighbor.persist
@@ -450,6 +445,7 @@ OSPF-MIB::ospfNbrEntry:
       oid: .1.3.6.1.2.1.14.10.1.13
       name: ospf.neighbor.graceful_restart.helper.age
       syntax: Unsigned32
+      metric: gauge
     ospfNbrRestartHelperExitReason:
       oid: .1.3.6.1.2.1.14.10.1.14
       name: ospf.neighbor.graceful_restart.helper.exit_reason
@@ -486,10 +482,12 @@ OSPF-MIB::ospfVirtNbrEntry:
       oid: .1.3.6.1.2.1.14.11.1.6
       name: ospf.virt_neighbor.state.changes
       syntax: Counter32
+      metric: counter
     ospfVirtNbrLsRetransQLen:
       oid: .1.3.6.1.2.1.14.11.1.7
       name: ospf.virt_neighbor.link_state_retrans_queue
       syntax: Gauge32
+      metric: gauge
     ospfVirtNbrHelloSuppressed:
       oid: .1.3.6.1.2.1.14.11.1.8
       name: ospf.virt_neighbor.hello_suppress
@@ -501,167 +499,12 @@ OSPF-MIB::ospfVirtNbrEntry:
     ospfVirtNbrRestartHelperAge:
       oid: .1.3.6.1.2.1.14.11.1.10
       name: ospf.virt_neighbor.graceful_restart.helper.age
-      syntax: Unsigned32
+      syntax: TicksSec
+      metric: gauge
     ospfVirtNbrRestartHelperExitReason:
       oid: .1.3.6.1.2.1.14.11.1.11
       name: ospf.virt_neighbor.graceful_restart.helper.exit_reason
       syntax: EnumInteger
-
-# OSPF-MIB::ospfExtLsdbEntry:
-#   mib: OSPF-MIB
-#   object: ospfExtLsdbEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.14.12.1.1
-#       name: ospf.lsdb.as_extern.lsa.type # ospfExtLsdbType
-#       syntax: EnumInteger
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.12.1.2
-#       name: ospf.lsdb.as_extern.lsa.lsid # ospfExtLsdbLsid
-#       syntax: IpAddressAsID
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.12.1.3
-#       name: ospf.lsdb.as_extern.lsa.router.id # ospfExtLsdbRouterId
-#       syntax: IpAddressAsID # RouterID
-#   discovery_attribute: ospfExtLsdbSequence
-#   attributes:
-#     ospfExtLsdbSequence:
-#       oid: .1.3.6.1.2.1.14.12.1.4
-#       name: ospf.lsdb.as_extern.lsa.seq
-#       syntax: Integer32
-#     ospfExtLsdbAge:
-#       oid: .1.3.6.1.2.1.14.12.1.5
-#       name: ospf.lsdb.as_extern.lsa.age
-#       syntax: Unsigned32
-#     ospfExtLsdbChecksum:
-#       oid: .1.3.6.1.2.1.14.12.1.6
-#       name: ospf.lsdb.as_extern.lsa.checksum
-#       syntax: Unsigned32
-#     ospfExtLsdbAdvertisement:
-#       oid: .1.3.6.1.2.1.14.12.1.7
-#       name: ospf.lsdb.as_extern.lsa.advert
-#       syntax: OctetString
-
-# OSPF-MIB::ospfLocalLsdbEntry:
-#   mib: OSPF-MIB
-#   object: ospfLocalLsdbEntry
-#   index:
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.17.1.1
-#       name: ospf.lsdb.link_local.lsa.netif # ospfLocalLsdbIpAddress
-#       syntax: IpAddress
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.14.17.1.2
-#       name: ospf.lsdb.link_local.lsa.netif # ospfLocalLsdbAddressLessIf
-#       syntax: InterfaceIndexOrZero
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.14.17.1.3
-#       name: ospf.lsdb.link_local.lsa.type # ospfLocalLsdbType
-#       syntax: EnumInteger
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.17.1.4
-#       name: ospf.lsdb.link_local.lsa.lsid # ospfLocalLsdbLsid
-#       syntax: IpAddressAsID
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.17.1.5
-#       name: ospf.lsdb.link_local.lsa.router.id # ospfLocalLsdbRouterId
-#       syntax: IpAddressAsID # RouterID
-#   discovery_attribute: ospfLocalLsdbSequence
-#   attributes:
-#     ospfLocalLsdbSequence:
-#       oid: .1.3.6.1.2.1.14.17.1.6
-#       name: ospf.lsdb.link_local.lsa.seq
-#       syntax: Integer32
-#     ospfLocalLsdbAge:
-#       oid: .1.3.6.1.2.1.14.17.1.7
-#       name: ospf.lsdb.link_local.lsa.age
-#       syntax: Unsigned32
-#     ospfLocalLsdbChecksum:
-#       oid: .1.3.6.1.2.1.14.17.1.8
-#       name: ospf.lsdb.link_local.lsa.checksum
-#       syntax: Unsigned32
-#     ospfLocalLsdbAdvertisement:
-#       oid: .1.3.6.1.2.1.14.17.1.9
-#       name: ospf.lsdb.link_local.lsa.advert
-#       syntax: OctetString
-
-# OSPF-MIB::ospfVirtLocalLsdbEntry:
-#   mib: OSPF-MIB
-#   object: ospfVirtLocalLsdbEntry
-#   index:
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.18.1.1
-#       name: ospf.lsdb.virt_link_local.lsa.transit_area.id # ospfVirtLocalLsdbTransitArea
-#       syntax: IpAddressAsID # AreaID
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.18.1.2
-#       name: ospf.lsdb.virt_link_local.lsa.neigbor.router.id # ospfVirtLocalLsdbNeighbor
-#       syntax: IpAddressAsID # RouterID
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.14.18.1.3
-#       name: ospf.lsdb.virt_link_local.lsa.type # ospfVirtLocalLsdbType
-#       syntax: EnumInteger
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.18.1.4
-#       name: ospf.lsdb.virt_link_local.lsa.lsid # ospfVirtLocalLsdbLsid
-#       syntax: IpAddressAsID
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.18.1.5
-#       name: ospf.lsdb.virt_link_local.lsa.router.id # ospfVirtLocalLsdbRouterId
-#       syntax: IpAddressAsID # RouterID
-#   discovery_attribute: ospfVirtLocalLsdbSequence
-#   attributes:
-#     ospfVirtLocalLsdbSequence:
-#       oid: .1.3.6.1.2.1.14.18.1.6
-#       name: ospf.lsdb.virt_link_local.lsa.seq
-#       syntax: Integer32
-#     ospfVirtLocalLsdbAge:
-#       oid: .1.3.6.1.2.1.14.18.1.7
-#       name: ospf.lsdb.virt_link_local.lsa.age
-#       syntax: Unsigned32
-#     ospfVirtLocalLsdbChecksum:
-#       oid: .1.3.6.1.2.1.14.18.1.8
-#       name: ospf.lsdb.virt_link_local.lsa.checksum
-#       syntax: Unsigned32
-#     ospfVirtLocalLsdbAdvertisement:
-#       oid: .1.3.6.1.2.1.14.18.1.9
-#       name: ospf.lsdb.virt_link_local.lsa.advert
-#       syntax: OctetString
-
-# OSPF-MIB::ospfAsLsdbEntry:
-#   mib: OSPF-MIB
-#   object: ospfAsLsdbEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.14.19.1.1
-#       name: ospf.lsdb.as_scope.lsa.type # ospfAsLsdbType
-#       syntax: EnumInteger
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.19.1.2
-#       name: ospf.lsdb.as_scope.lsa.lsid # ospfAsLsdbLsid
-#       syntax: IpAddressAsID
-#     - type: IpAddress
-#       oid: .1.3.6.1.2.1.14.19.1.3
-#       name: ospf.lsdb.as_scope.lsa.router.id # ospfAsLsdbRouterId
-#       syntax: IpAddressAsID # RouterID
-#   discovery_attribute: ospfAsLsdbSequence
-#   attributes:
-#     ospfAsLsdbSequence:
-#       oid: .1.3.6.1.2.1.14.19.1.4
-#       name: ospf.lsdb.as_scope.lsa.seq
-#       syntax: Integer32
-#     ospfAsLsdbAge:
-#       oid: .1.3.6.1.2.1.14.19.1.5
-#       name: ospf.lsdb.as_scope.lsa.age
-#       syntax: Unsigned32
-#     ospfAsLsdbChecksum:
-#       oid: .1.3.6.1.2.1.14.19.1.6
-#       name: ospf.lsdb.as_scope.lsa.checksum
-#       syntax: Unsigned32
-#     ospfAsLsdbAdvertisement:
-#       oid: .1.3.6.1.2.1.14.19.1.7
-#       name: ospf.lsdb.as_scope.lsa.advert
-#       syntax: OctetString
 
 OSPF-MIB::ospfAreaLsaCountEntry:
   mib: OSPF-MIB
@@ -681,3 +524,4 @@ OSPF-MIB::ospfAreaLsaCountEntry:
       oid: .1.3.6.1.2.1.14.20.1.3
       name: ospf.area.lsa.count
       syntax: Gauge32
+      metric: gauge

--- a/objects/ietf/OSPFv3-MIB.yml
+++ b/objects/ietf/OSPFv3-MIB.yml
@@ -29,6 +29,7 @@ OSPFV3-MIB::ospfv3GeneralGroup:
       oid: .1.3.6.1.2.1.191.1.1.6
       name: ospf.lsdb.as_scope.lsas
       syntax: Gauge32
+      metric: gauge
     ospfv3AsScopeLsaCksumSum:
       oid: .1.3.6.1.2.1.191.1.1.7
       name: ospf.lsdb.as_scope.checksum
@@ -37,22 +38,27 @@ OSPFV3-MIB::ospfv3GeneralGroup:
       oid: .1.3.6.1.2.1.191.1.1.8
       name: ospf.lsas.new.out
       syntax: Counter32
+      metric: counter
     ospfv3RxNewLsas:
       oid: .1.3.6.1.2.1.191.1.1.9
       name: ospf.lsas.new.in
       syntax: Counter32
+      metric: counter
     ospfv3ExtLsaCount:
       oid: .1.3.6.1.2.1.191.1.1.10
       name: ospf.lsdb.as_extern.lsas
       syntax: Gauge32
+      metric: gauge
     ospfv3ExtAreaLsdbLimit:
       oid: .1.3.6.1.2.1.191.1.1.11
       name: ospf.lsdb.as_extern.limit
       syntax: Integer32
+      metric: gauge
     ospfv3ExitOverflowInterval:
       oid: .1.3.6.1.2.1.191.1.1.12
       name: ospf.lsdb.as_extern.overflow_interval
       syntax: Unsigned32
+      metric: gauge
     ospfv3DemandExtensions:
       oid: .1.3.6.1.2.1.191.1.1.13
       name: ospf.demand.support
@@ -61,6 +67,7 @@ OSPFV3-MIB::ospfv3GeneralGroup:
       oid: .1.3.6.1.2.1.191.1.1.14
       name: ospf.reference_bandwidth
       syntax: BandwidthKBits
+      metric: gauge
     ospfv3RestartSupport:
       oid: .1.3.6.1.2.1.191.1.1.15
       name: ospf.graceful_restart.support
@@ -69,6 +76,7 @@ OSPFV3-MIB::ospfv3GeneralGroup:
       oid: .1.3.6.1.2.1.191.1.1.16
       name: ospf.graceful_restart.interval
       syntax: Unsigned32 # Ospfv3UpToRefreshIntervalTC
+      metric: gauge
     ospfv3RestartStrictLsaChecking:
       oid: .1.3.6.1.2.1.191.1.1.17
       name: ospf.graceful_restart.strict_check
@@ -81,6 +89,7 @@ OSPFV3-MIB::ospfv3GeneralGroup:
       oid: .1.3.6.1.2.1.191.1.1.19
       name: ospf.graceful_restart.age
       syntax: Unsigned32 # Ospfv3UpToRefreshIntervalTC
+      metric: gauge
     ospfv3RestartExitReason:
       oid: .1.3.6.1.2.1.191.1.1.20
       name: ospf.graceful_restart.exit_reason
@@ -97,10 +106,12 @@ OSPFV3-MIB::ospfv3GeneralGroup:
       oid: .1.3.6.1.2.1.191.1.1.24
       name: ospf.discontinuity_time
       syntax: TimeStamp
+      metric: counter
     ospfv3RestartTime:
       oid: .1.3.6.1.2.1.191.1.1.25
       name: ospf.graceful_restart.sysuptime
       syntax: TimeStamp
+      metric: counter
 
 OSPFV3-MIB::ospfv3AreaEntry:
   mib: OSPFV3-MIB
@@ -120,18 +131,22 @@ OSPFV3-MIB::ospfv3AreaEntry:
       oid: .1.3.6.1.2.1.191.1.2.1.3
       name: ospf.area.spf.runs
       syntax: Counter32
+      metric: counter
     ospfv3AreaBdrRtrCount:
       oid: .1.3.6.1.2.1.191.1.2.1.4
       name: ospf.area.area_border_routers
       syntax: Gauge32
+      metric: gauge
     ospfv3AreaAsBdrRtrCount:
       oid: .1.3.6.1.2.1.191.1.2.1.5
       name: ospf.area.as_border_routers
       syntax: Gauge32
+      metric: gauge
     ospfv3AreaScopeLsaCount:
       oid: .1.3.6.1.2.1.191.1.2.1.6
       name: ospf.area.lsdb.area_scope.lsas
       syntax: Gauge32
+      metric: gauge
     ospfv3AreaScopeLsaCksumSum:
       oid: .1.3.6.1.2.1.191.1.2.1.7
       name: ospf.area.lsdb.area_scope.checksum
@@ -144,6 +159,7 @@ OSPFV3-MIB::ospfv3AreaEntry:
       oid: .1.3.6.1.2.1.191.1.2.1.10
       name: ospf.area.stub.metric.value
       syntax: Unsigned32 # BigMetric
+      metric: gauge
     ospfv3AreaNssaTranslatorRole:
       oid: .1.3.6.1.2.1.191.1.2.1.11
       name: ospf.area.nssa_translator.role
@@ -156,10 +172,12 @@ OSPFV3-MIB::ospfv3AreaEntry:
       oid: .1.3.6.1.2.1.191.1.2.1.13
       name: ospf.area.nssa_translator.stability_interval
       syntax: Unsigned32
+      metric: gauge
     ospfv3AreaNssaTranslatorEvents:
       oid: .1.3.6.1.2.1.191.1.2.1.14
       name: ospf.area.nssa_translator.events
       syntax: Counter32
+      metric: counter
     ospfv3AreaStubMetricType:
       oid: .1.3.6.1.2.1.191.1.2.1.15
       name: ospf.area.stub.metric.type
@@ -168,135 +186,6 @@ OSPFV3-MIB::ospfv3AreaEntry:
       oid: .1.3.6.1.2.1.191.1.2.1.16
       name: ospf.area.te.enable
       syntax: TruthValue
-
-# OSPFV3-MIB::ospfv3AsLsdbEntry:
-#   mib: OSPFV3-MIB
-#   object: ospfv3AsLsdbEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.3.1.1
-#       name: ospf.lsdb.as_scope.lsa.type.id # ospfv3AsLsdbType
-#       syntax: UnsignedAsID
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.3.1.2
-#       name: ospf.lsdb.as_scope.lsa.router.id # ospfv3AsLsdbRouterId
-#       syntax: UnsignedAsID # Ospfv3RouterIdTC
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.3.1.3
-#       name: ospf.lsdb.as_scope.lsa.lsid # ospfv3AsLsdbLsid
-#       syntax: UnsignedAsID # Ospfv3LsIdTC
-#   discovery_attribute: ospfv3AsLsdbSequence
-#   attributes:
-#     ospfv3AsLsdbSequence:
-#       oid: .1.3.6.1.2.1.191.1.3.1.4
-#       name: ospf.lsdb.as_scope.lsa.seq
-#       syntax: Integer32 # Ospfv3LsaSequenceTC
-#     ospfv3AsLsdbAge:
-#       oid: .1.3.6.1.2.1.191.1.3.1.5
-#       name: ospf.lsdb.as_scope.lsa.age
-#       syntax: Unsigned32 # Ospfv3LsaAgeTC
-#     ospfv3AsLsdbChecksum:
-#       oid: .1.3.6.1.2.1.191.1.3.1.6
-#       name: ospf.lsdb.as_scope.lsa.checksum
-#       syntax: Unsigned32
-#     ospfv3AsLsdbAdvertisement:
-#       oid: .1.3.6.1.2.1.191.1.3.1.7
-#       name: ospf.lsdb.as_scope.lsa.advert
-#       syntax: OctetString
-#     ospfv3AsLsdbTypeKnown:
-#       oid: .1.3.6.1.2.1.191.1.3.1.8
-#       name: ospf.lsdb.as_scope.lsa.recognized
-#       syntax: TruthValue
-
-# OSPFV3-MIB::ospfv3AreaLsdbEntry:
-#   mib: OSPFV3-MIB
-#   object: ospfv3AreaLsdbEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.4.1.1
-#       name: ospf.lsdb.area_scope.lsa.area.id # ospfv3AreaLsdbAreaId
-#       syntax: UnsignedAsID # Ospfv3AreaIdTC
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.4.1.2
-#       name: ospf.lsdb.area_scope.lsa.type.id # ospfv3AreaLsdbType
-#       syntax: UnsignedAsID
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.4.1.3
-#       name: ospf.lsdb.area_scope.lsa.router.id # ospfv3AreaLsdbRouterId
-#       syntax: UnsignedAsID # Ospfv3RouterIdTC
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.4.1.4
-#       name: ospf.lsdb.area_scope.lsa.lsid # ospfv3AreaLsdbLsid
-#       syntax: UnsignedAsID # Ospfv3LsIdTC
-#   discovery_attribute: ospfv3AreaLsdbSequence
-#   attributes:
-#     ospfv3AreaLsdbSequence:
-#       oid: .1.3.6.1.2.1.191.1.4.1.5
-#       name: ospf.lsdb.area_scope.lsa.seq
-#       syntax: Integer32 # Ospfv3LsaSequenceTC
-#     ospfv3AreaLsdbAge:
-#       oid: .1.3.6.1.2.1.191.1.4.1.6
-#       name: ospf.lsdb.area_scope.lsa.age
-#       syntax: Unsigned32 # Ospfv3LsaAgeTC
-#     ospfv3AreaLsdbChecksum:
-#       oid: .1.3.6.1.2.1.191.1.4.1.7
-#       name: ospf.lsdb.area_scope.lsa.checksum
-#       syntax: Unsigned32
-#     ospfv3AreaLsdbAdvertisement:
-#       oid: .1.3.6.1.2.1.191.1.4.1.8
-#       name: ospf.lsdb.area_scope.lsa.advert
-#       syntax: OctetString
-#     ospfv3AreaLsdbTypeKnown:
-#       oid: .1.3.6.1.2.1.191.1.4.1.9
-#       name: ospf.lsdb.area_scope.lsa.recognized
-#       syntax: TruthValue
-
-# OSPFV3-MIB::ospfv3LinkLsdbEntry:
-#   mib: OSPFV3-MIB
-#   object: ospfv3LinkLsdbEntry
-#   index:
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.191.1.5.1.1
-#       name: ospf.lsdb.link_scope.lsa.netif # ospfv3LinkLsdbIfIndex
-#       syntax: InterfaceIndex
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.5.1.2
-#       name: ospf.lsdb.link_scope.lsa.netif.inst.id # ospfv3LinkLsdbIfInstId
-#       syntax: UnsignedAsID # Ospfv3IfInstIdTC
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.5.1.3
-#       name: ospf.lsdb.link_scope.lsa.type.id # ospfv3LinkLsdbType
-#       syntax: UnsignedAsID
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.5.1.4
-#       name: ospf.lsdb.link_scope.lsa.router.id # ospfv3LinkLsdbRouterId
-#       syntax: UnsignedAsID # Ospfv3RouterIdTC
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.5.1.5
-#       name: ospf.lsdb.link_scope.lsa.lsid # ospfv3LinkLsdbLsid
-#       syntax: UnsignedAsID # Ospfv3LsIdTC
-#   discovery_attribute: ospfv3LinkLsdbSequence
-#   attributes:
-#     ospfv3LinkLsdbSequence:
-#       oid: .1.3.6.1.2.1.191.1.5.1.6
-#       name: ospf.lsdb.link_scope.lsa.seq
-#       syntax: Integer32 # Ospfv3LsaSequenceTC
-#     ospfv3LinkLsdbAge:
-#       oid: .1.3.6.1.2.1.191.1.5.1.7
-#       name: ospf.lsdb.link_scope.lsa.age
-#       syntax: Unsigned32 # Ospfv3LsaAgeTC
-#     ospfv3LinkLsdbChecksum:
-#       oid: .1.3.6.1.2.1.191.1.5.1.8
-#       name: ospf.lsdb.link_scope.lsa.checksum
-#       syntax: Unsigned32
-#     ospfv3LinkLsdbAdvertisement:
-#       oid: .1.3.6.1.2.1.191.1.5.1.9
-#       name: ospf.lsdb.link_scope.lsa.advert
-#       syntax: OctetString
-#     ospfv3LinkLsdbTypeKnown:
-#       oid: .1.3.6.1.2.1.191.1.5.1.10
-#       name: ospf.lsdb.link_scope.lsa.recognized
-#       syntax: TruthValue
 
 OSPFV3-MIB::ospfv3IfEntry:
   mib: OSPFV3-MIB
@@ -329,26 +218,32 @@ OSPFV3-MIB::ospfv3IfEntry:
       oid: .1.3.6.1.2.1.191.1.7.1.6
       name: ospf.netif.designated_router.priority
       syntax: Integer32 # DesignatedRouterPriority
+      metric: gauge
     ospfv3IfTransitDelay:
       oid: .1.3.6.1.2.1.191.1.7.1.7
       name: ospf.netif.lsa.transit_delay
       syntax: Unsigned32 # Ospfv3UpToRefreshIntervalTC
+      metric: gauge
     ospfv3IfRetransInterval:
       oid: .1.3.6.1.2.1.191.1.7.1.8
       name: ospf.netif.lsa.retrans_interval
       syntax: Unsigned32 # Ospfv3UpToRefreshIntervalTC
+      metric: gauge
     ospfv3IfHelloInterval:
       oid: .1.3.6.1.2.1.191.1.7.1.9
       name: ospf.netif.hello_interval
       syntax: Unsigned32 # HelloRange
+      metric: gauge
     ospfv3IfRtrDeadInterval:
       oid: .1.3.6.1.2.1.191.1.7.1.10
       name: ospf.netif.router_dead_interval
       syntax: Unsigned32 # Ospfv3DeadIntervalRangeTC
+      metric: gauge
     ospfv3IfPollInterval:
       oid: .1.3.6.1.2.1.191.1.7.1.11
       name: ospf.netif.poll_interval
       syntax: Unsigned32
+      metric: gauge
     ospfv3IfState:
       oid: .1.3.6.1.2.1.191.1.7.1.12
       name: ospf.netif.state
@@ -365,18 +260,21 @@ OSPFV3-MIB::ospfv3IfEntry:
       oid: .1.3.6.1.2.1.191.1.7.1.15
       name: ospf.netif.state.chgs
       syntax: Counter32
+      metric: counter
     ospfv3IfDemand:
       oid: .1.3.6.1.2.1.191.1.7.1.17
-      name: ospf.netif.demand.state
+      name: ospf.netif.demand
       syntax: TruthValue
     ospfv3IfMetricValue:
       oid: .1.3.6.1.2.1.191.1.7.1.18
       name: ospf.netif.metric
       syntax: Unsigned32 # Metric
+      metric: gauge
     ospfv3IfLinkScopeLsaCount:
       oid: .1.3.6.1.2.1.191.1.7.1.19
       name: ospf.netif.lsdb.link_scope.lsas
       syntax: Gauge32
+      metric: gauge
     ospfv3IfLinkLsaCksumSum:
       oid: .1.3.6.1.2.1.191.1.7.1.20
       name: ospf.netif.lsdb.link_scope.checksum
@@ -389,10 +287,12 @@ OSPFV3-MIB::ospfv3IfEntry:
       oid: .1.3.6.1.2.1.191.1.7.1.22
       name: ospf.netif.neighbor.probe.retrans_limit
       syntax: Unsigned32
+      metric: gauge
     ospfv3IfDemandNbrProbeInterval:
       oid: .1.3.6.1.2.1.191.1.7.1.23
       name: ospf.netif.neighbor.probe_interval
       syntax: Unsigned32
+      metric: gauge
     ospfv3IfTEDisabled:
       oid: .1.3.6.1.2.1.191.1.7.1.24
       name: ospf.netif.te.disable
@@ -430,18 +330,22 @@ OSPFV3-MIB::ospfv3VirtIfEntry:
       oid: .1.3.6.1.2.1.191.1.8.1.5
       name: ospf.virt_netif.lsa.transit_delay
       syntax: TicksSec # Ospfv3UpToRefreshIntervalTC
+      metric: gauge
     ospfv3VirtIfRetransInterval:
       oid: .1.3.6.1.2.1.191.1.8.1.6
       name: ospf.virt_netif.lsa.retrans_interval
       syntax: TicksSec # Ospfv3UpToRefreshIntervalTC
+      metric: gauge
     ospfv3VirtIfHelloInterval:
       oid: .1.3.6.1.2.1.191.1.8.1.7
       name: ospf.virt_netif.hello_interval
       syntax: TicksSec # HelloRange
+      metric: gauge
     ospfv3VirtIfRtrDeadInterval:
       oid: .1.3.6.1.2.1.191.1.8.1.8
       name: ospf.virt_netif.router_dead_interval
       syntax: TicksSec # Ospfv3DeadIntervalRangeTC
+      metric: gauge
     ospfv3VirtIfState:
       oid: .1.3.6.1.2.1.191.1.8.1.9
       name: ospf.virt_netif.state
@@ -450,10 +354,12 @@ OSPFV3-MIB::ospfv3VirtIfEntry:
       oid: .1.3.6.1.2.1.191.1.8.1.10
       name: ospf.virt_netif.state.chgs
       syntax: Counter32
+      metric: counter
     ospfv3VirtIfLinkScopeLsaCount:
       oid: .1.3.6.1.2.1.191.1.8.1.12
       name: ospf.virt_netif.lsdb.link_scope.lsas
       syntax: Gauge32
+      metric: gauge
     ospfv3VirtIfLinkLsaCksumSum:
       oid: .1.3.6.1.2.1.191.1.8.1.13
       name: ospf.virt_netif.lsdb.link_scope.checksum
@@ -490,6 +396,7 @@ OSPFV3-MIB::ospfv3NbrEntry:
       oid: .1.3.6.1.2.1.191.1.9.1.7
       name: ospf.neighbor.designated_router.priority
       syntax: Integer32 # DesignatedRouterPriority
+      metric: gauge
     ospfv3NbrState:
       oid: .1.3.6.1.2.1.191.1.9.1.8
       name: ospf.neighbor.state
@@ -498,10 +405,12 @@ OSPFV3-MIB::ospfv3NbrEntry:
       oid: .1.3.6.1.2.1.191.1.9.1.9
       name: ospf.neighbor.state.changes
       syntax: Counter32
+      metric: counter
     ospfv3NbrLsRetransQLen:
       oid: .1.3.6.1.2.1.191.1.9.1.10
       name: ospf.neighbor.link_state_retrans_queue
       syntax: Gauge32
+      metric: gauge
     ospfv3NbrHelloSuppressed:
       oid: .1.3.6.1.2.1.191.1.9.1.11
       name: ospf.neighbor.hello_suppress
@@ -518,6 +427,7 @@ OSPFV3-MIB::ospfv3NbrEntry:
       oid: .1.3.6.1.2.1.191.1.9.1.14
       name: ospf.neighbor.graceful_restart.helper.age
       syntax: Unsigned32 # Ospfv3UpToRefreshIntervalTC
+      metric: gauge
     ospfv3NbrRestartHelperExitReason:
       oid: .1.3.6.1.2.1.191.1.9.1.15
       name: ospf.neighbor.graceful_restart.helper.exit_reason
@@ -564,10 +474,12 @@ OSPFV3-MIB::ospfv3VirtNbrEntry:
       oid: .1.3.6.1.2.1.191.1.11.1.9
       name: ospf.virt_neighbor.state.changes
       syntax: Counter32
+      metric: counter
     ospfv3VirtNbrLsRetransQLen:
       oid: .1.3.6.1.2.1.191.1.11.1.10
       name: ospf.virt_neighbor.link_state_retrans_queue
       syntax: Gauge32
+      metric: gauge
     ospfv3VirtNbrHelloSuppressed:
       oid: .1.3.6.1.2.1.191.1.11.1.11
       name: ospf.virt_neighbor.hello_suppress
@@ -584,54 +496,8 @@ OSPFV3-MIB::ospfv3VirtNbrEntry:
       oid: .1.3.6.1.2.1.191.1.11.1.14
       name: ospf.virt_neighbor.graceful_restart.helper.age
       syntax: TicksSec # Ospfv3UpToRefreshIntervalTC
+      metric: gauge
     ospfv3VirtNbrRestartHelperExitReason:
       oid: .1.3.6.1.2.1.191.1.11.1.15
       name: ospf.virt_neighbor.graceful_restart.helper.exit_reason
       syntax: EnumInteger
-
-# OSPFV3-MIB::ospfv3VirtLinkLsdbEntry:
-#   mib: OSPFV3-MIB
-#   object: ospfv3VirtLinkLsdbEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.13.1.1
-#       name: ospf.lsdb.virt_link_scope.lsa.transit_area.id # ospfv3VirtLinkLsdbIfAreaId
-#       syntax: UnsignedAsID # Ospfv3AreaIdTC
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.13.1.2
-#       name: ospf.lsdb.virt_link_scope.lsa.neigbor.router.id # ospfv3VirtLinkLsdbIfNeighbor
-#       syntax: UnsignedAsID # Ospfv3RouterIdTC
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.13.1.3
-#       name: ospf.lsdb.virt_link_scope.lsa.type.id # ospfv3VirtLinkLsdbType
-#       syntax: UnsignedAsID
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.13.1.4
-#       name: ospf.lsdb.virt_link_scope.lsa.router.id # ospfv3VirtLinkLsdbRouterId
-#       syntax: UnsignedAsID # Ospfv3RouterIdTC
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.191.1.13.1.5
-#       name: ospf.lsdb.virt_link_scope.lsa.lsid # ospfv3VirtLinkLsdbLsid
-#       syntax: UnsignedAsID # Ospfv3LsIdTC
-#   discovery_attribute: ospfv3VirtLinkLsdbSequence
-#   attributes:
-#     ospfv3VirtLinkLsdbSequence:
-#       oid: .1.3.6.1.2.1.191.1.13.1.6
-#       name: ospf.lsdb.virt_link_scope.lsa.seq
-#       syntax: Integer32 # Ospfv3LsaSequenceTC
-#     ospfv3VirtLinkLsdbAge:
-#       oid: .1.3.6.1.2.1.191.1.13.1.7
-#       name: ospf.lsdb.virt_link_scope.lsa.age
-#       syntax: Unsigned32 # Ospfv3LsaAgeTC
-#     ospfv3VirtLinkLsdbChecksum:
-#       oid: .1.3.6.1.2.1.191.1.13.1.8
-#       name: ospf.lsdb.virt_link_scope.lsa.checksum
-#       syntax: Unsigned32
-#     ospfv3VirtLinkLsdbAdvertisement:
-#       oid: .1.3.6.1.2.1.191.1.13.1.9
-#       name: ospf.lsdb.virt_link_scope.lsa.advert
-#       syntax: OctetString
-#     ospfv3VirtLinkLsdbTypeKnown:
-#       oid: .1.3.6.1.2.1.191.1.13.1.10
-#       name: ospf.lsdb.virt_link_scope.lsa.recognized
-#       syntax: TruthValue

--- a/objects/ietf/P-BRIDGE-MIB.yml
+++ b/objects/ietf/P-BRIDGE-MIB.yml
@@ -28,97 +28,6 @@ P-BRIDGE-MIB::dot1dPortCapabilitiesEntry:
       name: bridge.port.capability
       syntax: EnumBitmap
 
-# P-BRIDGE-MIB::dot1dPortPriorityEntry:
-#   mib: P-BRIDGE-MIB
-#   object: dot1dPortPriorityEntry
-#   augments: BRIDGE-MIB::dot1dBasePortEntry
-#   discovery_attribute: dot1dPortDefaultUserPriority
-#   attributes:
-#     dot1dPortDefaultUserPriority:
-#       oid: .1.3.6.1.2.1.17.6.1.2.1.1.1
-#       name: dot1dPortDefaultUserPriority
-#       syntax: Integer32
-#     dot1dPortNumTrafficClasses:
-#       oid: .1.3.6.1.2.1.17.6.1.2.1.1.2
-#       name: dot1dPortNumTrafficClasses
-#       syntax: Integer32
-
-# P-BRIDGE-MIB::dot1dUserPriorityRegenEntry:
-#   mib: P-BRIDGE-MIB
-#   object: dot1dUserPriorityRegenEntry
-#   index:
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.1.4.1.1
-#       name: dot1dBasePort
-#       syntax: IntegerAsID
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.6.1.2.2.1.1
-#       name: dot1dUserPriority
-#       syntax: Integer32
-#   discovery_attribute: dot1dRegenUserPriority
-#   attributes:
-#     dot1dRegenUserPriority:
-#       oid: .1.3.6.1.2.1.17.6.1.2.2.1.2
-#       name: dot1dRegenUserPriority
-#       syntax: Integer32
-
-# P-BRIDGE-MIB::dot1dTrafficClassEntry:
-#   mib: P-BRIDGE-MIB
-#   object: dot1dTrafficClassEntry
-#   index:
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.1.4.1.1
-#       name: dot1dBasePort
-#       syntax: IntegerAsID
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.6.1.2.3.1.1
-#       name: dot1dTrafficClassPriority
-#       syntax: Integer32
-#   discovery_attribute: dot1dTrafficClass
-#   attributes:
-#     dot1dTrafficClass:
-#       oid: .1.3.6.1.2.1.17.6.1.2.3.1.2
-#       name: dot1dTrafficClass
-#       syntax: Integer32
-
-# P-BRIDGE-MIB::dot1dPortOutboundAccessPriorityEntry:
-#   mib: P-BRIDGE-MIB
-#   object: dot1dPortOutboundAccessPriorityEntry
-#   index:
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.1.4.1.1
-#       name: dot1dBasePort
-#       syntax: IntegerAsID
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.6.1.2.2.1.2
-#       name: dot1dRegenUserPriority
-#       syntax: Integer32
-#   discovery_attribute: dot1dPortOutboundAccessPriority
-#   attributes:
-#     dot1dPortOutboundAccessPriority:
-#       oid: .1.3.6.1.2.1.17.6.1.2.4.1.1
-#       name: dot1dPortOutboundAccessPriority
-#       syntax: Integer32
-
-# P-BRIDGE-MIB::dot1dPortGarpEntry:
-#   mib: P-BRIDGE-MIB
-#   object: dot1dPortGarpEntry
-#   augments: BRIDGE-MIB::dot1dBasePortEntry
-#   discovery_attribute: dot1dPortGarpJoinTime
-#   attributes:
-#     dot1dPortGarpJoinTime:
-#       oid: .1.3.6.1.2.1.17.6.1.3.1.1.1
-#       name: dot1dPortGarpJoinTime
-#       syntax: Integer32
-#     dot1dPortGarpLeaveTime:
-#       oid: .1.3.6.1.2.1.17.6.1.3.1.1.2
-#       name: dot1dPortGarpLeaveTime
-#       syntax: Integer32
-#     dot1dPortGarpLeaveAllTime:
-#       oid: .1.3.6.1.2.1.17.6.1.3.1.1.3
-#       name: dot1dPortGarpLeaveAllTime
-#       syntax: Integer32
-
 P-BRIDGE-MIB::dot1dPortGmrpEntry:
   mib: P-BRIDGE-MIB
   object: dot1dPortGmrpEntry
@@ -133,6 +42,7 @@ P-BRIDGE-MIB::dot1dPortGmrpEntry:
       oid: .1.3.6.1.2.1.17.6.1.4.1.1.2
       name: bridge.port.gmrp.registrations.failed
       syntax: Counter32
+      metric: counter
     dot1dPortGmrpLastPduOrigin:
       oid: .1.3.6.1.2.1.17.6.1.4.1.1.3
       name: bridge.port.gmrp.last_origin
@@ -152,6 +62,7 @@ P-BRIDGE-MIB::dot1dTpHCPortEntry:
       oid: .1.3.6.1.2.1.17.4.5.1.1
       name: bridge.port.transparent.frames.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: BRIDGE-MIB::dot1dTpPortEntry
         attribute: dot1dTpPortInFrames
@@ -159,6 +70,7 @@ P-BRIDGE-MIB::dot1dTpHCPortEntry:
       oid: .1.3.6.1.2.1.17.4.5.1.2
       name: bridge.port.transparent.frames.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: BRIDGE-MIB::dot1dTpPortEntry
         attribute: dot1dTpPortOutFrames
@@ -166,25 +78,7 @@ P-BRIDGE-MIB::dot1dTpHCPortEntry:
       oid: .1.3.6.1.2.1.17.4.5.1.3
       name: bridge.port.transparent.frames.discard.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: BRIDGE-MIB::dot1dTpPortEntry
         attribute: dot1dTpPortInDiscards
-
-# P-BRIDGE-MIB::dot1dTpPortOverflowEntry:
-#   mib: P-BRIDGE-MIB
-#   object: dot1dTpPortOverflowEntry
-#   augments: BRIDGE-MIB::dot1dBasePortEntry
-#   discovery_attribute: dot1dTpPortInOverflowFrames
-#   attributes:
-#     dot1dTpPortInOverflowFrames:
-#       oid: .1.3.6.1.2.1.17.4.6.1.1
-#       name: dot1dTpPortInOverflowFrames
-#       syntax: Counter32
-#     dot1dTpPortOutOverflowFrames:
-#       oid: .1.3.6.1.2.1.17.4.6.1.2
-#       name: dot1dTpPortOutOverflowFrames
-#       syntax: Counter32
-#     dot1dTpPortInOverflowDiscards:
-#       oid: .1.3.6.1.2.1.17.4.6.1.3
-#       name: dot1dTpPortInOverflowDiscards
-#       syntax: Counter32

--- a/objects/ietf/POWER-ETHERNET-MIB.yml
+++ b/objects/ietf/POWER-ETHERNET-MIB.yml
@@ -36,6 +36,7 @@ POWER-ETHERNET-MIB::pethPsePortEntry:
       oid: .1.3.6.1.2.1.105.1.1.1.8
       name: pethPsePortMPSAbsentCounter
       syntax: Counter32
+      metric: counter
     pethPsePortType:
       oid: .1.3.6.1.2.1.105.1.1.1.9
       name: pethPsePortType
@@ -48,18 +49,22 @@ POWER-ETHERNET-MIB::pethPsePortEntry:
       oid: .1.3.6.1.2.1.105.1.1.1.11
       name: pethPsePortInvalidSignatureCounter
       syntax: Counter32
+      metric: counter
     pethPsePortPowerDeniedCounter:
       oid: .1.3.6.1.2.1.105.1.1.1.12
       name: pethPsePortPowerDeniedCounter
       syntax: Counter32
+      metric: counter
     pethPsePortOverLoadCounter:
       oid: .1.3.6.1.2.1.105.1.1.1.13
       name: pethPsePortOverLoadCounter
       syntax: Counter32
+      metric: counter
     pethPsePortShortCounter:
       oid: .1.3.6.1.2.1.105.1.1.1.14
       name: pethPsePortShortCounter
       syntax: Counter32
+      metric: counter
 
 POWER-ETHERNET-MIB::pethMainPseEntry:
   mib: POWER-ETHERNET-MIB
@@ -75,6 +80,7 @@ POWER-ETHERNET-MIB::pethMainPseEntry:
       oid: .1.3.6.1.2.1.105.1.3.1.1.2
       name: pethMainPsePower
       syntax: PowerWatt
+      metric: gauge
     pethMainPseOperStatus:
       oid: .1.3.6.1.2.1.105.1.3.1.1.3
       name: pethMainPseOperStatus
@@ -83,7 +89,9 @@ POWER-ETHERNET-MIB::pethMainPseEntry:
       oid: .1.3.6.1.2.1.105.1.3.1.1.4
       name: pethMainPseConsumptionPower
       syntax: PowerWatt
+      metric: gauge
     pethMainPseUsageThreshold:
       oid: .1.3.6.1.2.1.105.1.3.1.1.5
       name: pethMainPseUsageThreshold
       syntax: Percent100
+      metric: gauge

--- a/objects/ietf/PW-STD-MIB.yml
+++ b/objects/ietf/PW-STD-MIB.yml
@@ -7,6 +7,7 @@ PW-STD-MIB::pwObjects:
       oid: .1.3.6.1.2.1.10.246.1.6
       name: pwire.packets.error.total
       syntax: Counter32
+      metric: counter
 
 PW-STD-MIB::pwEntry:
   mib: PW-STD-MIB
@@ -78,6 +79,7 @@ PW-STD-MIB::pwEntry:
       oid: .1.3.6.1.2.1.10.246.1.2.1.18
       name: pwire.local.mtu
       syntax: BytesB
+      metric: gauge
     pwLocalIfString:
       oid: .1.3.6.1.2.1.10.246.1.2.1.19
       name: pwire.local.send_netif_alias
@@ -98,6 +100,7 @@ PW-STD-MIB::pwEntry:
       oid: .1.3.6.1.2.1.10.246.1.2.1.23
       name: pwire.remote.mtu
       syntax: BytesB
+      metric: gauge
     pwRemoteIfString:
       oid: .1.3.6.1.2.1.10.246.1.2.1.24
       name: pwire.remote.netif.alias
@@ -110,6 +113,7 @@ PW-STD-MIB::pwEntry:
       oid: .1.3.6.1.2.1.10.246.1.2.1.26
       name: pwire.frag.size
       syntax: BytesB
+      metric: gauge
     pwRmtFragCapability:
       oid: .1.3.6.1.2.1.10.246.1.2.1.27
       name: pwire.remote.frag.capability
@@ -142,14 +146,17 @@ PW-STD-MIB::pwEntry:
       oid: .1.3.6.1.2.1.10.246.1.2.1.34
       name: pwire.create_time
       syntax: TimeStamp
+      metric: counter
     pwUpTime:
       oid: .1.3.6.1.2.1.10.246.1.2.1.35
       name: pwire.uptime
       syntax: TimeTicks
+      metric: counter
     pwLastChange:
       oid: .1.3.6.1.2.1.10.246.1.2.1.36
       name: pwire.last_chg
       syntax: TimeTicks
+      metric: counter
     pwAdminStatus:
       oid: .1.3.6.1.2.1.10.246.1.2.1.37
       name: pwire.state.admin
@@ -174,6 +181,7 @@ PW-STD-MIB::pwEntry:
       oid: .1.3.6.1.2.1.10.246.1.2.1.42
       name: pwire.interval.elapsed
       syntax: TicksSec
+      metric: counter
     pwOamEnable:
       oid: .1.3.6.1.2.1.10.246.1.2.1.46
       name: pwire.oam.enable
@@ -201,6 +209,7 @@ PW-STD-MIB::pwPerfCurrentEntry:
       oid: .1.3.6.1.2.1.10.246.1.3.1.1
       name: pwire.packets.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: PW-STD-MIB::pwPerfCurrentEntry
         attribute: pwPerfCurrentInPackets
@@ -208,6 +217,7 @@ PW-STD-MIB::pwPerfCurrentEntry:
       oid: .1.3.6.1.2.1.10.246.1.3.1.2
       name: pwire.bytes.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: PW-STD-MIB::pwPerfCurrentEntry
         attribute: pwPerfCurrentInBytes
@@ -215,6 +225,7 @@ PW-STD-MIB::pwPerfCurrentEntry:
       oid: .1.3.6.1.2.1.10.246.1.3.1.3
       name: pwire.packets.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: PW-STD-MIB::pwPerfCurrentEntry
         attribute: pwPerfCurrentOutPackets
@@ -222,6 +233,7 @@ PW-STD-MIB::pwPerfCurrentEntry:
       oid: .1.3.6.1.2.1.10.246.1.3.1.4
       name: pwire.bytes.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: PW-STD-MIB::pwPerfCurrentEntry
         attribute: pwPerfCurrentOutBytes
@@ -229,15 +241,19 @@ PW-STD-MIB::pwPerfCurrentEntry:
       oid: .1.3.6.1.2.1.10.246.1.3.1.5
       name: pwire.packets.in
       syntax: Gauge32
+      metric: counter
     pwPerfCurrentInBytes:
       oid: .1.3.6.1.2.1.10.246.1.3.1.6
       name: pwire.bytes.in
       syntax: Gauge32
+      metric: counter
     pwPerfCurrentOutPackets:
       oid: .1.3.6.1.2.1.10.246.1.3.1.7
       name: pwire.packets.out
       syntax: Gauge32
+      metric: counter
     pwPerfCurrentOutBytes:
       oid: .1.3.6.1.2.1.10.246.1.3.1.8
       name: pwire.bytes.out
       syntax: Gauge32
+      metric: counter

--- a/objects/ietf/Printer-MIB.yml
+++ b/objects/ietf/Printer-MIB.yml
@@ -13,6 +13,7 @@ Printer-MIB::prtGeneralEntry:
       oid: .1.3.6.1.2.1.43.5.1.1.1
       name: printer.config.chgs
       syntax: Counter32
+      metric: counter
     prtGeneralCurrentOperator:
       oid: .1.3.6.1.2.1.43.5.1.1.4
       name: printer.operator
@@ -53,10 +54,12 @@ Printer-MIB::prtGeneralEntry:
       oid: .1.3.6.1.2.1.43.5.1.1.18
       name: printer.alerts.critical
       syntax: Counter32
+      metric: counter
     prtAlertAllEvents:
       oid: .1.3.6.1.2.1.43.5.1.1.19
       name: printer.alerts.all
       syntax: Counter32
+      metric: counter
 
 Printer-MIB::prtCoverEntry:
   mib: Printer-MIB
@@ -127,10 +130,12 @@ Printer-MIB::prtInputEntry:
       oid: .1.3.6.1.2.1.43.8.2.1.9
       name: printer.input.capacity.max
       syntax: Integer32
+      metric: gauge
     prtInputCurrentLevel:
       oid: .1.3.6.1.2.1.43.8.2.1.10
       name: printer.input.capacity.level
       syntax: Integer32
+      metric: gauge
     prtInputStatus:
       oid: .1.3.6.1.2.1.43.8.2.1.11
       name: printer.input.state.id
@@ -214,10 +219,12 @@ Printer-MIB::prtOutputEntry:
       oid: .1.3.6.1.2.1.43.9.2.1.4
       name: printer.output.capacity.max
       syntax: Integer32
+      metric: gauge
     prtOutputRemainingCapacity:
       oid: .1.3.6.1.2.1.43.9.2.1.5
       name: printer.output.capacity.remain
       syntax: Integer32
+      metric: gauge
     prtOutputStatus:
       oid: .1.3.6.1.2.1.43.9.2.1.6
       name: printer.output.state.id
@@ -321,10 +328,12 @@ Printer-MIB::prtMarkerEntry:
       oid: .1.3.6.1.2.1.43.10.2.1.4
       name: printer.marker.life
       syntax: Counter32
+      metric: counter
     prtMarkerPowerOnCount:
       oid: .1.3.6.1.2.1.43.10.2.1.5
       name: printer.marker.power-ons
       syntax: Counter32
+      metric: counter
     prtMarkerProcessColorants:
       oid: .1.3.6.1.2.1.43.10.2.1.6
       name: printer.marker.colors.process
@@ -400,10 +409,12 @@ Printer-MIB::prtMarkerSuppliesEntry:
       oid: .1.3.6.1.2.1.43.11.1.1.8
       name: printer.supply.capacity
       syntax: Integer32
+      metric: gauge
     prtMarkerSuppliesLevel:
       oid: .1.3.6.1.2.1.43.11.1.1.9
       name: printer.supply.level
       syntax: Integer32
+      metric: gauge
 
 Printer-MIB::prtMarkerColorantEntry:
   mib: Printer-MIB
@@ -544,10 +555,12 @@ Printer-MIB::prtConsoleLightEntry:
       oid: .1.3.6.1.2.1.43.17.6.1.2
       name: printer.console.on_time
       syntax: OpTicksMilliSec
+      metric: gauge
     prtConsoleOffTime:
       oid: .1.3.6.1.2.1.43.17.6.1.3
       name: printer.console.off_time
       syntax: OpTicksMilliSec
+      metric: gauge
     prtConsoleColor:
       oid: .1.3.6.1.2.1.43.17.6.1.4
       name: printer.console.color

--- a/objects/ietf/Q-BRIDGE-MIB.yml
+++ b/objects/ietf/Q-BRIDGE-MIB.yml
@@ -16,266 +16,16 @@ Q-BRIDGE-MIB::dot1qBase:
       oid: .1.3.6.1.2.1.17.7.1.1.3
       name: bridge.vlans_supported
       syntax: Unsigned32
+      metric: gauge
     dot1qNumVlans:
       oid: .1.3.6.1.2.1.17.7.1.1.4
       name: bridge.vlans
       syntax: Unsigned32
+      metric: gauge
     dot1qGvrpStatus:
       oid: .1.3.6.1.2.1.17.7.1.1.5
       name: bridge.gvrp.status
       syntax: EnumInteger
-
-# Q-BRIDGE-MIB::dot1qFdbEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qFdbEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.2.1.1.1
-#       name: bridge.fdb.id # dot1qFdbId
-#       syntax: UnsignedAsID
-#   discovery_attribute: dot1qFdbDynamicCount
-#   attributes:
-#     dot1qFdbDynamicCount:
-#       oid: .1.3.6.1.2.1.17.7.1.2.1.1.2
-#       name: dot1qFdbDynamicCount
-#       syntax: Counter32
-
-# Q-BRIDGE-MIB::dot1qTpFdbEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qTpFdbEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.2.1.1.1
-#       name: dot1qFdbId
-#       syntax: UnsignedAsID
-#     - type: MacAddress
-#       oid: .1.3.6.1.2.1.17.7.1.2.2.1.1
-#       name: dot1qTpFdbAddress
-#       syntax: MacAddress
-#   discovery_attribute: dot1qTpFdbPort
-#   attributes:
-#     dot1qTpFdbPort:
-#       oid: .1.3.6.1.2.1.17.7.1.2.2.1.2
-#       name: dot1qTpFdbPort
-#       syntax: IntegerAsID
-#     dot1qTpFdbStatus:
-#       oid: .1.3.6.1.2.1.17.7.1.2.2.1.3
-#       name: dot1qTpFdbStatus
-#       syntax: EnumInteger
-
-# Q-BRIDGE-MIB::dot1qTpGroupEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qTpGroupEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.2
-#       name: dot1qVlanIndex
-#       syntax: UnsignedAsID
-#     - type: MacAddress
-#       oid: .1.3.6.1.2.1.17.7.1.2.3.1.1
-#       name: dot1qTpGroupAddress
-#       syntax: MacAddress
-#   discovery_attribute: dot1qTpGroupEgressPorts
-#   attributes:
-#     dot1qTpGroupEgressPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.2.3.1.2
-#       name: dot1qTpGroupEgressPorts
-#       syntax: OctetString
-#     dot1qTpGroupLearnt:
-#       oid: .1.3.6.1.2.1.17.7.1.2.3.1.3
-#       name: dot1qTpGroupLearnt
-#       syntax: OctetString
-
-# Q-BRIDGE-MIB::dot1qForwardAllEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qForwardAllEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.2
-#       name: dot1qVlanIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: dot1qForwardAllPorts
-#   attributes:
-#     dot1qForwardAllPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.2.4.1.1
-#       name: dot1qForwardAllPorts
-#       syntax: OctetString
-#     dot1qForwardAllStaticPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.2.4.1.2
-#       name: dot1qForwardAllStaticPorts
-#       syntax: OctetString
-#     dot1qForwardAllForbiddenPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.2.4.1.3
-#       name: dot1qForwardAllForbiddenPorts
-#       syntax: OctetString
-
-# Q-BRIDGE-MIB::dot1qForwardUnregisteredEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qForwardUnregisteredEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.2
-#       name: dot1qVlanIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: dot1qForwardUnregisteredPorts
-#   attributes:
-#     dot1qForwardUnregisteredPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.2.5.1.1
-#       name: dot1qForwardUnregisteredPorts
-#       syntax: OctetString
-#     dot1qForwardUnregisteredStaticPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.2.5.1.2
-#       name: dot1qForwardUnregisteredStaticPorts
-#       syntax: OctetString
-#     dot1qForwardUnregisteredForbiddenPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.2.5.1.3
-#       name: dot1qForwardUnregisteredForbiddenPorts
-#       syntax: OctetString
-
-# Q-BRIDGE-MIB::dot1qStaticUnicastEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qStaticUnicastEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.2.1.1.1
-#       name: dot1qFdbId
-#       syntax: UnsignedAsID
-#     - type: MacAddress
-#       oid: .1.3.6.1.2.1.17.7.1.3.1.1.1
-#       name: dot1qStaticUnicastAddress
-#       syntax: MacAddress
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.7.1.3.1.1.2
-#       name: dot1qStaticUnicastReceivePort
-#       syntax: Integer32
-#   augments: 
-#   discovery_attribute: dot1qStaticUnicastAllowedToGoTo
-#   attributes:
-#     dot1qStaticUnicastAllowedToGoTo:
-#       oid: .1.3.6.1.2.1.17.7.1.3.1.1.3
-#       name: dot1qStaticUnicastAllowedToGoTo
-#       syntax: OctetString
-#     dot1qStaticUnicastStatus:
-#       oid: .1.3.6.1.2.1.17.7.1.3.1.1.4
-#       name: dot1qStaticUnicastStatus
-#       syntax: EnumInteger
-
-# Q-BRIDGE-MIB::dot1qStaticMulticastEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qStaticMulticastEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.2
-#       name: dot1qVlanIndex
-#       syntax: UnsignedAsID
-#     - type: MacAddress
-#       oid: .1.3.6.1.2.1.17.7.1.3.2.1.1
-#       name: dot1qStaticMulticastAddress
-#       syntax: MacAddress
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.7.1.3.2.1.2
-#       name: dot1qStaticMulticastReceivePort
-#       syntax: IntegerAsID
-#   discovery_attribute: dot1qStaticMulticastStaticEgressPorts
-#   attributes:
-#     dot1qStaticMulticastStaticEgressPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.3.2.1.3
-#       name: dot1qStaticMulticastStaticEgressPorts
-#       syntax: OctetString
-#     dot1qStaticMulticastForbiddenEgressPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.3.2.1.4
-#       name: dot1qStaticMulticastForbiddenEgressPorts
-#       syntax: OctetString
-#     dot1qStaticMulticastStatus:
-#       oid: .1.3.6.1.2.1.17.7.1.3.2.1.5
-#       name: dot1qStaticMulticastStatus
-#       syntax: EnumInteger
-
-# Q-BRIDGE-MIB::dot1qVlan:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qVlan
-#   augments: BRIDGE-MIB::dot1dBase
-#   discovery_attribute: dot1qVlanNumDeletes
-#   attributes:
-#     dot1qVlanNumDeletes:
-#       oid: .1.3.6.1.2.1.17.7.1.4.1
-#       name: dot1qVlanNumDeletes
-#       syntax: Counter32
-#     dot1qNextFreeLocalVlanIndex:
-#       oid: .1.3.6.1.2.1.17.7.1.4.4
-#       name: dot1qNextFreeLocalVlanIndex
-#       syntax: IntegerAsID
-#     dot1qConstraintSetDefault:
-#       oid: .1.3.6.1.2.1.17.7.1.4.9
-#       name: dot1qConstraintSetDefault
-#       syntax: Integer32
-#     dot1qConstraintTypeDefault:
-#       oid: .1.3.6.1.2.1.17.7.1.4.10
-#       name: dot1qConstraintTypeDefault
-#       syntax: EnumInteger
-
-# Q-BRIDGE-MIB::dot1qVlanCurrentEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qVlanCurrentEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.1
-#       name: dot1qVlanTimeMark
-#       syntax: TimeTicks
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.2
-#       name: dot1qVlanIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: dot1qVlanFdbId
-#   attributes:
-#     dot1qVlanFdbId:
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.3
-#       name: dot1qVlanFdbId
-#       syntax: UnsignedAsID
-#     dot1qVlanCurrentEgressPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.4
-#       name: dot1qVlanCurrentEgressPorts
-#       syntax: OctetString
-#     dot1qVlanCurrentUntaggedPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.5
-#       name: dot1qVlanCurrentUntaggedPorts
-#       syntax: OctetString
-#     dot1qVlanStatus:
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.6
-#       name: dot1qVlanStatus
-#       syntax: EnumInteger
-#     dot1qVlanCreationTime:
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.7
-#       name: dot1qVlanCreationTime
-#       syntax: TimeTicks
-
-# Q-BRIDGE-MIB::dot1qVlanStaticEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qVlanStaticEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.4.2.1.2
-#       name: dot1qVlanIndex
-#       syntax: UnsignedAsID
-#   discovery_attribute: dot1qVlanStaticName
-#   attributes:
-#     dot1qVlanStaticName:
-#       oid: .1.3.6.1.2.1.17.7.1.4.3.1.1
-#       tag: true
-#       name: dot1qVlanStaticName
-#       syntax: DisplayString
-#     dot1qVlanStaticEgressPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.4.3.1.2
-#       name: dot1qVlanStaticEgressPorts
-#       syntax: OctetString
-#     dot1qVlanForbiddenEgressPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.4.3.1.3
-#       name: dot1qVlanForbiddenEgressPorts
-#       syntax: OctetString
-#     dot1qVlanStaticUntaggedPorts:
-#       oid: .1.3.6.1.2.1.17.7.1.4.3.1.4
-#       name: dot1qVlanStaticUntaggedPorts
-#       syntax: OctetString
 
 Q-BRIDGE-MIB::dot1qPortVlanEntry:
   mib: Q-BRIDGE-MIB
@@ -304,6 +54,7 @@ Q-BRIDGE-MIB::dot1qPortVlanEntry:
       oid: .1.3.6.1.2.1.17.7.1.4.5.1.5
       name: bridge.port.gvrp.regs.failed
       syntax: Counter32
+      metric: counter
     dot1qPortGvrpLastPduOrigin:
       oid: .1.3.6.1.2.1.17.7.1.4.5.1.6
       name: bridge.port.gvrp.last_origin
@@ -331,26 +82,17 @@ Q-BRIDGE-MIB::dot1qPortVlanStatisticsEntry:
       oid: .1.3.6.1.2.1.17.7.1.4.6.1.1
       name: bridge.port.transparent.vlan.frames.in
       syntax: Counter32
+      metric: counter
     dot1qTpVlanPortOutFrames:
       oid: .1.3.6.1.2.1.17.7.1.4.6.1.2
       name: bridge.port.transparent.vlan.frames.out
       syntax: Counter32
+      metric: counter
     dot1qTpVlanPortInDiscards:
       oid: .1.3.6.1.2.1.17.7.1.4.6.1.3
       name: bridge.port.transparent.vlan.frames.discard.in
       syntax: Counter32
-    # dot1qTpVlanPortInOverflowFrames:
-    #   oid: .1.3.6.1.2.1.17.7.1.4.6.1.4
-    #   name: dot1qTpVlanPortInOverflowFrames
-    #   syntax: Counter32
-    # dot1qTpVlanPortOutOverflowFrames:
-    #   oid: .1.3.6.1.2.1.17.7.1.4.6.1.5
-    #   name: dot1qTpVlanPortOutOverflowFrames
-    #   syntax: Counter32
-    # dot1qTpVlanPortInOverflowDiscards:
-    #   oid: .1.3.6.1.2.1.17.7.1.4.6.1.6
-    #   name: dot1qTpVlanPortInOverflowDiscards
-    #   syntax: Counter32
+      metric: counter
 
 Q-BRIDGE-MIB::dot1qPortVlanHCStatisticsEntry:
   mib: Q-BRIDGE-MIB
@@ -362,6 +104,7 @@ Q-BRIDGE-MIB::dot1qPortVlanHCStatisticsEntry:
       oid: .1.3.6.1.2.1.17.7.1.4.7.1.1
       name: bridge.port.transparent.vlan.frames.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: Q-BRIDGE-MIB::dot1qPortVlanStatisticsEntry
         attribute: dot1qTpVlanPortInFrames
@@ -369,6 +112,7 @@ Q-BRIDGE-MIB::dot1qPortVlanHCStatisticsEntry:
       oid: .1.3.6.1.2.1.17.7.1.4.7.1.2
       name: bridge.port.transparent.vlan.frames.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: Q-BRIDGE-MIB::dot1qPortVlanStatisticsEntry
         attribute: dot1qTpVlanPortOutFrames
@@ -376,63 +120,7 @@ Q-BRIDGE-MIB::dot1qPortVlanHCStatisticsEntry:
       oid: .1.3.6.1.2.1.17.7.1.4.7.1.3
       name: bridge.port.transparent.vlan.frames.discard.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: Q-BRIDGE-MIB::dot1qPortVlanStatisticsEntry
         attribute: dot1qTpVlanPortInDiscards
-
-# Q-BRIDGE-MIB::dot1qLearningConstraintsEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1qLearningConstraintsEntry
-#   index:
-#     - type: Unsigned32
-#       oid: .1.3.6.1.2.1.17.7.1.4.8.1.1
-#       name: dot1qConstraintVlan
-#       syntax: UnsignedAsID
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.7.1.4.8.1.2
-#       name: dot1qConstraintSet
-#       syntax: Integer32
-#   discovery_attribute: dot1qConstraintType
-#   attributes:
-#     dot1qConstraintType:
-#       oid: .1.3.6.1.2.1.17.7.1.4.8.1.3
-#       name: dot1qConstraintType
-#       syntax: EnumInteger
-
-# Q-BRIDGE-MIB::dot1vProtocolGroupEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1vProtocolGroupEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.17.7.1.5.1.1.1
-#       name: dot1vProtocolTemplateFrameType
-#       syntax: EnumInteger
-#     - type: OctetString
-#       oid: .1.3.6.1.2.1.17.7.1.5.1.1.2
-#       name: dot1vProtocolTemplateProtocolValue
-#       syntax: OctetString
-#   discovery_attribute: dot1vProtocolGroupId
-#   attributes:
-#     dot1vProtocolGroupId:
-#       oid: .1.3.6.1.2.1.17.7.1.5.1.1.3
-#       name: dot1vProtocolGroupId
-#       syntax: IntegerAsID
-
-# Q-BRIDGE-MIB::dot1vProtocolPortEntry:
-#   mib: Q-BRIDGE-MIB
-#   object: dot1vProtocolPortEntry
-#   index:
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.1.4.1.1
-#       name: dot1dBasePort
-#       syntax: IntegerAsID
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.17.7.1.5.2.1.2
-#       name: dot1vProtocolPortGroupVid
-#       syntax: IntegerAsID
-#   discovery_attribute: dot1vProtocolPortGroupVid
-#   attributes:
-#     dot1vProtocolPortGroupVid:
-#       oid: .1.3.6.1.2.1.17.7.1.5.2.1.2
-#       name: dot1vProtocolPortGroupVid
-#       syntax: IntegerAsID

--- a/objects/ietf/RIPv2-MIB.yml
+++ b/objects/ietf/RIPv2-MIB.yml
@@ -7,10 +7,12 @@ RIPv2-MIB::rip2Globals:
       oid: .1.3.6.1.2.1.23.1.1
       name: rip.route_chgs
       syntax: Counter32
+      metric: counter
     rip2GlobalQueries:
       oid: .1.3.6.1.2.1.23.1.2
       name: rip.queries
       syntax: Counter32
+      metric: counter
 
 RIPv2-MIB::rip2IfStatEntry:
   mib: RIPv2-MIB
@@ -26,14 +28,17 @@ RIPv2-MIB::rip2IfStatEntry:
       oid: .1.3.6.1.2.1.23.2.1.2
       name: rip.netif.packets.bad.in
       syntax: Counter32
+      metric: counter
     rip2IfStatRcvBadRoutes:
       oid: .1.3.6.1.2.1.23.2.1.3
       name: rip.netif.routes.bad.in
       syntax: Counter32
+      metric: counter
     rip2IfStatSentUpdates:
       oid: .1.3.6.1.2.1.23.2.1.4
       name: rip.netif.updates.out
       syntax: Counter32
+      metric: counter
 
 RIPv2-MIB::rip2IfConfEntry:
   mib: RIPv2-MIB
@@ -88,6 +93,7 @@ RIPv2-MIB::rip2PeerEntry:
       oid: .1.3.6.1.2.1.23.4.1.3
       name: rip.peer.last_update
       syntax: TimeTicks
+      metric: counter
     rip2PeerVersion:
       oid: .1.3.6.1.2.1.23.4.1.4
       name: rip.peer.version.ver
@@ -96,7 +102,9 @@ RIPv2-MIB::rip2PeerEntry:
       oid: .1.3.6.1.2.1.23.4.1.5
       name: rip.peer.packets.bad.in
       syntax: Counter32
+      metric: counter
     rip2PeerRcvBadRoutes:
       oid: .1.3.6.1.2.1.23.4.1.6
       name: rip.peer.routes.bad.in
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/RMON-MIB.yml
+++ b/objects/ietf/RMON-MIB.yml
@@ -16,70 +16,87 @@ RMON-MIB::etherStatsEntry:
       oid: .1.3.6.1.2.1.16.1.1.1.3
       name: netif.ethernet.events.drop.in
       syntax: Counter32
+      metric: counter
     etherStatsOctets:
       oid: .1.3.6.1.2.1.16.1.1.1.4
       name: netif.ethernet.bytes.in
       syntax: Counter32
+      metric: counter
     etherStatsPkts:
       oid: .1.3.6.1.2.1.16.1.1.1.5
       name: netif.ethernet.packets.in
       syntax: Counter32
+      metric: counter
     etherStatsBroadcastPkts:
       oid: .1.3.6.1.2.1.16.1.1.1.6
       name: netif.ethernet.packets.bcast.in
       syntax: Counter32
+      metric: counter
     etherStatsMulticastPkts:
       oid: .1.3.6.1.2.1.16.1.1.1.7
       name: netif.ethernet.packets.mcast.in
       syntax: Counter32
+      metric: counter
     etherStatsCRCAlignErrors:
       oid: .1.3.6.1.2.1.16.1.1.1.8
       name: netif.ethernet.errors.crc_align.in
       syntax: Counter32
+      metric: counter
     etherStatsUndersizePkts:
       oid: .1.3.6.1.2.1.16.1.1.1.9
       name: netif.ethernet.packets.runt.in
       syntax: Counter32
+      metric: counter
     etherStatsOversizePkts:
       oid: .1.3.6.1.2.1.16.1.1.1.10
       name: netif.ethernet.packets.giant.in
       syntax: Counter32
+      metric: counter
     etherStatsFragments:
       oid: .1.3.6.1.2.1.16.1.1.1.11
       name: netif.ethernet.packets.fragment.in
       syntax: Counter32
+      metric: counter
     etherStatsJabbers:
       oid: .1.3.6.1.2.1.16.1.1.1.12
       name: netif.ethernet.packets.jabber.in
       syntax: Counter32
+      metric: counter
     etherStatsCollisions:
       oid: .1.3.6.1.2.1.16.1.1.1.13
       name: netif.ethernet.collisions.total
       syntax: Counter32
+      metric: counter
     etherStatsPkts64Octets:
       oid: .1.3.6.1.2.1.16.1.1.1.14
       name: netif.ethernet.packets.to_64_bytes.in
       syntax: Counter32
+      metric: counter
     etherStatsPkts65to127Octets:
       oid: .1.3.6.1.2.1.16.1.1.1.15
       name: netif.ethernet.packets.65_127_bytes.in
       syntax: Counter32
+      metric: counter
     etherStatsPkts128to255Octets:
       oid: .1.3.6.1.2.1.16.1.1.1.16
       name: netif.ethernet.packets.128_255_bytes.in
       syntax: Counter32
+      metric: counter
     etherStatsPkts256to511Octets:
       oid: .1.3.6.1.2.1.16.1.1.1.17
       name: netif.ethernet.packets.256_511_bytes.in
       syntax: Counter32
+      metric: counter
     etherStatsPkts512to1023Octets:
       oid: .1.3.6.1.2.1.16.1.1.1.18
       name: netif.ethernet.packets.512_1023_bytes.in
       syntax: Counter32
+      metric: counter
     etherStatsPkts1024to1518Octets:
       oid: .1.3.6.1.2.1.16.1.1.1.19
       name: netif.ethernet.packets.1024_1518_bytes.in
       syntax: Counter32
+      metric: counter
     etherStatsOwner:
       oid: .1.3.6.1.2.1.16.1.1.1.20
       name: netif.ethernet.owner

--- a/objects/ietf/RSTP-MIB.yml
+++ b/objects/ietf/RSTP-MIB.yml
@@ -12,6 +12,7 @@ RSTP-MIB::dot1dStp:
       oid: .1.3.6.1.2.1.17.2.17
       name: stp.hold_count
       syntax: Integer32
+      metric: gauge
 
 RSTP-MIB::dot1dStpExtPortEntry:
   mib: RSTP-MIB
@@ -43,3 +44,4 @@ RSTP-MIB::dot1dStpExtPortEntry:
       oid: .1.3.6.1.2.1.17.2.19.1.6
       name: bridge.port.stp.path_cost.admin
       syntax: Integer32
+      metric: gauge

--- a/objects/ietf/SNMP-FRAMEWORK-MIB.yml
+++ b/objects/ietf/SNMP-FRAMEWORK-MIB.yml
@@ -12,6 +12,7 @@ SNMP-FRAMEWORK-MIB::snmpEngine:
       oid: .1.3.6.1.6.3.10.2.1.2
       name: snmp.engine.starts
       syntax: Unsigned32
+      metric: counter
     snmpEngineTime:
       oid: .1.3.6.1.6.3.10.2.1.3
       name: snmp.engine.uptime
@@ -20,3 +21,4 @@ SNMP-FRAMEWORK-MIB::snmpEngine:
       oid: .1.3.6.1.6.3.10.2.1.4
       name: snmp.engine.max_msg_size
       syntax: Unsigned32
+      metric: gauge

--- a/objects/ietf/SNMP-MPD-MIB.yml
+++ b/objects/ietf/SNMP-MPD-MIB.yml
@@ -8,11 +8,14 @@ SNMP-MPD-MIB::snmpMPDStats:
       oid: .1.3.6.1.6.3.11.2.1.1
       name: snmp.msgs.sec_model_unknown.in
       syntax: Counter32
+      metric: counter
     snmpInvalidMsgs:
       oid: .1.3.6.1.6.3.11.2.1.2
       name: snmp.msgs.invalid.in
       syntax: Counter32
+      metric: counter
     snmpUnknownPDUHandlers:
       oid: .1.3.6.1.6.3.11.2.1.3
       name: snmp.msgs.pdu_handler_unknown.in
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/SNMP-TARGET-MIB.yml
+++ b/objects/ietf/SNMP-TARGET-MIB.yml
@@ -9,7 +9,9 @@ SNMP-TARGET-MIB::snmpTargetObjects:
       oid: .1.3.6.1.6.3.12.1.4
       name: snmp.msgs.context_unavail
       syntax: Counter32
+      metric: counter
     snmpUnknownContexts:
       oid: .1.3.6.1.6.3.12.1.5
       name: snmp.msgs.context_unknown
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/SNMP-USER-BASED-SM-MIB.yml
+++ b/objects/ietf/SNMP-USER-BASED-SM-MIB.yml
@@ -8,23 +8,29 @@ SNMP-USER-BASED-SM-MIB::usmStats:
       oid: .1.3.6.1.6.3.15.1.1.1
       name: snmp.usm.msgs.sec_level_unsupp.in
       syntax: Counter32
+      metric: counter
     usmStatsNotInTimeWindows:
       oid: .1.3.6.1.6.3.15.1.1.2
       name: snmp.usm.msgs.not_in_time_window.in
       syntax: Counter32
+      metric: counter
     usmStatsUnknownUserNames:
       oid: .1.3.6.1.6.3.15.1.1.3
       name: snmp.usm.msgs.user_unknown.in
       syntax: Counter32
+      metric: counter
     usmStatsUnknownEngineIDs:
       oid: .1.3.6.1.6.3.15.1.1.4
       name: snmp.usm.msgs.engine_id_unknown.in
       syntax: Counter32
+      metric: counter
     usmStatsWrongDigests:
       oid: .1.3.6.1.6.3.15.1.1.5
       name: snmp.usm.msgs.digest_wrong.in
       syntax: Counter32
+      metric: counter
     usmStatsDecryptionErrors:
       oid: .1.3.6.1.6.3.15.1.1.6
       name: snmp.usm.msgs.decrypt_error.in
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/SNMPv2-MIB.yml
+++ b/objects/ietf/SNMPv2-MIB.yml
@@ -15,6 +15,7 @@ SNMPv2-MIB::system:
       oid: .1.3.6.1.2.1.1.3
       name: system.sysuptime
       syntax: TimeTicks
+      metric: counter
       rediscover: OnReset
     sysContact:
       oid: .1.3.6.1.2.1.1.4
@@ -36,6 +37,7 @@ SNMPv2-MIB::system:
       oid: .1.3.6.1.2.1.1.8
       name: system.capability.last_chg
       syntax: TimeStamp
+      metric: counter
 
 SNMPv2-MIB::snmp:
   mib: SNMPv2-MIB
@@ -46,110 +48,137 @@ SNMPv2-MIB::snmp:
       oid: .1.3.6.1.2.1.11.1
       name: snmp.packets.in
       syntax: Counter32
+      metric: counter
     snmpInBadVersions:
       oid: .1.3.6.1.2.1.11.3
       name: snmp.msgs.ver_unsupp.in
       syntax: Counter32
+      metric: counter
     snmpInBadCommunityNames:
       oid: .1.3.6.1.2.1.11.4
       name: snmp.msgs.community_unknown.in
       syntax: Counter32
+      metric: counter
     snmpInBadCommunityUses:
       oid: .1.3.6.1.2.1.11.5
       name: snmp.msgs.community_not_auth.in
       syntax: Counter32
+      metric: counter
     snmpInASNParseErrs:
       oid: .1.3.6.1.2.1.11.6
       name: snmp.errors.asn1_parse.in
       syntax: Counter32
+      metric: counter
     snmpOutPkts:
       oid: .1.3.6.1.2.1.11.2
       name: snmp.packets.out
       syntax: Counter32
+      metric: counter
     snmpInTooBigs:
       oid: .1.3.6.1.2.1.11.8
       name: snmp.errors.too_big.in
       syntax: Counter32
+      metric: counter
     snmpInNoSuchNames:
       oid: .1.3.6.1.2.1.11.9
       name: snmp.errors.no_such_name.in
       syntax: Counter32
+      metric: counter
     snmpInBadValues:
       oid: .1.3.6.1.2.1.11.10
       name: snmp.errors.bad_values.in
       syntax: Counter32
+      metric: counter
     snmpInReadOnlys:
       oid: .1.3.6.1.2.1.11.11
       name: snmp.errors.read_only.in
       syntax: Counter32
+      metric: counter
     snmpInGenErrs:
       oid: .1.3.6.1.2.1.11.12
       name: snmp.errors.gen_err.in
       syntax: Counter32
+      metric: counter
     snmpInTotalReqVars:
       oid: .1.3.6.1.2.1.11.13
       name: snmp.oids.get.in
       syntax: Counter32
+      metric: counter
     snmpInTotalSetVars:
       oid: .1.3.6.1.2.1.11.14
       name: snmp.oids.set.in
       syntax: Counter32
+      metric: counter
     snmpInGetRequests:
       oid: .1.3.6.1.2.1.11.15
       name: snmp.pdus.get_req.in
       syntax: Counter32
+      metric: counter
     snmpInGetNexts:
       oid: .1.3.6.1.2.1.11.16
       name: snmp.pdus.get_next.in
       syntax: Counter32
+      metric: counter
     snmpInSetRequests:
       oid: .1.3.6.1.2.1.11.17
       name: snmp.pdus.set_req.in
       syntax: Counter32
+      metric: counter
     snmpInGetResponses:
       oid: .1.3.6.1.2.1.11.18
       name: snmp.pdus.get_resp.in
       syntax: Counter32
+      metric: counter
     snmpInTraps:
       oid: .1.3.6.1.2.1.11.19
       name: snmp.pdus.trap.in
       syntax: Counter32
+      metric: counter
     snmpOutTooBigs:
       oid: .1.3.6.1.2.1.11.20
       name: snmp.errors.too_big.out
       syntax: Counter32
+      metric: counter
     snmpOutNoSuchNames:
       oid: .1.3.6.1.2.1.11.21
       name: snmp.errors.no_such_names.out
       syntax: Counter32
+      metric: counter
     snmpOutBadValues:
       oid: .1.3.6.1.2.1.11.22
       name: snmp.errors.bad_values.out
       syntax: Counter32
+      metric: counter
     snmpOutGenErrs:
       oid: .1.3.6.1.2.1.11.24
       name: snmp.errors.gen_err.out
       syntax: Counter32
+      metric: counter
     snmpOutGetRequests:
       oid: .1.3.6.1.2.1.11.25
       name: snmp.pdus.get_req.out
       syntax: Counter32
+      metric: counter
     snmpOutGetNexts:
       oid: .1.3.6.1.2.1.11.26
       name: snmp.pdus.get_next.out
       syntax: Counter32
+      metric: counter
     snmpOutSetRequests:
       oid: .1.3.6.1.2.1.11.27
       name: snmp.pdus.set_req.out
       syntax: Counter32
+      metric: counter
     snmpOutGetResponses:
       oid: .1.3.6.1.2.1.11.28
       name: snmp.pdus.get_resp.out
       syntax: Counter32
+      metric: counter
     snmpOutTraps:
       oid: .1.3.6.1.2.1.11.29
       name: snmp.pdus.trap.out
       syntax: Counter32
+      metric: counter
     snmpEnableAuthenTraps:
       oid: .1.3.6.1.2.1.11.30
       name: snmp.auth_trap.enable
@@ -158,7 +187,9 @@ SNMPv2-MIB::snmp:
       oid: .1.3.6.1.2.1.11.31
       name: snmp.pdus.drop_silent
       syntax: Counter32
+      metric: counter
     snmpProxyDrops:
       oid: .1.3.6.1.2.1.11.32
       name: snmp.pdus.drop_proxy
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/SONET-MIB.yml
+++ b/objects/ietf/SONET-MIB.yml
@@ -26,6 +26,7 @@ SONET-MIB::sonetMediumEntry:
       oid: .1.3.6.1.2.1.10.39.1.1.1.1.2
       name: ietf.sonetMediumTimeElapsed
       syntax: TicksSec
+      metric: counter
     sonetMediumValidIntervals:
       oid: .1.3.6.1.2.1.10.39.1.1.1.1.3
       name: ietf.sonetMediumValidIntervals
@@ -46,6 +47,7 @@ SONET-MIB::sonetMediumEntry:
       oid: .1.3.6.1.2.1.10.39.1.1.1.1.7
       name: ietf.sonetMediumInvalidIntervals
       syntax: Integer32
+      metric: counter
     sonetMediumLoopbackConfig:
       oid: .1.3.6.1.2.1.10.39.1.1.1.1.8
       name: ietf.sonetMediumLoopbackConfig
@@ -86,53 +88,22 @@ SONET-MIB::sonetSectionCurrentEntry:
       oid: .1.3.6.1.2.1.10.39.1.2.1.1.2
       name: ietf.sonetSectionCurrentESs
       syntax: Gauge32
+      metric: gauge
     sonetSectionCurrentSESs:
       oid: .1.3.6.1.2.1.10.39.1.2.1.1.3
       name: ietf.sonetSectionCurrentSESs
       syntax: Gauge32
+      metric: gauge
     sonetSectionCurrentSEFSs:
       oid: .1.3.6.1.2.1.10.39.1.2.1.1.4
       name: ietf.sonetSectionCurrentSEFSs
       syntax: Gauge32
+      metric: gauge
     sonetSectionCurrentCVs:
       oid: .1.3.6.1.2.1.10.39.1.2.1.1.5
       name: ietf.sonetSectionCurrentCVs
       syntax: Gauge32
-
-# SONET-MIB::sonetSectionIntervalEntry:
-#   mib: SONET-MIB
-#   object: sonetSectionIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.39.1.2.2.1.1
-#       name: ietf.sonetSectionIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: sonetSectionIntervalESs
-#   attributes:
-#     sonetSectionIntervalESs:
-#       oid: .1.3.6.1.2.1.10.39.1.2.2.1.2
-#       name: ietf.sonetSectionIntervalESs
-#       syntax: Gauge32
-#     sonetSectionIntervalSESs:
-#       oid: .1.3.6.1.2.1.10.39.1.2.2.1.3
-#       name: ietf.sonetSectionIntervalSESs
-#       syntax: Gauge32
-#     sonetSectionIntervalSEFSs:
-#       oid: .1.3.6.1.2.1.10.39.1.2.2.1.4
-#       name: ietf.sonetSectionIntervalSEFSs
-#       syntax: Gauge32
-#     sonetSectionIntervalCVs:
-#       oid: .1.3.6.1.2.1.10.39.1.2.2.1.5
-#       name: ietf.sonetSectionIntervalCVs
-#       syntax: Gauge32
-#     sonetSectionIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.39.1.2.2.1.6
-#       name: ietf.sonetSectionIntervalValidData
-#       syntax: TruthValue
+      metric: gauge
 
 SONET-MIB::sonetLineCurrentEntry:
   mib: SONET-MIB
@@ -148,53 +119,22 @@ SONET-MIB::sonetLineCurrentEntry:
       oid: .1.3.6.1.2.1.10.39.1.3.1.1.2
       name: ietf.sonetLineCurrentESs
       syntax: Gauge32
+      metric: gauge
     sonetLineCurrentSESs:
       oid: .1.3.6.1.2.1.10.39.1.3.1.1.3
       name: ietf.sonetLineCurrentSESs
       syntax: Gauge32
+      metric: gauge
     sonetLineCurrentCVs:
       oid: .1.3.6.1.2.1.10.39.1.3.1.1.4
       name: ietf.sonetLineCurrentCVs
       syntax: Gauge32
+      metric: gauge
     sonetLineCurrentUASs:
       oid: .1.3.6.1.2.1.10.39.1.3.1.1.5
       name: ietf.sonetLineCurrentUASs
       syntax: Gauge32
-
-# SONET-MIB::sonetLineIntervalEntry:
-#   mib: SONET-MIB
-#   object: sonetLineIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.39.1.3.2.1.1
-#       name: ietf.sonetLineIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: sonetLineIntervalESs
-#   attributes:
-#     sonetLineIntervalESs:
-#       oid: .1.3.6.1.2.1.10.39.1.3.2.1.2
-#       name: ietf.sonetLineIntervalESs
-#       syntax: Gauge32
-#     sonetLineIntervalSESs:
-#       oid: .1.3.6.1.2.1.10.39.1.3.2.1.3
-#       name: ietf.sonetLineIntervalSESs
-#       syntax: Gauge32
-#     sonetLineIntervalCVs:
-#       oid: .1.3.6.1.2.1.10.39.1.3.2.1.4
-#       name: ietf.sonetLineIntervalCVs
-#       syntax: Gauge32
-#     sonetLineIntervalUASs:
-#       oid: .1.3.6.1.2.1.10.39.1.3.2.1.5
-#       name: ietf.sonetLineIntervalUASs
-#       syntax: Gauge32
-#     sonetLineIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.39.1.3.2.1.6
-#       name: ietf.sonetLineIntervalValidData
-#       syntax: TruthValue
+      metric: gauge
 
 SONET-MIB::sonetFarEndLineCurrentEntry:
   mib: SONET-MIB
@@ -206,53 +146,22 @@ SONET-MIB::sonetFarEndLineCurrentEntry:
       oid: .1.3.6.1.2.1.10.39.1.4.1.1.1
       name: ietf.sonetFarEndLineCurrentESs
       syntax: Gauge32
+      metric: gauge
     sonetFarEndLineCurrentSESs:
       oid: .1.3.6.1.2.1.10.39.1.4.1.1.2
       name: ietf.sonetFarEndLineCurrentSESs
       syntax: Gauge32
+      metric: gauge
     sonetFarEndLineCurrentCVs:
       oid: .1.3.6.1.2.1.10.39.1.4.1.1.3
       name: ietf.sonetFarEndLineCurrentCVs
       syntax: Gauge32
+      metric: gauge
     sonetFarEndLineCurrentUASs:
       oid: .1.3.6.1.2.1.10.39.1.4.1.1.4
       name: ietf.sonetFarEndLineCurrentUASs
       syntax: Gauge32
-
-# SONET-MIB::sonetFarEndLineIntervalEntry:
-#   mib: SONET-MIB
-#   object: sonetFarEndLineIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.39.1.4.2.1.1
-#       name: ietf.sonetFarEndLineIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: sonetFarEndLineIntervalESs
-#   attributes:
-#     sonetFarEndLineIntervalESs:
-#       oid: .1.3.6.1.2.1.10.39.1.4.2.1.2
-#       name: ietf.sonetFarEndLineIntervalESs
-#       syntax: Gauge32
-#     sonetFarEndLineIntervalSESs:
-#       oid: .1.3.6.1.2.1.10.39.1.4.2.1.3
-#       name: ietf.sonetFarEndLineIntervalSESs
-#       syntax: Gauge32
-#     sonetFarEndLineIntervalCVs:
-#       oid: .1.3.6.1.2.1.10.39.1.4.2.1.4
-#       name: ietf.sonetFarEndLineIntervalCVs
-#       syntax: Gauge32
-#     sonetFarEndLineIntervalUASs:
-#       oid: .1.3.6.1.2.1.10.39.1.4.2.1.5
-#       name: ietf.sonetFarEndLineIntervalUASs
-#       syntax: Gauge32
-#     sonetFarEndLineIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.39.1.4.2.1.6
-#       name: ietf.sonetFarEndLineIntervalValidData
-#       syntax: TruthValue
+      metric: gauge
 
 SONET-MIB::sonetPathCurrentEntry:
   mib: SONET-MIB
@@ -272,53 +181,22 @@ SONET-MIB::sonetPathCurrentEntry:
       oid: .1.3.6.1.2.1.10.39.2.1.1.1.3
       name: ietf.sonetPathCurrentESs
       syntax: Gauge32
+      metric: gauge
     sonetPathCurrentSESs:
       oid: .1.3.6.1.2.1.10.39.2.1.1.1.4
       name: ietf.sonetPathCurrentSESs
       syntax: Gauge32
+      metric: gauge
     sonetPathCurrentCVs:
       oid: .1.3.6.1.2.1.10.39.2.1.1.1.5
       name: ietf.sonetPathCurrentCVs
       syntax: Gauge32
+      metric: gauge
     sonetPathCurrentUASs:
       oid: .1.3.6.1.2.1.10.39.2.1.1.1.6
       name: ietf.sonetPathCurrentUASs
       syntax: Gauge32
-
-# SONET-MIB::sonetPathIntervalEntry:
-#   mib: SONET-MIB
-#   object: sonetPathIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.39.2.1.2.1.1
-#       name: ietf.sonetPathIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: sonetPathIntervalESs
-#   attributes:
-#     sonetPathIntervalESs:
-#       oid: .1.3.6.1.2.1.10.39.2.1.2.1.2
-#       name: ietf.sonetPathIntervalESs
-#       syntax: Gauge32
-#     sonetPathIntervalSESs:
-#       oid: .1.3.6.1.2.1.10.39.2.1.2.1.3
-#       name: ietf.sonetPathIntervalSESs
-#       syntax: Gauge32
-#     sonetPathIntervalCVs:
-#       oid: .1.3.6.1.2.1.10.39.2.1.2.1.4
-#       name: ietf.sonetPathIntervalCVs
-#       syntax: Gauge32
-#     sonetPathIntervalUASs:
-#       oid: .1.3.6.1.2.1.10.39.2.1.2.1.5
-#       name: ietf.sonetPathIntervalUASs
-#       syntax: Gauge32
-#     sonetPathIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.39.2.1.2.1.6
-#       name: ietf.sonetPathIntervalValidData
-#       syntax: TruthValue
+      metric: gauge
 
 SONET-MIB::sonetFarEndPathCurrentEntry:
   mib: SONET-MIB
@@ -330,53 +208,22 @@ SONET-MIB::sonetFarEndPathCurrentEntry:
       oid: .1.3.6.1.2.1.10.39.2.2.1.1.1
       name: ietf.sonetFarEndPathCurrentESs
       syntax: Gauge32
+      metric: gauge
     sonetFarEndPathCurrentSESs:
       oid: .1.3.6.1.2.1.10.39.2.2.1.1.2
       name: ietf.sonetFarEndPathCurrentSESs
       syntax: Gauge32
+      metric: gauge
     sonetFarEndPathCurrentCVs:
       oid: .1.3.6.1.2.1.10.39.2.2.1.1.3
       name: ietf.sonetFarEndPathCurrentCVs
       syntax: Gauge32
+      metric: gauge
     sonetFarEndPathCurrentUASs:
       oid: .1.3.6.1.2.1.10.39.2.2.1.1.4
       name: ietf.sonetFarEndPathCurrentUASs
       syntax: Gauge32
-
-# SONET-MIB::sonetFarEndPathIntervalEntry:
-#   mib: SONET-MIB
-#   object: sonetFarEndPathIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.39.2.2.2.1.1
-#       name: ietf.sonetFarEndPathIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: sonetFarEndPathIntervalESs
-#   attributes:
-#     sonetFarEndPathIntervalESs:
-#       oid: .1.3.6.1.2.1.10.39.2.2.2.1.2
-#       name: ietf.sonetFarEndPathIntervalESs
-#       syntax: Gauge32
-#     sonetFarEndPathIntervalSESs:
-#       oid: .1.3.6.1.2.1.10.39.2.2.2.1.3
-#       name: ietf.sonetFarEndPathIntervalSESs
-#       syntax: Gauge32
-#     sonetFarEndPathIntervalCVs:
-#       oid: .1.3.6.1.2.1.10.39.2.2.2.1.4
-#       name: ietf.sonetFarEndPathIntervalCVs
-#       syntax: Gauge32
-#     sonetFarEndPathIntervalUASs:
-#       oid: .1.3.6.1.2.1.10.39.2.2.2.1.5
-#       name: ietf.sonetFarEndPathIntervalUASs
-#       syntax: Gauge32
-#     sonetFarEndPathIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.39.2.2.2.1.6
-#       name: ietf.sonetFarEndPathIntervalValidData
-#       syntax: TruthValue
+      metric: gauge
 
 SONET-MIB::sonetVTCurrentEntry:
   mib: SONET-MIB
@@ -396,53 +243,22 @@ SONET-MIB::sonetVTCurrentEntry:
       oid: .1.3.6.1.2.1.10.39.3.1.1.1.3
       name: ietf.sonetVTCurrentESs
       syntax: Gauge32
+      metric: gauge
     sonetVTCurrentSESs:
       oid: .1.3.6.1.2.1.10.39.3.1.1.1.4
       name: ietf.sonetVTCurrentSESs
       syntax: Gauge32
+      metric: gauge
     sonetVTCurrentCVs:
       oid: .1.3.6.1.2.1.10.39.3.1.1.1.5
       name: ietf.sonetVTCurrentCVs
       syntax: Gauge32
+      metric: gauge
     sonetVTCurrentUASs:
       oid: .1.3.6.1.2.1.10.39.3.1.1.1.6
       name: ietf.sonetVTCurrentUASs
       syntax: Gauge32
-
-# SONET-MIB::sonetVTIntervalEntry:
-#   mib: SONET-MIB
-#   object: sonetVTIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.39.3.1.2.1.1
-#       name: ietf.sonetVTIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: sonetVTIntervalESs
-#   attributes:
-#     sonetVTIntervalESs:
-#       oid: .1.3.6.1.2.1.10.39.3.1.2.1.2
-#       name: ietf.sonetVTIntervalESs
-#       syntax: Gauge32
-#     sonetVTIntervalSESs:
-#       oid: .1.3.6.1.2.1.10.39.3.1.2.1.3
-#       name: ietf.sonetVTIntervalSESs
-#       syntax: Gauge32
-#     sonetVTIntervalCVs:
-#       oid: .1.3.6.1.2.1.10.39.3.1.2.1.4
-#       name: ietf.sonetVTIntervalCVs
-#       syntax: Gauge32
-#     sonetVTIntervalUASs:
-#       oid: .1.3.6.1.2.1.10.39.3.1.2.1.5
-#       name: ietf.sonetVTIntervalUASs
-#       syntax: Gauge32
-#     sonetVTIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.39.3.1.2.1.6
-#       name: ietf.sonetVTIntervalValidData
-#       syntax: TruthValue
+      metric: gauge
 
 SONET-MIB::sonetFarEndVTCurrentEntry:
   mib: SONET-MIB
@@ -454,50 +270,19 @@ SONET-MIB::sonetFarEndVTCurrentEntry:
       oid: .1.3.6.1.2.1.10.39.3.2.1.1.1
       name: ietf.sonetFarEndVTCurrentESs
       syntax: Gauge32
+      metric: gauge
     sonetFarEndVTCurrentSESs:
       oid: .1.3.6.1.2.1.10.39.3.2.1.1.2
       name: ietf.sonetFarEndVTCurrentSESs
       syntax: Gauge32
+      metric: gauge
     sonetFarEndVTCurrentCVs:
       oid: .1.3.6.1.2.1.10.39.3.2.1.1.3
       name: ietf.sonetFarEndVTCurrentCVs
       syntax: Gauge32
+      metric: gauge
     sonetFarEndVTCurrentUASs:
       oid: .1.3.6.1.2.1.10.39.3.2.1.1.4
       name: ietf.sonetFarEndVTCurrentUASs
       syntax: Gauge32
-
-# SONET-MIB::sonetFarEndVTIntervalEntry:
-#   mib: SONET-MIB
-#   object: sonetFarEndVTIntervalEntry
-#   index:
-#     - type: Integer
-#       oid: .1.3.6.1.2.1.2.2.1.1
-#       name: netif # ifIndex
-#       syntax: InterfaceIndex
-#     - type: Integer32
-#       oid: .1.3.6.1.2.1.10.39.3.2.2.1.1
-#       name: ietf.sonetFarEndVTIntervalNumber
-#       syntax: Integer32
-#   discovery_attribute: sonetFarEndVTIntervalESs
-#   attributes:
-#     sonetFarEndVTIntervalESs:
-#       oid: .1.3.6.1.2.1.10.39.3.2.2.1.2
-#       name: ietf.sonetFarEndVTIntervalESs
-#       syntax: Gauge32
-#     sonetFarEndVTIntervalSESs:
-#       oid: .1.3.6.1.2.1.10.39.3.2.2.1.3
-#       name: ietf.sonetFarEndVTIntervalSESs
-#       syntax: Gauge32
-#     sonetFarEndVTIntervalCVs:
-#       oid: .1.3.6.1.2.1.10.39.3.2.2.1.4
-#       name: ietf.sonetFarEndVTIntervalCVs
-#       syntax: Gauge32
-#     sonetFarEndVTIntervalUASs:
-#       oid: .1.3.6.1.2.1.10.39.3.2.2.1.5
-#       name: ietf.sonetFarEndVTIntervalUASs
-#       syntax: Gauge32
-#     sonetFarEndVTIntervalValidData:
-#       oid: .1.3.6.1.2.1.10.39.3.2.2.1.6
-#       name: ietf.sonetFarEndVTIntervalValidData
-#       syntax: TruthValue
+      metric: gauge

--- a/objects/ietf/SOURCE-ROUTING-MIB.yml
+++ b/objects/ietf/SOURCE-ROUTING-MIB.yml
@@ -12,6 +12,7 @@ SOURCE-ROUTING-MIB::dot1dSrPortEntry:
       oid: .1.3.6.1.2.1.17.3.1.1.2
       name: ietf.dot1dSrPortHopCount
       syntax: Integer32
+      metric: gauge
     dot1dSrPortLocalSegment:
       oid: .1.3.6.1.2.1.17.3.1.1.3
       name: ietf.dot1dSrPortLocalSegment
@@ -28,6 +29,7 @@ SOURCE-ROUTING-MIB::dot1dSrPortEntry:
       oid: .1.3.6.1.2.1.17.3.1.1.6
       name: ietf.dot1dSrPortLargestFrame
       syntax: Integer32
+      metric: gauge
     dot1dSrPortSTESpanMode:
       oid: .1.3.6.1.2.1.17.3.1.1.7
       name: ietf.dot1dSrPortSTESpanMode
@@ -36,46 +38,57 @@ SOURCE-ROUTING-MIB::dot1dSrPortEntry:
       oid: .1.3.6.1.2.1.17.3.1.1.8
       name: ietf.dot1dSrPortSpecInFrames
       syntax: Counter32
+      metric: counter
     dot1dSrPortSpecOutFrames:
       oid: .1.3.6.1.2.1.17.3.1.1.9
       name: ietf.dot1dSrPortSpecOutFrames
       syntax: Counter32
+      metric: counter
     dot1dSrPortApeInFrames:
       oid: .1.3.6.1.2.1.17.3.1.1.10
       name: ietf.dot1dSrPortApeInFrames
       syntax: Counter32
+      metric: counter
     dot1dSrPortApeOutFrames:
       oid: .1.3.6.1.2.1.17.3.1.1.11
       name: ietf.dot1dSrPortApeOutFrames
       syntax: Counter32
+      metric: counter
     dot1dSrPortSteInFrames:
       oid: .1.3.6.1.2.1.17.3.1.1.12
       name: ietf.dot1dSrPortSteInFrames
       syntax: Counter32
+      metric: counter
     dot1dSrPortSteOutFrames:
       oid: .1.3.6.1.2.1.17.3.1.1.13
       name: ietf.dot1dSrPortSteOutFrames
       syntax: Counter32
+      metric: counter
     dot1dSrPortSegmentMismatchDiscards:
       oid: .1.3.6.1.2.1.17.3.1.1.14
       name: ietf.dot1dSrPortSegmentMismatchDiscards
       syntax: Counter32
+      metric: counter
     dot1dSrPortDuplicateSegmentDiscards:
       oid: .1.3.6.1.2.1.17.3.1.1.15
       name: ietf.dot1dSrPortDuplicateSegmentDiscards
       syntax: Counter32
+      metric: counter
     dot1dSrPortHopCountExceededDiscards:
       oid: .1.3.6.1.2.1.17.3.1.1.16
       name: ietf.dot1dSrPortHopCountExceededDiscards
       syntax: Counter32
+      metric: counter
     dot1dSrPortDupLanIdOrTreeErrors:
       oid: .1.3.6.1.2.1.17.3.1.1.17
       name: ietf.dot1dSrPortDupLanIdOrTreeErrors
       syntax: Counter32
+      metric: counter
     dot1dSrPortLanIdMismatches:
       oid: .1.3.6.1.2.1.17.3.1.1.18
       name: ietf.dot1dSrPortLanIdMismatches
       syntax: Counter32
+      metric: counter
 
 SOURCE-ROUTING-MIB::dot1dPortPairEntry:
   mib: SOURCE-ROUTING-MIB

--- a/objects/ietf/TCP-MIB.yml
+++ b/objects/ietf/TCP-MIB.yml
@@ -11,58 +11,72 @@ TCP-MIB::tcp:
       oid: .1.3.6.1.2.1.6.2
       name: tcp.rto.min
       syntax: Integer32
+      metric: gauge
     tcpRtoMax:
       oid: .1.3.6.1.2.1.6.3
       name: tcp.rto.max
       syntax: Integer32
+      metric: gauge
     tcpMaxConn:
       oid: .1.3.6.1.2.1.6.4
       name: tcp.conns.max
       syntax: Integer32
+      metric: gauge
     tcpActiveOpens:
       oid: .1.3.6.1.2.1.6.5
       name: tcp.conns.open_active
       syntax: Counter32
+      metric: counter
     tcpPassiveOpens:
       oid: .1.3.6.1.2.1.6.6
       name: tcp.conns.open_passive
       syntax: Counter32
+      metric: counter
     tcpAttemptFails:
       oid: .1.3.6.1.2.1.6.7
       name: tcp.conns.fail
       syntax: Counter32
+      metric: counter
     tcpEstabResets:
       oid: .1.3.6.1.2.1.6.8
       name: tcp.conns.reset
       syntax: Counter32
+      metric: counter
     tcpCurrEstab:
       oid: .1.3.6.1.2.1.6.9
       name: tcp.conns.establish
       syntax: Gauge32
+      metric: gauge
     tcpInSegs:
       oid: .1.3.6.1.2.1.6.10
       name: tcp.segs.in
       syntax: Counter32
+      metric: counter
     tcpOutSegs:
       oid: .1.3.6.1.2.1.6.11
       name: tcp.segs.out
       syntax: Counter32
+      metric: counter
     tcpRetransSegs:
       oid: .1.3.6.1.2.1.6.12
       name: tcp.segs.retrans
       syntax: Counter32
+      metric: counter
     tcpInErrs:
       oid: .1.3.6.1.2.1.6.14
       name: tcp.errors.in
       syntax: Counter32
+      metric: counter
     tcpOutRsts:
       oid: .1.3.6.1.2.1.6.15
       name: tcp.errors.out
       syntax: Counter32
+      metric: counter
     tcpHCInSegs:
       oid: .1.3.6.1.2.1.6.17
       name: tcp.segs.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: TCP-MIB::tcp
         attribute: tcpInSegs
@@ -70,6 +84,7 @@ TCP-MIB::tcp:
       oid: .1.3.6.1.2.1.6.18
       name: tcp.segs.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: TCP-MIB::tcp
         attribute: tcpOutSegs

--- a/objects/ietf/TUNNEL-MIB.yml
+++ b/objects/ietf/TUNNEL-MIB.yml
@@ -24,6 +24,7 @@ TUNNEL-MIB::tunnelIfEntry:
       oid: .1.3.6.1.2.1.10.131.1.1.1.1.4
       name: tunnel.hop_limit
       syntax: Integer32
+      metric: gauge
     tunnelIfSecurity:
       oid: .1.3.6.1.2.1.10.131.1.1.1.1.5
       name: tunnel.sec.type
@@ -54,3 +55,4 @@ TUNNEL-MIB::tunnelIfEntry:
       oid: .1.3.6.1.2.1.10.131.1.1.1.1.11
       name: tunnel.encap.limit
       syntax: Integer32
+      metric: gauge

--- a/objects/ietf/UDP-MIB.yml
+++ b/objects/ietf/UDP-MIB.yml
@@ -7,22 +7,27 @@ UDP-MIB::udp:
       oid: .1.3.6.1.2.1.7.1
       name: udp.dgrms.in
       syntax: Counter32
+      metric: counter
     udpNoPorts:
       oid: .1.3.6.1.2.1.7.2
       name: udp.dgrms.unkproto.in
       syntax: Counter32
+      metric: counter
     udpInErrors:
       oid: .1.3.6.1.2.1.7.3
       name: udp.dgrms.error.in
       syntax: Counter32
+      metric: counter
     udpOutDatagrams:
       oid: .1.3.6.1.2.1.7.4
       name: udp.dgrms.out
       syntax: Counter32
+      metric: counter
     udpHCInDatagrams:
       oid: .1.3.6.1.2.1.7.8
       name: udp.dgrms.in
       syntax: Counter64
+      metric: counter
       overrides:
         object: UDP-MIB::udp
         attribute: udpInDatagrams
@@ -30,6 +35,7 @@ UDP-MIB::udp:
       oid: .1.3.6.1.2.1.7.9
       name: udp.dgrms.out
       syntax: Counter64
+      metric: counter
       overrides:
         object: UDP-MIB::udp
         attribute: udpOutDatagrams

--- a/objects/ietf/UDPLITE-MIB.yml
+++ b/objects/ietf/UDPLITE-MIB.yml
@@ -7,31 +7,39 @@ UDPLITE-MIB::udplite:
       oid: .1.3.6.1.2.1.170.1.1
       name: udplite.dgrms.in
       syntax: Counter64
+      metric: counter
     udpliteInPartialCov:
       oid: .1.3.6.1.2.1.170.1.2
       name: udplite.dgrms.partial_cover.in
       syntax: Counter64
+      metric: counter
     udpliteNoPorts:
       oid: .1.3.6.1.2.1.170.1.3
       name: udplite.dgrms.unkproto.in
       syntax: Counter32
+      metric: counter
     udpliteInErrors:
       oid: .1.3.6.1.2.1.170.1.4
       name: udplite.dgrms.error.in
       syntax: Counter32
+      metric: counter
     udpliteInBadChecksum:
       oid: .1.3.6.1.2.1.170.1.5
       name: udplite.dgrms.bad_checksum.in
       syntax: Counter32
+      metric: counter
     udpliteOutDatagrams:
       oid: .1.3.6.1.2.1.170.1.6
       name: udplite.dgrms.out
       syntax: Counter64
+      metric: counter
     udpliteOutPartialCov:
       oid: .1.3.6.1.2.1.170.1.7
       name: udplite.dgrms.partial_cover.out
       syntax: Counter64
+      metric: counter
     udpliteStatsDiscontinuityTime:
       oid: .1.3.6.1.2.1.170.1.9
       name: udplite.stats.discontinuity_time
       syntax: TimeStamp
+      metric: counter

--- a/objects/ietf/UPS-MIB.yml
+++ b/objects/ietf/UPS-MIB.yml
@@ -42,26 +42,32 @@ UPS-MIB::upsBattery:
       oid: .1.3.6.1.2.1.33.1.2.2
       name: ups.battery.time.on
       syntax: TicksSec
+      metric: counter
     upsEstimatedMinutesRemaining:
       oid: .1.3.6.1.2.1.33.1.2.3
       name: ups.battery.time.remain
       syntax: TicksMin
+      metric: gauge
     upsEstimatedChargeRemaining:
       oid: .1.3.6.1.2.1.33.1.2.4
       name: ups.battery.charge.remain
       syntax: Percent100
+      metric: gauge
     upsBatteryVoltage:
       oid: .1.3.6.1.2.1.33.1.2.5
       name: ups.battery.voltage.volts
       syntax: VoltageDeciVolt
+      metric: gauge
     upsBatteryCurrent:
       oid: .1.3.6.1.2.1.33.1.2.6
       name: ups.battery.current.amps
       syntax: CurrentDeciAmp
+      metric: gauge
     upsBatteryTemperature:
       oid: .1.3.6.1.2.1.33.1.2.7
       name: ups.battery.temp.degrees
       syntax: TemperatureC
+      metric: gauge
 
 UPS-MIB::upsInput:
   mib: UPS-MIB
@@ -73,10 +79,12 @@ UPS-MIB::upsInput:
       oid: .1.3.6.1.2.1.33.1.3.1
       name: ups.input.lines.out_of_tolerance
       syntax: Counter32
+      metric: counter
     upsInputNumLines:
       oid: .1.3.6.1.2.1.33.1.3.2
       name: ups.input.lines
       syntax: Integer
+      metric: gauge
 
 UPS-MIB::upsInputEntry:
   mib: UPS-MIB
@@ -92,18 +100,22 @@ UPS-MIB::upsInputEntry:
       oid: .1.3.6.1.2.1.33.1.3.3.1.2
       name: ups.input.freq.hertz
       syntax: FreqDeciHz
+      metric: gauge
     upsInputVoltage:
       oid: .1.3.6.1.2.1.33.1.3.3.1.3
       name: ups.input.voltage.volts
       syntax: VoltageVolt
+      metric: gauge
     upsInputCurrent:
       oid: .1.3.6.1.2.1.33.1.3.3.1.4
       name: ups.input.current.amps
       syntax: CurrentDeciAmp
+      metric: gauge
     upsInputTruePower:
       oid: .1.3.6.1.2.1.33.1.3.3.1.5
       name: ups.input.power.watts
       syntax: PowerWatt
+      metric: gauge
 
 UPS-MIB::upsOutput:
   mib: UPS-MIB
@@ -119,10 +131,12 @@ UPS-MIB::upsOutput:
       oid: .1.3.6.1.2.1.33.1.4.2
       name: ups.output.freq.hertz
       syntax: FreqDeciHz
+      metric: gauge
     upsOutputNumLines:
       oid: .1.3.6.1.2.1.33.1.4.3
       name: ups.output.lines
       syntax: Integer
+      metric: gauge
 
 UPS-MIB::upsOutputEntry:
   mib: UPS-MIB
@@ -138,18 +152,22 @@ UPS-MIB::upsOutputEntry:
       oid: .1.3.6.1.2.1.33.1.4.4.1.2
       name: ups.output.voltage.volts
       syntax: VoltageVolt
+      metric: gauge
     upsOutputCurrent:
       oid: .1.3.6.1.2.1.33.1.4.4.1.3
       name: ups.output.current.amps
       syntax: CurrentDeciAmp
+      metric: gauge
     upsOutputPower:
       oid: .1.3.6.1.2.1.33.1.4.4.1.4
       name: ups.output.power.watts
       syntax: PowerWatt
+      metric: gauge
     upsOutputPercentLoad:
       oid: .1.3.6.1.2.1.33.1.4.4.1.5
       name: ups.output.load.pct
       syntax: Percent100
+      metric: gauge
 
 UPS-MIB::upsBypass:
   mib: UPS-MIB
@@ -161,10 +179,12 @@ UPS-MIB::upsBypass:
       oid: .1.3.6.1.2.1.33.1.5.1
       name: ups.bypass.freq.hertz
       syntax: FreqDeciHz
+      metric: gauge
     upsBypassNumLines:
       oid: .1.3.6.1.2.1.33.1.5.2
       name: ups.bypass.lines
       syntax: Integer
+      metric: gauge
 
 UPS-MIB::upsBypassEntry:
   mib: UPS-MIB
@@ -180,14 +200,17 @@ UPS-MIB::upsBypassEntry:
       oid: .1.3.6.1.2.1.33.1.5.3.1.2
       name: ups.bypass.voltage.volts
       syntax: VoltageVolt
+      metric: gauge
     upsBypassCurrent:
       oid: .1.3.6.1.2.1.33.1.5.3.1.3
       name: ups.bypass.current.amps
       syntax: CurrentDeciAmp
+      metric: gauge
     upsBypassPower:
       oid: .1.3.6.1.2.1.33.1.5.3.1.4
       name: ups.bypass.power.watts
       syntax: PowerWatt
+      metric: gauge
 
 UPS-MIB::upsAlarm:
   mib: UPS-MIB
@@ -199,6 +222,7 @@ UPS-MIB::upsAlarm:
       oid: .1.3.6.1.2.1.33.1.6.1
       name: ups.alarms
       syntax: Gauge32
+      metric: gauge
 
 UPS-MIB::upsConfig:
   mib: UPS-MIB
@@ -210,30 +234,37 @@ UPS-MIB::upsConfig:
       oid: .1.3.6.1.2.1.33.1.9.1
       name: ups.input.admin.voltage.volts
       syntax: VoltageVolt
+      metric: gauge
     upsConfigInputFreq:
       oid: .1.3.6.1.2.1.33.1.9.2
       name: ups.input.admin.freq.hertz
       syntax: FreqDeciHz
+      metric: gauge
     upsConfigOutputVoltage:
       oid: .1.3.6.1.2.1.33.1.9.3
       name: ups.output.admin.voltage.volts
       syntax: VoltageVolt
+      metric: gauge
     upsConfigOutputFreq:
       oid: .1.3.6.1.2.1.33.1.9.4
       name: ups.output.admin.freq.hertz
       syntax: FreqDeciHz
+      metric: gauge
     upsConfigOutputVA:
       oid: .1.3.6.1.2.1.33.1.9.5
       name: ups.output.admin.power.va
       syntax: PowerWatt
+      metric: gauge
     upsConfigOutputPower:
       oid: .1.3.6.1.2.1.33.1.9.6
       name: ups.output.admin.power.watts
       syntax: PowerWatt
+      metric: gauge
     upsConfigLowBattTime:
       oid: .1.3.6.1.2.1.33.1.9.7
       name: ups.battery.low_remain
       syntax: TicksMin
+      metric: gauge
     upsConfigAudibleStatus:
       oid: .1.3.6.1.2.1.33.1.9.8
       name: ups.audible.admin.state
@@ -242,7 +273,9 @@ UPS-MIB::upsConfig:
       oid: .1.3.6.1.2.1.33.1.9.9
       name: ups.input.transfer.volts_low
       syntax: VoltageVolt
+      metric: gauge
     upsConfigHighVoltageTransferPoint:
       oid: .1.3.6.1.2.1.33.1.9.10
       name: ups.input.transfer.volts_high
       syntax: VoltageVolt
+      metric: gauge

--- a/objects/ietf/VPLS-GENERIC-MIB.yml
+++ b/objects/ietf/VPLS-GENERIC-MIB.yml
@@ -37,14 +37,17 @@ VPLS-GENERIC-MIB::vplsConfigEntry:
       oid: .1.3.6.1.2.1.10.274.1.2.1.10
       name: vpls.fwd.high_thresh
       syntax: Percent100
+      metric: gauge
     vplsConfigFwdFullLowWatermark:
       oid: .1.3.6.1.2.1.10.274.1.2.1.11
       name: vpls.fwd.low_thresh
       syntax: Percent100
+      metric: gauge
     vplsConfigMtu:
       oid: .1.3.6.1.2.1.10.274.1.2.1.13
       name: vpls.mtu
       syntax: Unsigned32
+      metric: gauge
     vplsConfigVpnId:
       oid: .1.3.6.1.2.1.10.274.1.2.1.14
       name: vpls.vpn.id
@@ -68,6 +71,7 @@ VPLS-GENERIC-MIB::vplsStatusEntry:
       oid: .1.3.6.1.2.1.10.274.1.3.1.2
       name: vpls.peers
       syntax: Counter32
+      metric: counter
 
 VPLS-GENERIC-MIB::vplsPwBindEntry:
   mib: VPLS-GENERIC-MIB

--- a/objects/ietf/VRRP-MIB.yml
+++ b/objects/ietf/VRRP-MIB.yml
@@ -38,10 +38,12 @@ VRRP-MIB::vrrpOperEntry:
       oid: .1.3.6.1.2.1.68.1.3.1.5
       name: vrrp.router.priority
       syntax: Unsigned32
+      metric: gauge
     vrrpOperIpAddrCount:
       oid: .1.3.6.1.2.1.68.1.3.1.6
       name: vrrp.router.ipaddrs
       syntax: Integer32
+      metric: gauge
     vrrpOperMasterIpAddr:
       oid: .1.3.6.1.2.1.68.1.3.1.7
       name: vrrp.router.master
@@ -62,6 +64,7 @@ VRRP-MIB::vrrpOperEntry:
       oid: .1.3.6.1.2.1.68.1.3.1.11
       name: vrrp.router.advert_interval
       syntax: OpTicksCentiSec
+      metric: gauge
     vrrpOperPreemptMode:
       oid: .1.3.6.1.2.1.68.1.3.1.12
       name: vrrp.router.preempt.mode
@@ -84,14 +87,17 @@ VRRP-MIB::vrrpStatistics:
       oid: .1.3.6.1.2.1.68.2.1
       name: vrrp.errors.checksum
       syntax: Counter32
+      metric: counter
     vrrpRouterVersionErrors:
       oid: .1.3.6.1.2.1.68.2.2
       name: vrrp.errors.version
       syntax: Counter32
+      metric: counter
     vrrpRouterVrIdErrors:
       oid: .1.3.6.1.2.1.68.2.3
       name: vrrp.errors.vrid
       syntax: Counter32
+      metric: counter
 
 VRRP-MIB::vrrpRouterStatsEntry:
   mib: VRRP-MIB
@@ -103,47 +109,59 @@ VRRP-MIB::vrrpRouterStatsEntry:
       oid: .1.3.6.1.2.1.68.2.4.1.1
       name: vrrp.router.master_transitions
       syntax: Counter32
+      metric: counter
     vrrpStatsAdvertiseRcvd:
       oid: .1.3.6.1.2.1.68.2.4.1.2
       name: vrrp.router.adverts.in
       syntax: Counter32
+      metric: counter
     vrrpStatsAdvertiseIntervalErrors:
       oid: .1.3.6.1.2.1.68.2.4.1.3
       name: vrrp.router.errors.advert_interval
       syntax: Counter32
+      metric: counter
     vrrpStatsAuthFailures:
       oid: .1.3.6.1.2.1.68.2.4.1.4
       name: vrrp.router.auth.fails
       syntax: Counter32
+      metric: counter
     vrrpStatsIpTtlErrors:
       oid: .1.3.6.1.2.1.68.2.4.1.5
       name: vrrp.router.errors.ip_ttl
       syntax: Counter32
+      metric: counter
     vrrpStatsPriorityZeroPktsRcvd:
       oid: .1.3.6.1.2.1.68.2.4.1.6
       name: vrrp.router.packets.priority_zero.in
       syntax: Counter32
+      metric: counter
     vrrpStatsPriorityZeroPktsSent:
       oid: .1.3.6.1.2.1.68.2.4.1.7
       name: vrrp.router.packets.priority_zero.out
       syntax: Counter32
+      metric: counter
     vrrpStatsInvalidTypePktsRcvd:
       oid: .1.3.6.1.2.1.68.2.4.1.8
       name: vrrp.router.packets.invalid_type.in
       syntax: Counter32
+      metric: counter
     vrrpStatsAddressListErrors:
       oid: .1.3.6.1.2.1.68.2.4.1.9
       name: vrrp.router.errors.addr_list
       syntax: Counter32
+      metric: counter
     vrrpStatsInvalidAuthType:
       oid: .1.3.6.1.2.1.68.2.4.1.10
       name: vrrp.router.auth.type_invalids
       syntax: Counter32
+      metric: counter
     vrrpStatsAuthTypeMismatch:
       oid: .1.3.6.1.2.1.68.2.4.1.11
       name: vrrp.router.auth.type_mismatches
       syntax: Counter32
+      metric: counter
     vrrpStatsPacketLengthErrors:
       oid: .1.3.6.1.2.1.68.2.4.1.12
       name: vrrp.router.errors.packet_size
       syntax: Counter32
+      metric: counter

--- a/objects/ietf/VRRPV3-MIB.yml
+++ b/objects/ietf/VRRPV3-MIB.yml
@@ -36,14 +36,17 @@ VRRPV3-MIB::vrrpv3OperationsEntry:
       oid: .1.3.6.1.2.1.207.1.1.1.1.7
       name: vrrp.router.priority
       syntax: Unsigned32
+      metric: gauge
     vrrpv3OperationsAddrCount:
       oid: .1.3.6.1.2.1.207.1.1.1.1.8
       name: vrrp.router.ipaddrs
       syntax: Integer32
+      metric: gauge
     vrrpv3OperationsAdvInterval:
       oid: .1.3.6.1.2.1.207.1.1.1.1.9
       name: vrrp.router.advert_interval
       syntax: OpTicksCentiSec
+      metric: gauge
     vrrpv3OperationsPreemptMode:
       oid: .1.3.6.1.2.1.207.1.1.1.1.10
       name: vrrp.router.preempt.mode
@@ -56,6 +59,7 @@ VRRPV3-MIB::vrrpv3OperationsEntry:
       oid: .1.3.6.1.2.1.207.1.1.1.1.12
       name: vrrp.router.uptime
       syntax: TimeTicks
+      metric: counter
 
 VRRPV3-MIB::vrrpv3Statistics:
   mib: VRRPV3-MIB
@@ -66,14 +70,17 @@ VRRPV3-MIB::vrrpv3Statistics:
       oid: .1.3.6.1.2.1.207.1.2.1
       name: vrrp.errors.checksum
       syntax: Counter64
+      metric: counter
     vrrpv3RouterVersionErrors:
       oid: .1.3.6.1.2.1.207.1.2.2
       name: vrrp.errors.version
       syntax: Counter64
+      metric: counter
     vrrpv3RouterVrIdErrors:
       oid: .1.3.6.1.2.1.207.1.2.3
       name: vrrp.errors.vrid
       syntax: Counter64
+      metric: counter
     vrrpv3GlobalStatisticsDiscontinuityTime:
       oid: .1.3.6.1.2.1.207.1.2.4
       name: vrrp.stats.discontinuity_time
@@ -89,6 +96,7 @@ VRRPV3-MIB::vrrpv3StatisticsEntry:
       oid: .1.3.6.1.2.1.207.1.2.5.1.1
       name: vrrp.router.master_transitions
       syntax: Counter32
+      metric: counter
     vrrpv3StatisticsNewMasterReason:
       oid: .1.3.6.1.2.1.207.1.2.5.1.2
       name: vrrp.router.new_master.reason
@@ -97,14 +105,17 @@ VRRPV3-MIB::vrrpv3StatisticsEntry:
       oid: .1.3.6.1.2.1.207.1.2.5.1.3
       name: vrrp.router.adverts.in
       syntax: Counter64
+      metric: counter
     vrrpv3StatisticsAdvIntervalErrors:
       oid: .1.3.6.1.2.1.207.1.2.5.1.4
       name: vrrp.router.errors.advert_interval
       syntax: Counter64
+      metric: counter
     vrrpv3StatisticsIpTtlErrors:
       oid: .1.3.6.1.2.1.207.1.2.5.1.5
       name: vrrp.router.errors.ip_ttl
       syntax: Counter64
+      metric: counter
     vrrpv3StatisticsProtoErrReason:
       oid: .1.3.6.1.2.1.207.1.2.5.1.6
       name: vrrp.router.proto_error.reason
@@ -113,22 +124,27 @@ VRRPV3-MIB::vrrpv3StatisticsEntry:
       oid: .1.3.6.1.2.1.207.1.2.5.1.7
       name: vrrp.router.packets.priority_zero.in
       syntax: Counter64
+      metric: counter
     vrrpv3StatisticsSentPriZeroPackets:
       oid: .1.3.6.1.2.1.207.1.2.5.1.8
       name: vrrp.router.packets.priority_zero.out
       syntax: Counter64
+      metric: counter
     vrrpv3StatisticsRcvdInvalidTypePackets:
       oid: .1.3.6.1.2.1.207.1.2.5.1.9
       name: vrrp.router.packets.invalid_type.in
       syntax: Counter64
+      metric: counter
     vrrpv3StatisticsAddressListErrors:
       oid: .1.3.6.1.2.1.207.1.2.5.1.10
       name: vrrp.router.errors.addr_list
       syntax: Counter64
+      metric: counter
     vrrpv3StatisticsPacketLengthErrors:
       oid: .1.3.6.1.2.1.207.1.2.5.1.11
       name: vrrp.router.errors.packet_size
       syntax: Counter64
+      metric: counter
     vrrpv3StatisticsRowDiscontinuityTime:
       oid: .1.3.6.1.2.1.207.1.2.5.1.12
       name: vrrp.router.discontinuity_time
@@ -137,3 +153,4 @@ VRRPV3-MIB::vrrpv3StatisticsEntry:
       oid: .1.3.6.1.2.1.207.1.2.5.1.13
       name: vrrp.router.refresh_interval
       syntax: OpTicksMilliSec
+      metric: gauge

--- a/objects/juniper/BGP4-V2-MIB-JUNIPER.yml
+++ b/objects/juniper/BGP4-V2-MIB-JUNIPER.yml
@@ -127,10 +127,12 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerErrorsEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.2.1.1.3
       name: bgp.peer.last_error.time.in
       syntax: TimeTicks
+      metric: counter
     jnxBgpM2PeerLastErrorSentTime:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.2.1.1.4
       name: bgp.peer.last_error.time.out
       syntax: TimeTicks
+      metric: counter
     jnxBgpM2PeerLastErrorReceivedText:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.2.1.1.5
       name: bgp.peer.last_error.text.in
@@ -189,10 +191,12 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerEventTimesEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.4.1.1.1
       name: bgp.peer.fsm.established.duration
       syntax: Gauge32
+      metric: gauge
     jnxBgpM2PeerInUpdatesElapsedTime:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.4.1.1.2
       name: bgp.peer.last_update.elapsed
       syntax: Gauge32
+      metric: gauge
 
 BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerConfiguredTimersEntry:
   mib: BGP4-V2-MIB-JUNIPER
@@ -204,22 +208,27 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerConfiguredTimersEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.4.2.1.1
       name: bgp.peer.connect_retry.config.interval
       syntax: Unsigned32
+      metric: gauge
     jnxBgpM2PeerHoldTimeConfigured:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.4.2.1.2
       name: bgp.peer.hold_time.config.interval
       syntax: Unsigned32
+      metric: gauge
     jnxBgpM2PeerKeepAliveConfigured:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.4.2.1.3
       name: bgp.peer.keep_alive.config.interval
       syntax: Unsigned32
+      metric: gauge
     jnxBgpM2PeerMinASOrigInterval:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.4.2.1.4
       name: bgp.peer.min_as_origin.config.interval
       syntax: Unsigned32
+      metric: gauge
     jnxBgpM2PeerMinRouteAdverInterval:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.4.2.1.5
       name: bgp.peer.min_route_advert.config.interval
       syntax: Unsigned32
+      metric: gauge
 
 BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerNegotiatedTimersEntry:
   mib: BGP4-V2-MIB-JUNIPER
@@ -231,10 +240,12 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerNegotiatedTimersEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.4.3.1.1
       name: bgp.peer.hold_time.interval
       syntax: Unsigned32
+      metric: gauge
     jnxBgpM2PeerKeepAlive:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.4.3.1.2
       name: bgp.peer.keep_alive.interval
       syntax: Unsigned32
+      metric: gauge
 
 BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerCountersEntry:
   mib: BGP4-V2-MIB-JUNIPER
@@ -246,22 +257,27 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerCountersEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.1.1.1
       name: bgp.peer.msgs.update.in
       syntax: Counter32
+      metric: counter
     jnxBgpM2PeerOutUpdates:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.1.1.2
       name: bgp.peer.msgs.update.out
       syntax: Counter32
+      metric: counter
     jnxBgpM2PeerInTotalMessages:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.1.1.3
       name: bgp.peer.msgs.in
       syntax: Counter32
+      metric: counter
     jnxBgpM2PeerOutTotalMessages:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.1.1.4
       name: bgp.peer.msgs.out
       syntax: Counter32
+      metric: counter
     jnxBgpM2PeerFsmEstablishedTrans:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.1.1.5
       name: bgp.peer.fsm.established.transitions
       syntax: Counter32
+      metric: counter
 
 BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixCountersEntry:
   mib: BGP4-V2-MIB-JUNIPER
@@ -285,22 +301,27 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2PrefixCountersEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.2.1.7
       name: bgp.prefixes.in
       syntax: Gauge32
+      metric: gauge
     jnxBgpM2PrefixInPrefixesAccepted:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.2.1.8
       name: bgp.prefixes.accept.in
       syntax: Gauge32
+      metric: gauge
     jnxBgpM2PrefixInPrefixesRejected:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.2.1.9
       name: bgp.prefixes.reject.in
       syntax: Gauge32
+      metric: gauge
     jnxBgpM2PrefixOutPrefixes:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.2.1.10
       name: bgp.prefixes.out
       syntax: Gauge32
+      metric: gauge
     jnxBgpM2PrefixInPrefixesActive:
       oid: .1.3.6.1.4.1.2636.5.1.1.2.6.2.1.11
       name: bgp.prefixes.active.in
       syntax: Gauge32
+      metric: gauge
 
 BGP4-V2-MIB-JUNIPER::jnxBgpM2PeerReflectorClientEntry:
   mib: BGP4-V2-MIB-JUNIPER
@@ -362,6 +383,7 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2NlriEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.3.1.1.7
       name: bgp.nlri.local_pref_calc
       syntax: Unsigned32
+      metric: gauge
     jnxBgpM2PathAttrIndex:
       oid: .1.3.6.1.4.1.2636.5.1.1.3.1.1.8
       tag: true
@@ -390,10 +412,12 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2PathAttrEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.3.4.1.5
       name: bgp.nlri.path_attr.med
       syntax: Unsigned32
+      metric: gauge
     jnxBgpM2PathAttrLocalPref:
       oid: .1.3.6.1.4.1.2636.5.1.1.3.4.1.7
       name: bgp.nlri.path_attr.local_pref
       syntax: Unsigned32
+      metric: gauge
     jnxBgpM2PathAttrAtomicAggregate:
       oid: .1.3.6.1.4.1.2636.5.1.1.3.4.1.8
       name: bgp.nlri.path_attr.atomic_aggregate
@@ -410,6 +434,7 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2PathAttrEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.3.4.1.11
       name: bgp.as_path.hop_count
       syntax: Unsigned32
+      metric: gauge
     jnxBgpM2AsPathString:
       oid: .1.3.6.1.4.1.2636.5.1.1.3.4.1.12
       name: bgp.as_path.path
@@ -436,6 +461,7 @@ BGP4-V2-MIB-JUNIPER::jnxBgpM2AsPath4byteEntry:
       oid: .1.3.6.1.4.1.2636.5.1.1.3.5.1.3
       name: bgp.as_path.hop_count
       syntax: Unsigned32
+      metric: gauge
       overrides:
         object: BGP4-V2-MIB-JUNIPER::jnxBgpM2PathAttrEntry
         attribute: jnxBgpM2AsPathCalcLength

--- a/objects/juniper/OSPFV3-MIB-JUNIPER.yml
+++ b/objects/juniper/OSPFV3-MIB-JUNIPER.yml
@@ -29,6 +29,7 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3GeneralGroup:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.6
       name: ospf.lsdb.as_scope.lsas
       syntax: Gauge32
+      metric: gauge
     jnxOspfv3AsScopeLsaCksumSum:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.7
       name: ospf.lsdb.as_scope.checksum
@@ -37,18 +38,22 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3GeneralGroup:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.8
       name: ospf.lsas.new.out
       syntax: Counter32
+      metric: counter
     jnxOspfv3RxNewLsas:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.9
       name: ospf.lsas.new.in
       syntax: Counter32
+      metric: counter
     jnxOspfv3ExtLsaCount:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.10
       name: ospf.lsdb.as_extern.lsas
       syntax: Gauge32
+      metric: gauge
     jnxOspfv3ExtAreaLsdbLimit:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.11
       name: ospf.lsdb.as_extern.limit
       syntax: Integer32
+      metric: gauge
     jnxOspfv3MulticastExtensions:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.12
       name: ospf.mcast.ext
@@ -57,6 +62,7 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3GeneralGroup:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.13
       name: ospf.lsdb.as_extern.overflow_interval
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3DemandExtensions:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.14
       name: ospf.demand.support
@@ -65,6 +71,7 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3GeneralGroup:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.15
       name: ospf.reference_bandwidth
       syntax: BandwidthKBits
+      metric: gauge
     jnxOspfv3RestartSupport:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.16
       name: ospf.graceful_restart.support
@@ -73,6 +80,7 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3GeneralGroup:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.17
       name: ospf.graceful_restart.interval
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3RestartStatus:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.18
       name: ospf.graceful_restart.state
@@ -81,6 +89,7 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3GeneralGroup:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.19
       name: ospf.graceful_restart.age
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3RestartExitRc:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.1.20
       name: ospf.graceful_restart.exit_reason
@@ -104,18 +113,22 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3AreaEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.3
       name: ospf.area.spf.runs
       syntax: Counter32
+      metric: counter
     jnxOspfv3AreaBdrRtrCount:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.4
       name: ospf.area.area_border_routers
       syntax: Gauge32
+      metric: gauge
     jnxOspfv3AreaAsBdrRtrCount:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.5
       name: ospf.area.as_border_routers
       syntax: Gauge32
+      metric: gauge
     jnxOspfv3AreaScopeLsaCount:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.6
       name: ospf.area.lsdb.area_scope.lsas
       syntax: Gauge32
+      metric: gauge
     jnxOspfv3AreaScopeLsaCksumSum:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.7
       name: ospf.area.lsdb.area_scope.checksum
@@ -128,6 +141,7 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3AreaEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.10
       name: ospf.area.stub.metric.value
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3AreaNssaTranslatorRole:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.11
       name: ospf.area.nssa_translator.role
@@ -140,10 +154,12 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3AreaEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.13
       name: ospf.area.nssa_translator.stability_interval
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3AreaNssaTranslatorEvents:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.14
       name: ospf.area.nssa_translator.events
       syntax: Counter32
+      metric: counter
     jnxOspfv3AreaStubMetricType:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.2.1.15
       name: ospf.area.stub.metric.type
@@ -181,26 +197,32 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3IfEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.6
       name: ospf.netif.designated_router.priority
       syntax: Integer32
+      metric: gauge
     jnxOspfv3IfTransitDelay:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.7
       name: ospf.netif.lsa.transit_delay
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3IfRetransInterval:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.8
       name: ospf.netif.lsa.retrans_interval
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3IfHelloInterval:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.9
       name: ospf.netif.hello_interval
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3IfRtrDeadInterval:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.10
       name: ospf.netif.router_dead_interval
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3IfPollInterval:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.11
       name: ospf.netif.poll_interval
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3IfState:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.12
       name: ospf.netif.state
@@ -217,22 +239,25 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3IfEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.15
       name: ospf.netif.state.chgs
       syntax: Counter32
+      metric: counter
     jnxOspfv3IfMulticastForwarding:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.17
       name: ospf.netif.mcast.fwd
       syntax: EnumInteger
     jnxOspfv3IfDemand:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.18
-      name: ospf.netif.demand.state
+      name: ospf.netif.demand
       syntax: TruthValue
     jnxOspfv3IfMetricValue:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.19
       name: ospf.netif.metric
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3IfLinkScopeLsaCount:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.20
       name: ospf.netif.lsdb.link_scope.lsas
       syntax: Gauge32
+      metric: gauge
     jnxOspfv3IfLinkLsaCksumSum:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.21
       name: ospf.netif.lsdb.link_scope.checksum
@@ -245,10 +270,12 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3IfEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.23
       name: ospf.netif.neighbor.probe.retrans_limit
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3IfDemandNbrProbeInterval:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.7.1.24
       name: ospf.netif.neighbor.probe_interval
       syntax: Unsigned32
+      metric: gauge
 
 OSPFV3-MIB-JUNIPER::jnxOspfv3VirtIfEntry:
   mib: OSPFV3-MIB-JUNIPER
@@ -277,18 +304,22 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3VirtIfEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.8.1.5
       name: ospf.virt_netif.lsa.transit_delay
       syntax: TicksSec
+      metric: gauge
     jnxOspfv3VirtIfRetransInterval:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.8.1.6
       name: ospf.virt_netif.lsa.retrans_interval
       syntax: TicksSec
+      metric: gauge
     jnxOspfv3VirtIfHelloInterval:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.8.1.7
       name: ospf.virt_netif.hello_interval
       syntax: TicksSec
+      metric: gauge
     jnxOspfv3VirtIfRtrDeadInterval:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.8.1.8
       name: ospf.virt_netif.router_dead_interval
       syntax: TicksSec
+      metric: gauge
     jnxOspfv3VirtIfState:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.8.1.9
       name: ospf.virt_netif.state
@@ -297,10 +328,12 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3VirtIfEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.8.1.10
       name: ospf.virt_netif.state.chgs
       syntax: Counter32
+      metric: counter
     jnxOspfv3VirtIfLinkScopeLsaCount:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.8.1.12
       name: ospf.virt_netif.lsdb.link_scope.lsas
       syntax: Gauge32
+      metric: gauge
     jnxOspfv3VirtIfLinkLsaCksumSum:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.8.1.13
       name: ospf.virt_netif.lsdb.link_scope.checksum
@@ -337,6 +370,7 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3NbrEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.9.1.7
       name: ospf.neighbor.designated_router.priority
       syntax: Integer32
+      metric: gauge
     jnxOspfv3NbrState:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.9.1.8
       name: ospf.neighbor.state
@@ -345,10 +379,12 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3NbrEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.9.1.9
       name: ospf.neighbor.state.changes
       syntax: Counter32
+      metric: counter
     jnxOspfv3NbrLsRetransQLen:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.9.1.10
       name: ospf.neighbor.link_state_retrans_queue
       syntax: Gauge32
+      metric: gauge
     jnxOspfv3NbrHelloSuppressed:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.9.1.11
       name: ospf.neighbor.hello_suppress
@@ -365,6 +401,7 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3NbrEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.9.1.14
       name: ospf.neighbor.graceful_restart.helper.age
       syntax: Unsigned32
+      metric: gauge
     jnxOspfv3NbrRestartHelperExitRc:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.9.1.15
       name: ospf.neighbor.graceful_restart.helper.exit_reason
@@ -411,10 +448,12 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3VirtNbrEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.11.1.9
       name: ospf.virt_neighbor.state.changes
       syntax: Counter32
+      metric: counter
     jnxOspfv3VirtNbrLsRetransQLen:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.11.1.10
       name: ospf.virt_neighbor.link_state_retrans_queue
       syntax: Gauge32
+      metric: gauge
     jnxOspfv3VirtNbrHelloSuppressed:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.11.1.11
       name: ospf.virt_neighbor.hello_suppress
@@ -431,6 +470,7 @@ OSPFV3-MIB-JUNIPER::jnxOspfv3VirtNbrEntry:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.11.1.14
       name: ospf.virt_neighbor.graceful_restart.helper.age
       syntax: TicksSec
+      metric: gauge
     jnxOspfv3VirtNbrRestartHelperExitRc:
       oid: .1.3.6.1.4.1.2636.5.4.1.1.11.1.15
       name: ospf.virt_neighbor.graceful_restart.helper.exit_reason


### PR DESCRIPTION
Adding support for TSDS in snmpcoll for IETF objects.

In order to make sure that Elasticsearch TSDS works for snmp collector, we have to inform Elasticsearch what type of data it is: counter or gauge. This is needed by Elasticsearch so that it can downsample correctly.

