### PR TITLE
allow a suffix on enum OIDs

### DIFF
--- a/pkg/reader/utils.go
+++ b/pkg/reader/utils.go
@@ -40,7 +40,7 @@ func isYamlFile(filePath string) bool {
 	return yamlExtension.MatchString(filePath)
 }
 
-var oidRegex = regexp.MustCompile(`^\.?[0-9]+(\.[0-9]+)*$`)
+var oidRegex = regexp.MustCompile(`^\.?[0-9]+(\.[0-9]+)*(_[a-zA-Z0-9]+)?$`)
 
 func isValidOID(oid string) bool {
 	return oidRegex.MatchString(oid)

--- a/pkg/reader/utils_test.go
+++ b/pkg/reader/utils_test.go
@@ -19,6 +19,11 @@ func TestIsValidOID(t *testing.T) {
 		},
 		{
 			name: "invalid oid",
+			oid:  "1.3.6.1.2.1.1.1.0_rawTest2",
+			want: true,
+		},
+		{
+			name: "invalid oid",
 			oid:  "1.3.6.1.2.1.1.1.0.0.",
 			want: false,
 		},


### PR DESCRIPTION
For SNMP trap there are use-cases for having both the original and "pretty" version of enumerated values. So we need to do something like...

```yaml
.1.3.6.1.4.1.9.9.5.23_raw:
  1: 'rawEnumValue1'
  2: 'rawEnumValue2'

.1.3.6.1.4.1.9.9.5.23:
  1: 'pretty enum value 1' # rawEnumValue1
  2: 'pretty enum value 2' # rawEnumValue2
```

The collector handles this without issue as the OID is just  handled as a `string`. However the validator checked specifically for just decimal values and dots. This change to the validator regex also allows for a suffix of lower and uppercase characters and decimal values, without spaces or special characters, preceded by an underscore.
