### PR TITLE
DST-186 add CISCO-STACKWISE-MIB objects

### DIFF
--- a/device_groups/cisco.yml
+++ b/device_groups/cisco.yml
@@ -216,6 +216,7 @@ cisco_cat_1000:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -372,6 +373,7 @@ cisco_cat_2960:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -479,6 +481,7 @@ cisco_cat_3560:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -525,6 +528,7 @@ cisco_cat_3650:
     - cisco_pim
     - cisco_port
     - cisco_process
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -563,6 +567,7 @@ cisco_cat_3750:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -607,6 +612,7 @@ cisco_cat_3850:
     - cisco_pim
     - cisco_port
     - cisco_process
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -1036,6 +1042,7 @@ cisco_cat_9200:
     - cisco_pim
     - cisco_port
     - cisco_process
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -1083,6 +1090,7 @@ cisco_cat_9300:
     - cisco_pim
     - cisco_port
     - cisco_process
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -1130,6 +1138,7 @@ cisco_cat_9400:
     - cisco_pim
     - cisco_port
     - cisco_process
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -1177,6 +1186,7 @@ cisco_cat_9500:
     - cisco_pim
     - cisco_port
     - cisco_process
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -1224,6 +1234,7 @@ cisco_cat_9600:
     - cisco_pim
     - cisco_port
     - cisco_process
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -1319,6 +1330,7 @@ cisco_cat_cbs3000:
     - cisco_port
     - cisco_process
     - cisco_stack
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 
@@ -2449,6 +2461,7 @@ rockwell_stratix_5400:
     - cisco_process
     - cisco_ptp
     - cisco_stack
+    - cisco_stackwise
     - cisco_syslog
     - cisco_vtp
 

--- a/enums/bitmap/cisco/CISCO-STACKWISE-MIB.yml
+++ b/enums/bitmap/cisco/CISCO-STACKWISE-MIB.yml
@@ -1,0 +1,25 @@
+# cswEnableIndividualStackNotifications
+.1.3.6.1.4.1.9.9.500.1.1.5:
+  0: 'Port Change' # stackPortChange
+  1: 'New Master' # stackNewMaster
+  2: 'Mismatch' # stackMismatch
+  3: 'Ring Redundant' # stackRingRedundant
+  4: 'New Member' # stackNewMember
+  5: 'Member Removed' # stackMemberRemoved
+  6: 'Power Link Status Changed' # stackPowerLinkStatusChanged
+  7: 'Power Port Operational Status Changed' # stackPowerPortOperStatusChanged
+  8: 'Power Version Mismatch' # stackPowerVersionMismatch
+  9: 'Power Invalid Topology' # stackPowerInvalidTopology
+  10: 'Power Budget Warning' # stackPowerBudgetWarning
+  11: 'Power Invalid Input Current' # stackPowerInvalidInputCurrent
+  12: 'Power Invalid Output Current' # stackPowerInvalidOutputCurrent
+  13: 'Power Under Budget' # stackPowerUnderBudget
+  14: 'Power Unbalanced Power Supplies' # stackPowerUnbalancedPowerSupplies
+  15: 'Power Insufficient Power' # stackPowerInsufficientPower
+  16: 'Power Priority Conflict' # stackPowerPriorityConflict
+  17: 'Power Under Voltage' # stackPowerUnderVoltage
+  18: 'Power GLS' # stackPowerGLS
+  19: 'Power ILS' # stackPowerILS
+  20: 'Power SRLS' # stackPowerSRLS
+  21: 'Power SSLS' # stackPowerSSLS
+  22: 'Member Reload for Upgrade' # stackMemberToBeReloadedForUpgrade

--- a/enums/integer/cisco/CISCO-STACKWISE-MIB.yml
+++ b/enums/integer/cisco/CISCO-STACKWISE-MIB.yml
@@ -1,0 +1,58 @@
+# cswSwitchRole
+.1.3.6.1.4.1.9.9.500.1.2.1.1.3:
+  1: 'master' # master
+  2: 'member' # member
+  3: 'not member' # notMember
+  4: 'standby' # standby
+
+# cswSwitchState
+.1.3.6.1.4.1.9.9.500.1.2.1.1.6:
+  1: 'waiting' # waiting
+  2: 'progressing' # progressing
+  3: 'added' # added
+  4: 'ready' # ready
+  5: 'SDM mismatch' # sdmMismatch
+  6: 'version mismatch' # verMismatch
+  7: 'feature mismatch' # featureMismatch
+  8: 'new master initialized' # newMasterInit
+  9: 'provisioned' # provisioned
+  10: 'invalid' # invalid
+  11: 'removed' # removed
+
+# cswStackPortOperStatus
+.1.3.6.1.4.1.9.9.500.1.2.2.1.1:
+  1: 'up' # up
+  2: 'down' # down
+  3: 'forced down' # forcedDown
+
+# cswDistrStackLinkBundleOperStatus
+.1.3.6.1.4.1.9.9.500.1.2.3.1.2:
+  1: 'up' # up
+  2: 'down' # down
+
+# cswDistrStackPhyPortOperStatus
+.1.3.6.1.4.1.9.9.500.1.2.4.1.2:
+  1: 'up' # up
+  2: 'down' # down
+
+# cswStackPowerMode
+.1.3.6.1.4.1.9.9.500.1.3.1.1.2:
+  1: 'power sharing' # powerSharing
+  2: 'redundant' # redundant
+  3: 'power sharing strict' # powerSharingStrict
+  4: 'redundant strict' # redundantStrict
+
+# cswStackPowerType
+.1.3.6.1.4.1.9.9.500.1.3.1.1.6:
+  1: 'ring' # ring
+  2: 'star' # star
+
+# cswStackPowerPortOperStatus
+.1.3.6.1.4.1.9.9.500.1.3.2.1.2:
+  1: 'enabled' # enabled
+  2: 'disabled' # disabled
+
+# cswStackPowerPortLinkStatus
+.1.3.6.1.4.1.9.9.500.1.3.2.1.5:
+  1: 'up' # up
+  2: 'down' # down

--- a/object_groups/cisco.yml
+++ b/object_groups/cisco.yml
@@ -229,7 +229,9 @@ cisco_lwapp:
     - CISCO-LWAPP-AP-MIB::cLAPNtpInfoEntry
     # - CISCO-LWAPP-AP-MIB::cLAp11axRadioConfigEntry
     - CISCO-LWAPP-CDP-MIB::clcCdpTraffic
-    - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry
+    - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry_id
+    - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry_security
+    - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry_perf
     - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientStatisticEntry
     - CISCO-LWAPP-DOT11-MIB::cldHtMacOperationsEntry
     - CISCO-LWAPP-DOT11-MIB::cld11nMcsEntry
@@ -384,6 +386,16 @@ cisco_stack:
     - CISCO-STACK-MIB::chassisComponentEntry
     - CISCO-STACK-MIB::moduleEntry
     - CISCO-STACK-MIB::portEntry
+
+cisco_stackwise:
+  objects:
+    - CISCO-STACKWISE-MIB::cswGlobals
+    - CISCO-STACKWISE-MIB::cswSwitchInfoEntry
+    - CISCO-STACKWISE-MIB::cswStackPortInfoEntry
+    - CISCO-STACKWISE-MIB::cswDistrStackLinkInfoEntry
+    - CISCO-STACKWISE-MIB::cswDistrStackPhyPortInfoEntry
+    - CISCO-STACKWISE-MIB::cswStackPowerInfoEntry
+    - CISCO-STACKWISE-MIB::cswStackPowerPortInfoEntry
 
 cisco_switch:
   objects:

--- a/object_groups/test.yml
+++ b/object_groups/test.yml
@@ -1139,7 +1139,9 @@ all:
     - CISCO-LWAPP-AP-MIB::cLAPNtpInfoEntry
     # - CISCO-LWAPP-AP-MIB::cLAp11axRadioConfigEntry
     - CISCO-LWAPP-CDP-MIB::clcCdpTraffic
-    - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry
+    - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry_id
+    - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry_security
+    - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry_perf
     - CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientStatisticEntry
     - CISCO-LWAPP-DOT11-MIB::cldHtMacOperationsEntry
     - CISCO-LWAPP-DOT11-MIB::cld11nMcsEntry
@@ -1258,6 +1260,13 @@ all:
     - CISCO-STACK-MIB::chassisComponentEntry
     - CISCO-STACK-MIB::moduleEntry
     - CISCO-STACK-MIB::portEntry
+    - CISCO-STACKWISE-MIB::cswGlobals
+    - CISCO-STACKWISE-MIB::cswSwitchInfoEntry
+    - CISCO-STACKWISE-MIB::cswStackPortInfoEntry
+    - CISCO-STACKWISE-MIB::cswDistrStackLinkInfoEntry
+    - CISCO-STACKWISE-MIB::cswDistrStackPhyPortInfoEntry
+    - CISCO-STACKWISE-MIB::cswStackPowerInfoEntry
+    - CISCO-STACKWISE-MIB::cswStackPowerPortInfoEntry
     - CISCO-SWITCH-MULTICAST-MIB::cswmGlobal
     - CISCO-SWITCH-MULTICAST-MIB::cswmReplCapabilityEntry
     - CISCO-SWITCH-MULTICAST-MIB::cswmReplConfigEntry

--- a/objects/cisco/CISCO-LWAPP-DOT11-CLIENT-MIB.yml
+++ b/objects/cisco/CISCO-LWAPP-DOT11-CLIENT-MIB.yml
@@ -36,17 +36,21 @@
 #       name: cisco.cldcMaxClientsTrapPeriod
 #       syntax: Unsigned32
 
-CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
+CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry_id:
   mib: CISCO-LWAPP-DOT11-CLIENT-MIB
-  object: cldcClientEntry
-  type: dynamic
+  object: cldcClientEntry_id
+  type: active
   index:
     - type: MacAddress
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.1
       name: cisco.cldcClientMacAddress
-      syntax: MacAddressNoSuffix # MacAddress
+      syntax: MacAddressNoSuffix
   discovery_attribute: cldcClientStatus
   attributes:
+    cldcClientMacAddress:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.1
+      name: cisco.cldcClientMacAddress
+      syntax: MacAddressNoSuffix
     cldcClientStatus:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.2
       name: cisco.cldcClientStatus
@@ -54,7 +58,7 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
     cldcClientWlanProfileName:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.3
       name: cisco.cldcClientWlanProfileName
-      syntax: DisplayString # SnmpAdminString
+      syntax: DisplayString
     cldcClientWgbStatus:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.4
       name: cisco.cldcClientWgbStatus
@@ -62,27 +66,59 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
     cldcClientWgbMacAddress:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.5
       name: cisco.cldcClientWgbMacAddress
-      syntax: MacAddressNoSuffix # MacAddress
-    cldcClientProtocol:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.6
-      name: cisco.cldcClientProtocol
-      syntax: EnumInteger
-    cldcAssociationMode:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.7
-      name: cisco.cldcAssociationMode
-      syntax: EnumInteger
-    cldcApMacAddress:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.8
-      name: cisco.cldcApMacAddress
-      syntax: MacAddressNoSuffix # MacAddress
-    cldcIfType:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.9
-      name: cisco.cldcIfType
-      syntax: EnumInteger
+      syntax: MacAddressNoSuffix
     cldcClientIPAddress:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.10
       name: cisco.cldcClientIPAddress
       syntax: IpAddressNoSuffix # IpAddress
+    cldcClientUsername:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.27
+      name: cisco.cldcClientUsername
+      syntax: DisplayString
+    cldcClientSSID:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.28
+      name: cisco.cldcClientSSID
+      syntax: DisplayString
+    cldcClientSecurityTagId:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.29
+      name: cisco.cldcClientSecurityTagId
+      syntax: UnsignedAsID
+    cldcClientTypeKTS:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.30
+      name: cisco.cldcClientTypeKTS
+      syntax: TruthValue
+    cldcClientDeviceType:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.44
+      name: cisco.cldcClientDeviceType
+      syntax: DisplayString
+    cldcClientApMacAddress:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.8
+      name: cisco.cldcClientApMacAddress
+      syntax: MacAddressNoSuffix
+    cldcClientApRoamMacAddress:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.39
+      name: cisco.cldcClientApRoamMacAddress
+      syntax: MacAddressNoSuffix
+    cldcClientSessionID:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.38
+      name: cisco.cldcClientSessionID
+      syntax: DisplayString
+    cldcClientPolicyName:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.42
+      name: cisco.cldcClientPolicyName
+      syntax: DisplayString
+
+CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry_security:
+  mib: CISCO-LWAPP-DOT11-CLIENT-MIB
+  object: cldcClientEntry_security
+  type: active
+  index:
+    - type: MacAddress
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.1
+      name: cisco.cldcClientMacAddress
+      syntax: MacAddressNoSuffix
+  discovery_attribute: cldcClientNacState
+  attributes:
     cldcClientNacState:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.11
       name: cisco.cldcClientNacState
@@ -95,6 +131,78 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.13
       name: cisco.cldcClientAccessVLAN
       syntax: Integer32
+    cldcClientAclName:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.22
+      name: cisco.cldcClientAclName
+      syntax: DisplayString
+    cldcClientAclApplied:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.23
+      name: cisco.cldcClientAclApplied
+      syntax: EnumInteger
+    cldcClientRedirectUrl:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.24
+      name: cisco.cldcClientRedirectUrl
+      syntax: DisplayString
+    cldcClientAaaOverrideAclName:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.25
+      name: cisco.cldcClientAaaOverrideAclName
+      syntax: DisplayString
+    cldcClientAaaOverrideAclApplied:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.26
+      name: cisco.cldcClientAaaOverrideAclApplied
+      syntax: EnumInteger
+    cldcClientIpv6AclName:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.31
+      name: cisco.cldcClientIpv6AclName
+      syntax: DisplayString
+    cldcClientIpv6AclApplied:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.32
+      name: cisco.cldcClientIpv6AclApplied
+      syntax: EnumInteger
+    cldcClientAuthentication:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.34
+      name: cisco.cldcClientAuthentication
+      syntax: EnumInteger
+    cldcClientAuthMode:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.36
+      name: cisco.cldcClientAuthMode
+      syntax: EnumInteger
+    cldcClientHreapApAuth:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.19
+      name: cisco.cldcClientHreapApAuth
+      syntax: EnumInteger
+    cldcUserAuthType:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.45
+      name: cisco.cldcUserAuthType
+      syntax: EnumInteger
+    cldcClientiPSKTag:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.51
+      name: cisco.cldcClientiPSKTag
+      syntax: OctetString
+
+CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry_perf:
+  mib: CISCO-LWAPP-DOT11-CLIENT-MIB
+  object: cldcClientEntry_perf
+  type: dynamic
+  index:
+    - type: MacAddress
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.1
+      name: cisco.cldcClientMacAddress
+      syntax: MacAddressNoSuffix
+  discovery_attribute: cldcClientUpTime
+  attributes:
+    cldcClientProtocol:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.6
+      name: cisco.cldcClientProtocol
+      syntax: EnumInteger
+    cldcAssociationMode:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.7
+      name: cisco.cldcAssociationMode
+      syntax: EnumInteger
+    cldcIfType:
+      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.9
+      name: cisco.cldcIfType
+      syntax: EnumInteger
     cldcClientLoginTime:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.14
       name: cisco.cldcClientLoginTime
@@ -115,10 +223,6 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.18
       name: cisco.cldcClientDataRateSet
       syntax: OctetString
-    cldcClientHreapApAuth:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.19
-      name: cisco.cldcClientHreapApAuth
-      syntax: EnumInteger
     cldcClient80211uCapable:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.20
       name: cisco.cldcClient80211uCapable
@@ -127,102 +231,30 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.21
       name: cisco.cldcClientPostureState
       syntax: TruthValue
-    cldcClientAclName:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.22
-      name: cisco.cldcClientAclName
-      syntax: DisplayString # SnmpAdminString
-    cldcClientAclApplied:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.23
-      name: cisco.cldcClientAclApplied
-      syntax: EnumInteger
-    cldcClientRedirectUrl:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.24
-      name: cisco.cldcClientRedirectUrl
-      syntax: DisplayString # CiscoURLStringOrEmpty
-    cldcClientAaaOverrideAclName:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.25
-      name: cisco.cldcClientAaaOverrideAclName
-      syntax: DisplayString # SnmpAdminString
-    cldcClientAaaOverrideAclApplied:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.26
-      name: cisco.cldcClientAaaOverrideAclApplied
-      syntax: EnumInteger
-    cldcClientUsername:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.27
-      name: cisco.cldcClientUsername
-      syntax: DisplayString # SnmpAdminString
-    cldcClientSSID:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.28
-      name: cisco.cldcClientSSID
-      syntax: DisplayString # SnmpAdminString
-    cldcClientSecurityTagId:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.29
-      name: cisco.cldcClientSecurityTagId
-      syntax: UnsignedAsID
-    cldcClientTypeKTS:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.30
-      name: cisco.cldcClientTypeKTS
-      syntax: TruthValue
-    cldcClientIpv6AclName:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.31
-      name: cisco.cldcClientIpv6AclName
-      syntax: DisplayString # SnmpAdminString
-    cldcClientIpv6AclApplied:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.32
-      name: cisco.cldcClientIpv6AclApplied
-      syntax: EnumInteger
     cldcClientDataSwitching:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.33
       name: cisco.cldcClientDataSwitching
-      syntax: EnumInteger
-    cldcClientAuthentication:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.34
-      name: cisco.cldcClientAuthentication
       syntax: EnumInteger
     cldcClientChannel:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.35
       name: cisco.cldcClientChannel
       syntax: Unsigned32
-    cldcClientAuthMode:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.36
-      name: cisco.cldcClientAuthMode
-      syntax: EnumInteger
     cldcClientReasonCode:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.37
       name: cisco.cldcClientReasonCode
       syntax: EnumInteger
-    cldcClientSessionID:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.38
-      name: cisco.cldcClientSessionID
-      syntax: DisplayString # SnmpAdminString
-    cldcClientApRoamMacAddress:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.39
-      name: cisco.cldcClientApRoamMacAddress
-      syntax: MacAddressNoSuffix # MacAddress
     cldcClientMdnsProfile:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.40
       name: cisco.cldcClientMdnsProfile
-      syntax: DisplayString # SnmpAdminString
+      syntax: DisplayString
     cldcClientMdnsAdvCount:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.41
       name: cisco.cldcClientMdnsAdvCount
       syntax: Unsigned32
-    cldcClientPolicyName:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.42
-      name: cisco.cldcClientPolicyName
-      syntax: DisplayString # SnmpAdminString
     cldcClientAAARole:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.43
       name: cisco.cldcClientAAARole
-      syntax: DisplayString # SnmpAdminString
-    cldcClientDeviceType:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.44
-      name: cisco.cldcClientDeviceType
-      syntax: DisplayString # SnmpAdminString
-    cldcUserAuthType:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.45
-      name: cisco.cldcUserAuthType
-      syntax: EnumInteger
+      syntax: DisplayString
     cldcClientTunnelType:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.46
       name: cisco.cldcClientTunnelType
@@ -243,10 +275,6 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.50
       name: cisco.cldcClientCurrentTxRate
       syntax: BandwidthMBits
-    cldcClientiPSKTag:
-      oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.51
-      name: cisco.cldcClientiPSKTag
-      syntax: OctetString
     cldcClientMobileStPolicyType:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.52
       name: cisco.cldcClientMobileStPolicyType
@@ -259,7 +287,7 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
 #     - type: MacAddress
 #       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.1
 #       name: cisco.cldcClientMacAddress
-#       syntax: MacAddressNoSuffix # MacAddress
+#       syntax: MacAddressNoSuffix
 #     - type: Integer
 #       oid: .1.3.6.1.4.1.9.9.599.1.3.2.1.2
 #       name: cisco.cldcClientByIpAddressType
@@ -286,7 +314,7 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
 #     - type: MacAddress
 #       oid: .1.3.6.1.4.1.9.9.599.1.3.3.1.1
 #       name: cisco.cldcSleepingClientMacAddress
-#       syntax: MacAddressNoSuffix # MacAddress
+#       syntax: MacAddressNoSuffix
 #   discovery_attribute: cldcSleepingClientSsid
 #   attributes:
 #     cldcSleepingClientSsid:
@@ -296,7 +324,7 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientEntry:
 #     cldcSleepingClientUserName:
 #       oid: .1.3.6.1.4.1.9.9.599.1.3.3.1.3
 #       name: cisco.cldcSleepingClientUserName
-#       syntax: DisplayString # SnmpAdminString
+#       syntax: DisplayString
 #     cldcSleepingClientRemainingTime:
 #       oid: .1.3.6.1.4.1.9.9.599.1.3.3.1.4
 #       name: cisco.cldcSleepingClientRemainingTime
@@ -310,121 +338,149 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientStatisticEntry:
     - type: MacAddress
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.1
       name: cisco.cldcClientMacAddress
-      syntax: MacAddressNoSuffix # MacAddress
+      syntax: MacAddressNoSuffix
   discovery_attribute: cldcClientRtsRetries
   attributes:
     cldcClientDataRetries:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.1
       name: cisco.cldcClientDataRetries
       syntax: Counter64
+      metric: counter
     cldcClientRtsRetries:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.2
       name: cisco.cldcClientRtsRetries
       syntax: Counter64
+      metric: counter
     cldcClientDuplicatePackets:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.3
       name: cisco.cldcClientDuplicatePackets
       syntax: Counter64
+      metric: counter
     cldcClientDecryptFailures:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.4
       name: cisco.cldcClientDecryptFailures
       syntax: Counter64
+      metric: counter
     cldcClientMicErrors:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.5
       name: cisco.cldcClientMicErrors
       syntax: Counter64
+      metric: counter
     cldcClientMicMissingFrames:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.6
       name: cisco.cldcClientMicMissingFrames
       syntax: Counter64
+      metric: counter
     cldcClientRaPacketsDropped:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.7
       name: cisco.cldcClientRaPacketsDropped
       syntax: Counter64
+      metric: counter
     cldcClientInterimUpdatesCount:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.8
       name: cisco.cldcClientInterimUpdatesCount
       syntax: Counter64
+      metric: counter
     cldcClientDataBytesReceived:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.9
       name: cisco.cldcClientDataBytesReceived
       syntax: Counter64
+      metric: counter
     cldcClientRealtimeBytesReceived:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.10
       name: cisco.cldcClientRealtimeBytesReceived
       syntax: Counter64
+      metric: counter
     cldcClientRxDataBytesDropped:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.11
       name: cisco.cldcClientRxDataBytesDropped
       syntax: Counter64
+      metric: counter
     cldcClientRxRealtimeBytesDropped:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.12
       name: cisco.cldcClientRxRealtimeBytesDropped
       syntax: Counter64
+      metric: counter
     cldcClientDataBytesSent:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.13
       name: cisco.cldcClientDataBytesSent
       syntax: Counter64
+      metric: counter
     cldcClientRealtimeBytesSent:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.14
       name: cisco.cldcClientRealtimeBytesSent
       syntax: Counter64
+      metric: counter
     cldcClientTxDataBytesDropped:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.15
       name: cisco.cldcClientTxDataBytesDropped
       syntax: Counter64
+      metric: counter
     cldcClientTxRealtimeBytesDropped:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.16
       name: cisco.cldcClientTxRealtimeBytesDropped
       syntax: Counter64
+      metric: counter
     cldcClientDataPacketsReceived:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.17
       name: cisco.cldcClientDataPacketsReceived
       syntax: Counter64
+      metric: counter
     cldcClientRealtimePacketsReceived:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.18
       name: cisco.cldcClientRealtimePacketsReceived
       syntax: Counter64
+      metric: counter
     cldcClientRxDataPacketsDropped:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.19
       name: cisco.cldcClientRxDataPacketsDropped
       syntax: Counter64
+      metric: counter
     cldcClientRxRealtimePacketsDropped:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.20
       name: cisco.cldcClientRxRealtimePacketsDropped
       syntax: Counter64
+      metric: counter
     cldcClientDataPacketsSent:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.21
       name: cisco.cldcClientDataPacketsSent
       syntax: Counter64
+      metric: counter
     cldcClientRealtimePacketsSent:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.22
       name: cisco.cldcClientRealtimePacketsSent
       syntax: Counter64
+      metric: counter
     cldcClientTxDataPacketsDropped:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.23
       name: cisco.cldcClientTxDataPacketsDropped
       syntax: Counter64
+      metric: counter
     cldcClientTxRealtimePacketsDropped:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.24
       name: cisco.cldcClientTxRealtimePacketsDropped
       syntax: Counter64
+      metric: counter
     cldcClientTxDataPackets:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.25
       name: cisco.cldcClientTxDataPackets
       syntax: Counter64
+      metric: counter
     cldcClientTxDataBytes:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.26
       name: cisco.cldcClientTxDataBytes
       syntax: Counter64
+      metric: counter
     cldcClientRxDataPackets:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.27
       name: cisco.cldcClientRxDataPackets
       syntax: Counter64
+      metric: counter
     cldcClientRxDataBytes:
       oid: .1.3.6.1.4.1.9.9.599.1.4.1.1.28
       name: cisco.cldcClientRxDataBytes
       syntax: Counter64
+      metric: counter
     # Add for additional context
     cldcClientIPAddress:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.10
@@ -433,11 +489,11 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientStatisticEntry:
     cldcClientUsername:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.27
       name: cisco.cldcClientUsername
-      syntax: DisplayString # SnmpAdminString
+      syntax: DisplayString
     cldcClientSSID:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.28
       name: cisco.cldcClientSSID
-      syntax: DisplayString # SnmpAdminString
+      syntax: DisplayString
     cldcClientSecurityTagId:
       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.29
       name: cisco.cldcClientSecurityTagId
@@ -450,7 +506,7 @@ CISCO-LWAPP-DOT11-CLIENT-MIB::cldcClientStatisticEntry:
 #     - type: MacAddress
 #       oid: .1.3.6.1.4.1.9.9.599.1.3.1.1.1
 #       name: cisco.cldcClientMacAddress
-#       syntax: MacAddressNoSuffix # MacAddress
+#       syntax: MacAddressNoSuffix
 #   discovery_attribute: cldccCcxLocationServiceVersion
 #   attributes:
 #     cldccCcxFoundationServiceVersion:

--- a/objects/cisco/CISCO-STACKWISE-MIB.yml
+++ b/objects/cisco/CISCO-STACKWISE-MIB.yml
@@ -1,0 +1,261 @@
+CISCO-STACKWISE-MIB::cswGlobals:
+  mib: CISCO-STACKWISE-MIB
+  object: cswGlobals
+  type: stable
+  discovery_attribute: cswMaxSwitchNum
+  attributes:
+    cswMaxSwitchNum:
+      oid: .1.3.6.1.4.1.9.9.500.1.1.1
+      name: cisco.csw.MaxSwitchNum
+      syntax: Unsigned32
+    cswMaxSwitchConfigPriority:
+      oid: .1.3.6.1.4.1.9.9.500.1.1.2
+      name: cisco.csw.MaxSwitchConfigPriority
+      syntax: Unsigned32
+    cswRingRedundant:
+      oid: .1.3.6.1.4.1.9.9.500.1.1.3
+      name: cisco.csw.RingRedundant
+      syntax: TruthValue
+    cswEnableStackNotifications:
+      oid: .1.3.6.1.4.1.9.9.500.1.1.4
+      name: cisco.csw.EnableStackNotifications
+      syntax: TruthValue
+    # cswEnableIndividualStackNotifications:
+    #   oid: .1.3.6.1.4.1.9.9.500.1.1.5
+    #   name: cisco.csw.EnableIndividualStackNotifications
+    #   syntax: EnumBitmap
+    cswStackDomainNum:
+      oid: .1.3.6.1.4.1.9.9.500.1.1.6
+      name: cisco.csw.Stack.DomainNum
+      syntax: UnsignedAsID
+    cswStackType:
+      oid: .1.3.6.1.4.1.9.9.500.1.1.7
+      name: cisco.csw.Stack.Type
+      syntax: Unsigned32
+    cswStackBandWidth:
+      oid: .1.3.6.1.4.1.9.9.500.1.1.8
+      name: cisco.csw.Stack.BandWidth
+      syntax: Unsigned32
+
+CISCO-STACKWISE-MIB::cswSwitchInfoEntry:
+  mib: CISCO-STACKWISE-MIB
+  object: cswSwitchInfoEntry
+  type: active
+  index:
+    - type: Integer32
+      oid: .1.3.6.1.2.1.47.1.1.1.1.1
+      name: entity.phys.index # entPhysicalIndex
+      syntax: IntegerAsID
+  discovery_attribute: cswSwitchNumNextReload
+  attributes:
+    cswSwitchNumCurrent:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.1
+      name: cisco.csw.Switch.NumCurrent
+      syntax: UnsignedAsID
+    cswSwitchNumNextReload:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.2
+      name: cisco.csw.Switch.NumNextReload
+      syntax: UnsignedAsID
+    cswSwitchRole:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.3
+      name: cisco.csw.Switch.Role
+      syntax: EnumInteger
+    cswSwitchSwPriority:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.4
+      name: cisco.csw.Switch.SwPriority
+      syntax: Unsigned32
+    cswSwitchHwPriority:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.5
+      name: cisco.csw.Switch.HwPriority
+      syntax: Unsigned32
+    cswSwitchState:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.6
+      name: cisco.csw.Switch.State
+      syntax: EnumInteger
+    cswSwitchMacAddress:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.7
+      name: cisco.csw.Switch.MacAddress
+      syntax: MacAddressNoSuffix
+    cswSwitchSoftwareImage:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.8
+      name: cisco.csw.Switch.SoftwareImage
+      syntax: DisplayString
+    cswSwitchPowerBudget:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.9
+      name: cisco.csw.Switch.PowerBudget
+      syntax: PowerWatt
+      metric: gauge
+    cswSwitchPowerCommited:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.10
+      name: cisco.csw.Switch.PowerCommited
+      syntax: PowerWatt
+      metric: gauge
+    cswSwitchSystemPowerPriority:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.11
+      name: cisco.csw.Switch.SystemPowerPriority
+      syntax: Unsigned32
+    cswSwitchPoeDevicesLowPriority:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.12
+      name: cisco.csw.Switch.PoeDevicesLowPriority
+      syntax: Unsigned32
+    cswSwitchPoeDevicesHighPriority:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.13
+      name: cisco.csw.Switch.PoeDevicesHighPriority
+      syntax: Unsigned32
+    cswSwitchPowerAllocated:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.1.1.14
+      name: cisco.csw.Switch.PowerAllocated
+      syntax: PowerWatt
+      metric: gauge
+
+CISCO-STACKWISE-MIB::cswStackPortInfoEntry:
+  mib: CISCO-STACKWISE-MIB
+  object: cswStackPortInfoEntry
+  type: active
+  index:
+    - type: Integer32
+      oid: .1.3.6.1.2.1.2.2.1.1
+      name: netif # ifIndex
+      syntax: InterfaceIndex
+  discovery_attribute: cswStackPortNeighbor
+  attributes:
+    cswStackPortOperStatus:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.2.1.1
+      name: cisco.csw.StackPort.OperStatus
+      syntax: EnumInteger
+    cswStackPortNeighbor:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.2.1.2
+      name: cisco.csw.StackPort.Neighbor
+      syntax: IntegerAsID
+
+CISCO-STACKWISE-MIB::cswDistrStackLinkInfoEntry:
+  mib: CISCO-STACKWISE-MIB
+  object: cswDistrStackLinkInfoEntry
+  type: active
+  index:
+    - type: Integer32
+      oid: .1.3.6.1.2.1.47.1.1.1.1.1
+      name: entity.phys.index # entPhysicalIndex
+      syntax: IntegerAsID
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.500.1.2.3.1.1
+      name: cisco.csw.DistrStackLink.Index
+      syntax: UnsignedAsID
+  discovery_attribute: cswDistrStackLinkBundleOperStatus
+  attributes:
+    cswDistrStackLinkBundleOperStatus:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.3.1.2
+      name: cisco.csw.DistrStackLink.BundleOperStatus
+      syntax: EnumInteger
+
+CISCO-STACKWISE-MIB::cswDistrStackPhyPortInfoEntry:
+  mib: CISCO-STACKWISE-MIB
+  object: cswDistrStackPhyPortInfoEntry
+  type: active
+  index:
+    - type: Integer32
+      oid: .1.3.6.1.2.1.47.1.1.1.1.1
+      name: entity.phys.index # entPhysicalIndex
+      syntax: IntegerAsID
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.500.1.2.3.1.1
+      name: cisco.csw.DistrStackLink.Index
+      syntax: UnsignedAsID
+    - type: Integer32
+      oid: .1.3.6.1.2.1.2.2.1.1
+      name: netif # ifIndex
+      syntax: InterfaceIndex
+  discovery_attribute: cswDistrStackPhyPortOperStatus
+  attributes:
+    cswDistrStackPhyPort:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.4.1.1
+      name: cisco.csw.DistrStackPhyPort.Name
+      syntax: DisplayString
+    cswDistrStackPhyPortOperStatus:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.4.1.2
+      name: cisco.csw.DistrStackPhyPort.OperStatus
+      syntax: EnumInteger
+    cswDistrStackPhyPortNbr:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.4.1.3
+      name: cisco.csw.DistrStackPhyPort.Nbr
+      syntax: DisplayString
+    cswDistrStackPhyPortNbrsw:
+      oid: .1.3.6.1.4.1.9.9.500.1.2.4.1.4
+      name: cisco.csw.DistrStackPhyPort.Nbrsw
+      syntax: IntegerAsID
+
+CISCO-STACKWISE-MIB::cswStackPowerInfoEntry:
+  mib: CISCO-STACKWISE-MIB
+  object: cswStackPowerInfoEntry
+  type: active
+  index:
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.500.1.3.1.1.1
+      name: cisco.csw.StackPower.StackNumber
+      syntax: UnsignedAsID
+  discovery_attribute: cswStackPowerMode
+  attributes:
+    cswStackPowerMode:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.1.1.2
+      name: cisco.csw.StackPower.Mode
+      syntax: EnumInteger
+    cswStackPowerMasterMacAddress:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.1.1.3
+      name: cisco.csw.StackPower.MasterMacAddress
+      syntax: MacAddressNoSuffix
+    cswStackPowerMasterSwitchNum:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.1.1.4
+      name: cisco.csw.StackPower.MasterSwitchNum
+      syntax: UnsignedAsID
+    cswStackPowerNumMembers:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.1.1.5
+      name: cisco.csw.StackPower.NumMembers
+      syntax: Unsigned32
+    cswStackPowerType:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.1.1.6
+      name: cisco.csw.StackPower.Type
+      syntax: EnumInteger
+    cswStackPowerName:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.1.1.7
+      name: cisco.csw.StackPower.Name
+      syntax: DisplayString
+
+CISCO-STACKWISE-MIB::cswStackPowerPortInfoEntry:
+  mib: CISCO-STACKWISE-MIB
+  object: cswStackPowerPortInfoEntry
+  type: active
+  index:
+    - type: Integer32
+      oid: .1.3.6.1.2.1.47.1.1.1.1.1
+      name: entity.phys.index # entPhysicalIndex
+      syntax: IntegerAsID
+    - type: Unsigned32
+      oid: .1.3.6.1.4.1.9.9.500.1.3.2.1.1
+      name: cisco.csw.StackPowerPort.Index
+      syntax: UnsignedAsID
+  discovery_attribute: cswStackPowerPortOperStatus
+  attributes:
+    cswStackPowerPortOperStatus:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.2.1.2
+      name: cisco.csw.StackPowerPort.OperStatus
+      syntax: EnumInteger
+    cswStackPowerPortNeighborMacAddress:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.2.1.3
+      name: cisco.csw.StackPowerPort.NeighborMacAddress
+      syntax: MacAddressNoSuffix
+    cswStackPowerPortNeighborSwitchNum:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.2.1.4
+      name: cisco.csw.StackPowerPort.NeighborSwitchNum
+      syntax: UnsignedAsID
+    cswStackPowerPortLinkStatus:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.2.1.5
+      name: cisco.csw.StackPowerPort.LinkStatus
+      syntax: EnumInteger
+    cswStackPowerPortOverCurrentThreshold:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.2.1.6
+      name: cisco.csw.StackPowerPort.OverCurrentThreshold
+      syntax: CurrentAmp
+    cswStackPowerPortName:
+      oid: .1.3.6.1.4.1.9.9.500.1.3.2.1.7
+      name: cisco.csw.StackPowerPort.Name
+      syntax: DisplayString


### PR DESCRIPTION
DST-186:  add CISCO-STACKWISE-MIB objects

DST-139:  add split objects for CISCO-LWAPP-DOT11-CLIENT-MIB to fix overly large SNMP request