### PR TITLE
fix: Annotate GitHub actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
 
@@ -60,6 +60,6 @@ jobs:
       - validate
     steps:
       - name: Check if all checks passed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       valid_tag: ${{ steps.set_standard_vars.outputs.valid_tag }}
       rc: ${{ steps.set_standard_vars.outputs.rc }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: set outputs with default values
         id: set_standard_vars
         run: |
@@ -64,7 +64,7 @@ jobs:
     steps:
     - name: Generate SBOM and submit results to Github Dependency Graph
       if: ${{ !fromJSON(needs.set_standard_vars.outputs.rc) }}
-      uses: aquasecurity/trivy-action@fd25fed6972e341ff0007ddb61f77e88103953c2
+      uses: aquasecurity/trivy-action@fd25fed6972e341ff0007ddb61f77e88103953c2 # v0.21.0
       with:
         scan-type: 'fs'
         image-ref: '.'
@@ -75,7 +75,7 @@ jobs:
         output: 'dependency-results.sbom.json'
         github-pat: ${{ secrets.GITHUB_TOKEN }}
     - name: Scan Licenses
-      uses: aquasecurity/trivy-action@fd25fed6972e341ff0007ddb61f77e88103953c2
+      uses: aquasecurity/trivy-action@fd25fed6972e341ff0007ddb61f77e88103953c2 # v0.21.0
       with:
         image-ref: ''
         scan-type: rootfs


### PR DESCRIPTION
Annotate GitHub actions versions so Renovate correctly handles the updates