### PR TITLE
feat: Add ObjectTypeDefinition with validation and tests

### DIFF
--- a/pkg/def/objecttype.go
+++ b/pkg/def/objecttype.go
@@ -1,0 +1,85 @@
+package def
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ObjectTypeDefinition represents the structure of object_types.yml
+type ObjectTypeDefinition struct {
+	ObjectTypes         []ObjectTypeConfig `yaml:"object_types,omitempty" json:"object_types,omitempty"`
+	DefaultPollInterval uint64             `yaml:"default_poll_interval,omitempty" json:"default_poll_interval,omitempty"`
+}
+
+// ObjectTypeConfig represents a single object type configuration
+type ObjectTypeConfig struct {
+	Name                string `yaml:"name" json:"name"`
+	Description         string `yaml:"description,omitempty" json:"description,omitempty"`
+	DefaultPollInterval uint64 `yaml:"default_poll_interval" json:"default_poll_interval"`
+}
+
+// Validate validates the object types definition against its JSON schema.
+func (o ObjectTypeDefinition) Validate() error {
+	return validate(o, "schemas/object_types.json")
+}
+
+// ValidObjectTypes returns a slice of valid object type names
+func (o ObjectTypeDefinition) ValidObjectTypes() []string {
+	validTypes := make([]string, 0, len(o.ObjectTypes))
+	for _, objType := range o.ObjectTypes {
+		validTypes = append(validTypes, objType.Name)
+	}
+	return validTypes
+}
+
+// IsValidObjectType checks if the given object type is valid
+func (o ObjectTypeDefinition) IsValidObjectType(objectType string) bool {
+	if objectType == "" {
+		return true // Empty type is allowed (will use default)
+	}
+	for _, objType := range o.ObjectTypes {
+		if objType.Name == objectType {
+			return true
+		}
+	}
+	return false
+}
+
+// DefaultPollIntervalForType returns the default polling interval for a specific object type
+func (o ObjectTypeDefinition) DefaultPollIntervalForType(objectType string) uint64 {
+	if objectType == "" {
+		return o.DefaultPollInterval
+	}
+	for _, objType := range o.ObjectTypes {
+		if objType.Name == objectType {
+			return objType.DefaultPollInterval
+		}
+	}
+	return o.DefaultPollInterval
+}
+
+// ValidateObjectType validates that an object type is valid and returns an error if not
+func (o ObjectTypeDefinition) ValidateObjectType(objectType string) error {
+	if objectType == "" {
+		return nil // Empty type is allowed (will use defaults to ensure backwards compatibility)
+	}
+	if !o.IsValidObjectType(objectType) {
+		validTypes := o.ValidObjectTypes()
+		return fmt.Errorf("invalid object type '%s'. Valid types are: %s",
+			objectType, strings.Join(validTypes, ", "))
+	}
+	return nil
+}
+
+// ValidatePollIntervals validates that all poll interval keys are valid object types
+func (o ObjectTypeDefinition) ValidatePollIntervals(pollIntervals map[string]uint64) error {
+	if pollIntervals == nil {
+		return nil
+	}
+	for objectType := range pollIntervals {
+		if err := o.ValidateObjectType(objectType); err != nil {
+			return fmt.Errorf("invalid poll interval key: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/def/objecttype_test.go
+++ b/pkg/def/objecttype_test.go
@@ -1,0 +1,383 @@
+package def
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestObjectTypeDefinition_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		def     ObjectTypeDefinition
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			def: ObjectTypeDefinition{
+				DefaultPollInterval: 60,
+				ObjectTypes: []ObjectTypeConfig{
+					{Name: "interfaces", Description: "Interface-related objects", DefaultPollInterval: 60},
+					{Name: "routes", DefaultPollInterval: 300},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			def: ObjectTypeDefinition{
+				ObjectTypes: []ObjectTypeConfig{
+					{Name: "", DefaultPollInterval: 60},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty list",
+			def: ObjectTypeDefinition{
+				ObjectTypes: []ObjectTypeConfig{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-positive interval",
+			def: ObjectTypeDefinition{
+				ObjectTypes: []ObjectTypeConfig{
+					{Name: "bad", DefaultPollInterval: 0},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc // capture range var
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel() // safe: each case uses its own value
+
+			err := tc.def.Validate()
+
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestObjectTypeDefinition_GetValidObjectTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		otd      ObjectTypeDefinition
+		expected []string
+	}{
+		{
+			name: "empty object types",
+			otd: ObjectTypeDefinition{
+				ObjectTypes: []ObjectTypeConfig{},
+			},
+			expected: []string{},
+		},
+		{
+			name: "multiple object types",
+			otd: ObjectTypeDefinition{
+				ObjectTypes: []ObjectTypeConfig{
+					{Name: "configuration"},
+					{Name: "telemetry"},
+					{Name: "status"},
+					{Name: "performance"},
+				},
+			},
+			expected: []string{"configuration", "telemetry", "status", "performance"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.otd.ValidObjectTypes()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestObjectTypeDefinition_IsValidObjectType(t *testing.T) {
+	otd := ObjectTypeDefinition{
+		ObjectTypes: []ObjectTypeConfig{
+			{Name: "configuration"},
+			{Name: "telemetry"},
+			{Name: "status"},
+			{Name: "performance"},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		objectType string
+		expected   bool
+	}{
+		{
+			name:       "valid object type",
+			objectType: "configuration",
+			expected:   true,
+		},
+		{
+			name:       "valid object type - telemetry",
+			objectType: "telemetry",
+			expected:   true,
+		},
+		{
+			name:       "invalid object type",
+			objectType: "invalid_type",
+			expected:   false,
+		},
+		{
+			name:       "empty object type",
+			objectType: "",
+			expected:   true, // Empty type is allowed
+		},
+		{
+			name:       "case sensitive",
+			objectType: "Configuration",
+			expected:   false, // Case sensitive
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := otd.IsValidObjectType(tt.objectType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestObjectTypeDefinition_GetDefaultPollIntervalForType(t *testing.T) {
+	otd := ObjectTypeDefinition{
+		ObjectTypes: []ObjectTypeConfig{
+			{Name: "configuration", DefaultPollInterval: 86400},
+			{Name: "telemetry", DefaultPollInterval: 60},
+			{Name: "status", DefaultPollInterval: 300},
+			{Name: "performance", DefaultPollInterval: 120},
+		},
+		DefaultPollInterval: 300,
+	}
+
+	tests := []struct {
+		name       string
+		objectType string
+		expected   uint64
+	}{
+		{
+			name:       "configuration type",
+			objectType: "configuration",
+			expected:   86400,
+		},
+		{
+			name:       "telemetry type",
+			objectType: "telemetry",
+			expected:   60,
+		},
+		{
+			name:       "status type",
+			objectType: "status",
+			expected:   300,
+		},
+		{
+			name:       "performance type",
+			objectType: "performance",
+			expected:   120,
+		},
+		{
+			name:       "empty type",
+			objectType: "",
+			expected:   300, // Default poll interval
+		},
+		{
+			name:       "invalid type",
+			objectType: "invalid",
+			expected:   300, // Default poll interval
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := otd.DefaultPollIntervalForType(tt.objectType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestObjectTypeDefinition_ValidateObjectType(t *testing.T) {
+	otd := ObjectTypeDefinition{
+		ObjectTypes: []ObjectTypeConfig{
+			{Name: "configuration"},
+			{Name: "telemetry"},
+			{Name: "status"},
+			{Name: "performance"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		objectType  string
+		expectError bool
+	}{
+		{
+			name:        "valid object type",
+			objectType:  "configuration",
+			expectError: false,
+		},
+		{
+			name:        "valid object type - telemetry",
+			objectType:  "telemetry",
+			expectError: false,
+		},
+		{
+			name:        "empty object type",
+			objectType:  "",
+			expectError: false,
+		},
+		{
+			name:        "invalid object type",
+			objectType:  "invalid_type",
+			expectError: true,
+		},
+		{
+			name:        "case sensitive invalid",
+			objectType:  "Configuration",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := otd.ValidateObjectType(tt.objectType)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid object type")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestObjectTypeDefinition_ValidatePollIntervals(t *testing.T) {
+	otd := ObjectTypeDefinition{
+		ObjectTypes: []ObjectTypeConfig{
+			{Name: "configuration"},
+			{Name: "telemetry"},
+			{Name: "status"},
+			{Name: "performance"},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		pollIntervals map[string]uint64
+		expectError   bool
+	}{
+		{
+			name: "valid poll intervals",
+			pollIntervals: map[string]uint64{
+				"configuration": 86400,
+				"telemetry":     60,
+				"status":        300,
+				"performance":   120,
+			},
+			expectError: false,
+		},
+		{
+			name:          "nil poll intervals",
+			pollIntervals: nil,
+			expectError:   false,
+		},
+		{
+			name:          "empty poll intervals",
+			pollIntervals: map[string]uint64{},
+			expectError:   false,
+		},
+		{
+			name: "invalid poll interval key",
+			pollIntervals: map[string]uint64{
+				"configuration": 86400,
+				"invalid_type":  300,
+			},
+			expectError: true,
+		},
+		{
+			name: "multiple invalid keys",
+			pollIntervals: map[string]uint64{
+				"invalid_type1": 86400,
+				"invalid_type2": 300,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := otd.ValidatePollIntervals(tt.pollIntervals)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid poll interval key")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestObjectTypeDefinition_YAMLUnmarshal(t *testing.T) {
+	yamlContent := `
+object_types:
+  - name: configuration
+    description: "Static objects that describe how the device is configured"
+    default_poll_interval: 86400
+  - name: telemetry
+    description: "Dynamic objects that provide real-time telemetry data"
+    default_poll_interval: 60
+  - name: status
+    description: "Objects that indicate device or interface status"
+    default_poll_interval: 300
+  - name: performance
+    description: "Objects that provide performance metrics"
+    default_poll_interval: 120
+default_poll_interval: 300
+`
+
+	var otd ObjectTypeDefinition
+	err := yaml.Unmarshal([]byte(yamlContent), &otd)
+	require.NoError(t, err)
+
+	assert.Len(t, otd.ObjectTypes, 4)
+	assert.Equal(t, uint64(300), otd.DefaultPollInterval)
+
+	// Test individual object types
+	assert.Equal(t, "configuration", otd.ObjectTypes[0].Name)
+	assert.Equal(t, uint64(86400), otd.ObjectTypes[0].DefaultPollInterval)
+	assert.Equal(t, "Static objects that describe how the device is configured", otd.ObjectTypes[0].Description)
+
+	assert.Equal(t, "telemetry", otd.ObjectTypes[1].Name)
+	assert.Equal(t, uint64(60), otd.ObjectTypes[1].DefaultPollInterval)
+
+	assert.Equal(t, "status", otd.ObjectTypes[2].Name)
+	assert.Equal(t, uint64(300), otd.ObjectTypes[2].DefaultPollInterval)
+
+	assert.Equal(t, "performance", otd.ObjectTypes[3].Name)
+	assert.Equal(t, uint64(120), otd.ObjectTypes[3].DefaultPollInterval)
+
+	// Test validation methods
+	assert.True(t, otd.IsValidObjectType("configuration"))
+	assert.True(t, otd.IsValidObjectType("telemetry"))
+	assert.False(t, otd.IsValidObjectType("invalid"))
+
+	err = otd.ValidateObjectType("configuration")
+	assert.NoError(t, err)
+
+	err = otd.ValidateObjectType("invalid")
+	assert.Error(t, err)
+}

--- a/pkg/def/schemas/object_types.json
+++ b/pkg/def/schemas/object_types.json
@@ -1,0 +1,37 @@
+{
+  "$id": "object_types_schema",
+  "title": "Object Types Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "default_poll_interval": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Default polling interval (seconds) used when a specific type isn't matched."
+    },
+    "object_types": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "default_poll_interval"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "default_poll_interval": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Polling interval (seconds) for this object type."
+          }
+        }
+      }
+    }
+  },
+  "required": ["object_types"]
+}


### PR DESCRIPTION
## Summary

Introduce `ObjectTypeDefinition` to model the **object types** configuration for the ElastiFlow SNMP definitions, with helpers to validate the config against a JSON Schema and to work with object‑type–specific polling intervals. Includes comprehensive unit tests.

## What’s in this PR

* New Go types in `pkg/def/objecttype.go`:
  * `ObjectTypeDefinition` with fields:
    * `ObjectTypes []ObjectTypeConfig`
    * `DefaultPollInterval uint64`
  * `ObjectTypeConfig` with fields:
    * `Name`, `Description`, `DefaultPollInterval`
* Helper methods:
  * `Validate()` — validates against `schemas/object_types.json`
  * `ValidObjectTypes()`
  * `IsValidObjectType(string)`
  * `DefaultPollIntervalForType(string)`
  * `ValidateObjectType(string)`
  * `ValidatePollIntervals(map[string]uint64)`
    *(Empty `objectType` is treated as “use defaults,” preserving backward compatibility.)*

## Test coverage (`pkg/def/objecttype_test.go`)

* **Validation**: OK path; failure on missing `name`, empty list, or non‑positive intervals.
* **Lists & lookups**: `ValidObjectTypes()`, `IsValidObjectType()` (case‑sensitive; empty is allowed).
* **Intervals**: `DefaultPollIntervalForType()` returns per‑type value or global default when empty/unknown.
* **Guards**: `ValidateObjectType()` and `ValidatePollIntervals()` produce actionable error messages.
* **YAML round‑trip**: Deserialize example YAML into `ObjectTypeDefinition` and assert fields + helpers.

## Motivation

Provide a typed, schema‑validated foundation for object‑type specific polling behavior.

## Backward compatibility

* Passing an empty `objectType` is explicitly permitted and falls back to the default poll interval, avoiding breaking existing configs that omit per‑type values.