### PR TITLE
chore: Add "All Checks" CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,16 @@ jobs:
     secrets:
       build_gpg_key: ${{ secrets.GPG_KEY }}
       build_gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+  all_checks:
+    name: All Checks
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - go_checks
+      - validate
+    steps:
+      - name: Check if all checks passed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Add "All Checks" CI job to make it easier to add CI checks to "required" for a PR in the GitHub settings